### PR TITLE
Resolve #68: Separator between items is slightly thicker than divider between search results pane and detail pane

### DIFF
--- a/src/jyut-dict/components/entrysearchresult/resultlistdelegate.cpp
+++ b/src/jyut-dict/components/entrysearchresult/resultlistdelegate.cpp
@@ -218,7 +218,7 @@ void ResultListDelegate::paint(QPainter *painter,
 
     // Bottom divider
     QRect rct = option.rect;
-    rct.setY(rct.bottom() - 1);
+    rct.setY(rct.bottom());
     painter->fillRect(rct, option.palette.alternateBase());
 
     painter->restore();

--- a/src/jyut-dict/components/sentencesearchresult/sentenceresultlistdelegate.cpp
+++ b/src/jyut-dict/components/sentencesearchresult/sentenceresultlistdelegate.cpp
@@ -241,7 +241,7 @@ void SentenceResultListDelegate::paint(QPainter *painter,
 
     // Bottom divider
     QRect rct = option.rect;
-    rct.setY(rct.bottom() - 1);
+    rct.setY(rct.bottom());
     painter->fillRect(rct, option.palette.alternateBase());
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
Title: Reduce thickness of separator by one pixel.

# Description

Made rectangle for separator one pixel shorter.

Closes #(68)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visual inspection.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python code, none currently for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
