### PR TITLE
Add instructions for releasing binaries

### DIFF
--- a/src/jyut-dict/platform/README.md
+++ b/src/jyut-dict/platform/README.md
@@ -1,0 +1,48 @@
+# Release checklist
+
+## macOS
+
+### Install
+- [ ] Build install .app bundle.
+- [ ] Run macdeployqt on .app bundle.
+- [ ] Codesign install .app bundle.
+- [ ] Generate .dmg.
+- [ ] Codesign .dmg.
+- [ ] Notarize .dmg.
+- [ ] Staple notarization to .dmg.
+
+### Portable
+- [ ] Build portable .app bundle.
+- [ ] Run macdeployqt on .app bundle.
+- [ ] Codesign portable .app bundle.
+- [ ] Notarize .app bundle.
+- [ ] Staple notarization to .app bundle.
+- [ ] Compress .app bundle using the .zip format.
+
+## Windows
+
+### Install
+- [ ] Build 32-bit executable.
+- [ ] Move executable to platform/windows/installer data folder.
+- [ ] Run windeployqt on the executable.
+- [ ] Copy OpenSSL .dlls to the data folder.
+- [ ] Run binarycreator to generate installer file.
+- [ ] Repeat for 64-bit.
+
+### Portable
+- [ ] Build 32-bit executable.
+- [ ] Run windeployqt on the executable.
+- [ ] Copy OpenSSL .dlls to the data folder.
+- [ ] Compress using the .zip format.
+- [ ] Repeat for 64-bit.
+
+## Linux
+
+### .deb
+- [ ] Run `create-deb.sh` in Ubuntu 18.04.
+
+### AppImage
+- [ ] Build the binary using the Release configuration with APPIMAGE defined on Ubuntu 16.04.
+- [ ] Move the binary to the other folder structure under platform/linux.
+- [ ] Copy relevant data files to the folder structure.
+- [ ] Run linuxdeployqt.

--- a/src/jyut-dict/platform/mac/Info.plist
+++ b/src/jyut-dict/platform/mac/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleName</key>
   <string>Jyut Dictionary</string>
   <key>CFBundleIdentifier</key>
-  <string>Jyut Dictionary</string>
+  <string>com.aaronhktan.cantonesedictionary</string>
   <key>CFBundleExecutable</key>
   <string>MacOS/Jyut Dictionary</string>
   <key>CFBundleIconFile</key>

--- a/src/jyut-dict/platform/mac/README.md
+++ b/src/jyut-dict/platform/mac/README.md
@@ -3,3 +3,16 @@ To build for Mac:
 - Build the executable using the RELEASE configuration.
 - Run MacDeployQt on the generated .app bundle.
 - Run `create-dmg 'Jyut Dictionary.app' --overwrite` to generate the .dmg.
+
+Codesigning and Notarizing
+(See https://ahmad.ltd/How-To-Deploy-Your-Qt-macOS-App-Properly/ for instructions)
+- Use XCode to generate a Developer ID certificate: Preferences > Accounts > Manage Certificates... > + (lower left corner) > Developer ID Application.
+- BEFORE GENERATING THE DMG: codesign the generated .app bundle: `codesign -f --deep -v --options runtime -s 'Developer ID Application: {name of developer ID}' {app_name}.app`. You can find the name of the developer ID in Keychain, under `Certificates`; it'll have the format `Developer ID Application: <name> (<alphanumeric string>)`.
+- AFTER GENERATING THE DMG: codesign the .dmg: `codesign -f --deep -v --options runtime -s 'Developer ID Application: {name of developer ID}' {app_name}.dmg`.
+- Upload the codesigned .dmg file: `xcrun altool --notarize-app --primary-bundle-id '{bundle_ID}' --username '{apple_username}' --password '{apple_password}' --file {app_name}.dmg`.
+- Staple the notarization info to the .dmg: `xcrun stapler staple {app_name}.dmg`.
+- For the portable version, you can just codesign/upload the .app bundle and then staple the .app bundle before zipping. Stapling does not work on .zips.
+
+Common issues:
+- `Warning: unable to build chain to self-signed root for signer`: Open XCode, go to Preferences > Accounts, and click "Download Manual Profiles". You may also need to go to Keychain Access and make sure all the Apple Certificates (e.g. `Apple Root CA`, `Apple Worldwide Developer Relations Certification Authority`, `Developer ID Certification Authority`, etc.) are set to `Use System Default`, NOT `Always Trust`!
+- When uploading the codesigned .dmg, you may need an app-specific password (especially if you have MFA enabled on your Apple ID). See [here](https://support.apple.com/en-us/HT204397) for how to generate one.

--- a/src/jyut-dict/platform/windows/README.md
+++ b/src/jyut-dict/platform/windows/README.md
@@ -5,3 +5,6 @@ To build for Windows:
 - Run WinDeployQt on the executable. Make sure to run WinDeployQt with the command prompt installed in the Start Menu or run QtEnv2.bat, so that appropriate paths are added to the system path.
 - Download and install the appropriate OpenSSL 1.1.1 file (32-bit and 64-bit). Copy libssl-1_1.dll, libcrypto-1_1.dll, capi.dll, and dasync.dll to the data folder.
 - Run binarycreator.exe (from Qt Installer Framework Tools), passing `--offline-only -c <path-to-config/config.xml> -p <path-to-packages> <name-of-executable>`.
+
+Defender SmartScreen notes:
+- Submit the installer .exe and the portable .exe to Microsoft's malware analysis: https://www.microsoft.com/en-us/wdsi/filesubmission.


### PR DESCRIPTION
# Description

This PR adds documentation for the release process, including signing/notarization for macOS and malware analysis for Windows. It also adds a checklist for releasing for all three platforms in the `platform` directory.

Closes #65.

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

N/A

# Checklist:

- [x] I have made corresponding changes to the documentation
