### PR TITLE
Resolve #52: Add data from ABC Chinese-English Dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,9 +82,9 @@ CMakeLists.txt.user*
 **.mp4
 
 # Data files
-**/abc/archive_*
-**/abc/data/*
-**/abc/developer/*
+**/abc_/archive_*
+**/abc_/data/*
+**/abc_/developer/*
 **/cantodict/archive_*
 **/cantodict/data/*
 **/cantodict/developer/*

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ CMakeLists.txt.user*
 **.mp4
 
 # Data files
+**/abc/archive_*
+**/abc/data/*
+**/abc/developer/*
 **/cantodict/archive_*
 **/cantodict/data/*
 **/cantodict/developer/*

--- a/src/dictionaries/abc_/README.md
+++ b/src/dictionaries/abc_/README.md
@@ -1,0 +1,8 @@
+#### Usage:
+- To install required packages: `pip install -r requirements.txt`
+- Specific usage instructions for each script are provided by the scripts themselves.
+- **Run the scripts from the `dictionaries` folder, e.g. `python3 -m abc_.parse <database filename> <cidian.u8 file> <source name> <source short name> <source version> <source description> <source legal> <source link> <source update url> <source other>`.**
+
+#### Scripts:
+- `parse.py`
+  - This script generates a SQLite database from the `cidian.u8` file provided by Wenlin's Developer Program. See [Wenlin's webpage](https://wenlin.com/developers) for more details.

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -54,8 +54,8 @@ def insert_example(c, definition_id, starting_example_id, example):
     # translations
     examples_inserted = 0
 
-    trad = example[0].content
-    simp = HanziConv.toSimplified(trad) if trad else ""
+    simp = example[0].content
+    trad = HanziConv.toTraditional(simp) if simp else ""
     jyut = ""
     pin = example[0].pron
     lang = example[0].lang

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -186,12 +186,11 @@ def write(db_name, source, words):
 
 
 def parse_pinyin(content):
-    # Pinyin sometimes has superscript numbers preceding them
-    # I assume it's to distinguish between words with the same Pinyin? Unsure
-    content = content.strip("¹²³⁴⁵⁶⁷⁸⁹")
     # ABC indicates sound change by a dot underneath the vowel
     # But we don't support that, so remove it
-    content = content.translate(str.maketrans("ạẹịọụ", "aeiou", "*"))
+    # Pinyin also sometimes has superscript numbers preceding them that we need to strip
+    # I assume it's to distinguish between words with the same Pinyin? Unsure
+    content = content.translate(str.maketrans("ạẹịọụ", "aeiou", "*¹²³⁴⁵⁶⁷⁸⁹"))
     # Also replace combining characters with single-character equivalents
     content = unicodedata.normalize("NFKC", content)
     # Make the Pinyin lowercase, so that dragonmapper can parse it

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -24,6 +24,7 @@ import unicodedata
 # - 记/纪录 (1006248609): contains variant for simplified and traditional
 # - 回@@/迴 (1005378131): contains "@@" in entry headword
 # - 纪委 (1006643399): contains "-" in Pinyin
+# - 就 (1006571134): contains example with weird Pinyin ("yī̠diǎnr")
 
 IGNORED_LINES = ("cidian.wenlindb\n", ".-arc\n", ".-publish\n")
 IGNORED_TYPES = (
@@ -203,7 +204,7 @@ def parse_pinyin(content):
     # But we don't support that, so remove it
     # Pinyin also sometimes has superscript numbers preceding them that we need to remove
     # I assume it's to distinguish between words with the same Pinyin? Unsure
-    content = content.translate(str.maketrans("ạẹịọụ'-", "aeiou  ", "*¹²³⁴⁵⁶⁷⁸⁹"))
+    content = content.translate(str.maketrans("ạẹịọụ'-", "aeiou  ", "̠*¹²³⁴⁵⁶⁷⁸⁹"))
     # ABC also indicates erhua with (r) in Pinyin. This causes difficulties with
     # entry coalescing, so remove it.
     content = content.replace("(r)", "")

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -1,0 +1,117 @@
+from dragonmapper import transcriptions
+# import jieba
+# import pinyin_jyutping_sentence
+
+from database import database, objects
+
+import logging
+import re
+import sys
+
+IGNORED_LINES = ("cidian.wenlindb\n", ".-arc\n", ".-publish\n")
+EXAMPLE_TYPE = re.compile(r"(\d*)(\w*)(@\w*)*")
+
+def parse_pinyin(content):
+    # Pinyin sometimes has superscript numbers preceding them
+    # I assume it's to distinguish between words with the same Pinyin? Unsure
+    content = content.strip("¹²³⁴⁵⁶⁷⁸⁹")
+    # ABC indicates sound change by a dot underneath the vowel
+    # But we don't support that, so remove it
+    content = content.translate(str.maketrans('ạẹịọụ', 'aeiou', '*'))
+    # Make the Pinyin lowercase, so that dragonmapper can parse it
+    content = content.lower()
+    # Transcribing to zhuyin first identifies character boundaries
+    return transcriptions.to_pinyin(transcriptions.to_zhuyin(content), accented=False)
+
+def parse_char(content):
+    # Traditional form is indicated enclosed in square brackets
+    bracket_index = content.find("[")
+    if bracket_index != -1:
+        simp = content[:bracket_index]
+        trad = content[bracket_index+1:content.find("]")]
+    else:
+        simp = trad = content
+
+    return trad, simp
+
+
+def parse_file(filename, words):
+    with open(filename) as file:
+        for line in file.readlines():
+            if not line or line in IGNORED_LINES:
+                continue
+
+            if line == "\n":
+                # Write down parsed entry, start new entry
+                continue
+
+            line = line.split("   ")
+            if len(line) >= 2:
+                try:
+                    column_type, content = line[0], line[1]
+                except Exception as e:
+                    logging.error(f"Couldn't parse line: '{line}'")
+                    continue
+            else:
+                continue
+
+            content = content.strip()
+
+            if column_type == ".py":
+                pin = parse_pinyin(content)
+                print(f"pin: {pin}")
+            elif column_type == "char":
+                trad, simp = parse_char(content)
+                print(f"trad: {trad}, simp: {simp}")
+            elif column_type == "ps":
+                part_of_speech = content
+                print(f"pos: {part_of_speech}")
+            elif column_type[0].isdigit():
+                # Example number and column type are smushed together in examples
+                # e.g. "1ex": example_number = 1, column_type = example
+                match = re.match(EXAMPLE_TYPE, column_type)
+                example_number, example_type = match.group(1), match.group(2)
+                print(f"ex_num: {example_number}, ex_type: {example_type}")
+
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 11:
+        print(
+            (
+                "Usage: python3 script.py <database filename> "
+                "<cidian.u8 file> "
+                "<source name> <source short name> "
+                "<source version> <source description> <source legal> "
+                "<source link> <source update url> <source other>"
+            )
+        )
+        print(
+            (
+                "e.g. python3 -m abc_.parse abc.db abc/data/cidian.u8 "
+                '"ABC Chinese-English Dictionary" ABC 2015-12-18 '
+                '"This dictionary is an expansion of the ground breaking '
+                'ABC Chinese-English Dictionary, the first strictly '
+                'alphabetically ordered and Pinyin computerized dictionary. '
+                'It contains over 196,000 entries, compared to the 71,486 '
+                'entries of the earlier work, making it the most '
+                'comprehensive one-volume dictionary of Chinese." '
+                '"Copyright © 1996-2019 University of Hawai‘i Press, All Rights Reserved" '
+                '"https://wenlin.com/abc" "" "words,sentences"'
+            )
+        )
+        sys.exit(1)
+
+    entries = {}
+    source = objects.SourceTuple(
+        sys.argv[3],
+        sys.argv[4],
+        sys.argv[5],
+        sys.argv[6],
+        sys.argv[7],
+        sys.argv[8],
+        sys.argv[9],
+        sys.argv[10]
+    )
+    parse_file(sys.argv[2], entries)
+    # write(entries, sys.argv[1])

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -22,6 +22,7 @@ import unicodedata
 # - 机灵 (1006245990): contains dated variant
 # - 犄/觭角 (1006222031): contains variant for simplified
 # - 记/纪录 (1006248609): contains variant for simplified and traditional
+# - 回@@/迴 (1005378131): contains "@@" in entry headword
 
 IGNORED_LINES = ("cidian.wenlindb\n", ".-arc\n", ".-publish\n")
 IGNORED_TYPES = (
@@ -240,6 +241,8 @@ def parse_char(content):
 
     # Remove dated variants, if any (denoted by @{<variant>})
     content = ABRIDGED_DATED_VARIANT.sub("", content)
+    # Remove "@@" from characters
+    content = content.replace("@@", "")
 
     # Traditional form is indicated enclosed in square brackets
     bracket_index = content.find("[")

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -23,6 +23,7 @@ import unicodedata
 # - 犄/觭角 (1006222031): contains variant for simplified
 # - 记/纪录 (1006248609): contains variant for simplified and traditional
 # - 回@@/迴 (1005378131): contains "@@" in entry headword
+# - 纪委 (1006643399): contains "-" in Pinyin
 
 IGNORED_LINES = ("cidian.wenlindb\n", ".-arc\n", ".-publish\n")
 IGNORED_TYPES = (
@@ -202,7 +203,7 @@ def parse_pinyin(content):
     # But we don't support that, so remove it
     # Pinyin also sometimes has superscript numbers preceding them that we need to remove
     # I assume it's to distinguish between words with the same Pinyin? Unsure
-    content = content.translate(str.maketrans("ạẹịọụ'", "aeiou ", "*¹²³⁴⁵⁶⁷⁸⁹"))
+    content = content.translate(str.maketrans("ạẹịọụ'-", "aeiou  ", "*¹²³⁴⁵⁶⁷⁸⁹"))
     # ABC also indicates erhua with (r) in Pinyin. This causes difficulties with
     # entry coalescing, so remove it.
     content = content.replace("(r)", "")

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -1,15 +1,50 @@
 from dragonmapper import transcriptions
+
 # import jieba
 # import pinyin_jyutping_sentence
 
 from database import database, objects
 
+from collections import defaultdict
+import enum
 import logging
 import re
+import string
 import sys
 
 IGNORED_LINES = ("cidian.wenlindb\n", ".-arc\n", ".-publish\n")
-EXAMPLE_TYPE = re.compile(r"(\d*)(\w*)(@\w*)*")
+IGNORED_TYPES = (
+    "gr",
+    "ref",
+    "rem",
+    "ser",
+)
+EXAMPLE_TYPE = re.compile(
+    r"(?P<pos_index>\d?)(?P<def_index>\d?)(?P<ex_index>\d*)(?P<type>\w*)(@\w*)*"
+)
+
+
+class Type(Enum):
+    NONE = 0
+    IGNORED = 1
+    ERROR = 2
+    FINISHED_ENTRY = 3
+
+    PINYIN = 11
+    HANZI = 12
+
+    POS = 21
+    POSX = 22
+    DEFINITION = 23
+
+    EXAMPLE_PINYIN = 31
+    EXAMPLE_HANZI = 32
+    EXAMPLE_TRANSLATION = 33
+
+    SMUSHED = 41
+
+
+
 
 def parse_pinyin(content):
     # Pinyin sometimes has superscript numbers preceding them
@@ -17,61 +52,229 @@ def parse_pinyin(content):
     content = content.strip("¹²³⁴⁵⁶⁷⁸⁹")
     # ABC indicates sound change by a dot underneath the vowel
     # But we don't support that, so remove it
-    content = content.translate(str.maketrans('ạẹịọụ', 'aeiou', '*'))
+    content = content.translate(str.maketrans("ạẹịọụ", "aeiou", "*"))
     # Make the Pinyin lowercase, so that dragonmapper can parse it
     content = content.lower()
     # Transcribing to zhuyin first identifies character boundaries
     return transcriptions.to_pinyin(transcriptions.to_zhuyin(content), accented=False)
+
 
 def parse_char(content):
     # Traditional form is indicated enclosed in square brackets
     bracket_index = content.find("[")
     if bracket_index != -1:
         simp = content[:bracket_index]
+        # fmt: off
         trad = content[bracket_index+1:content.find("]")]
+        # fmt: on
     else:
         simp = trad = content
 
     return trad, simp
 
 
+def parse_definition(content):
+    # Assume translation is in English by default
+    lang = "en"
+
+    # If there are multiple translations for an example in different languages, they will
+    # start with the language tag enclosed in square brackets, e.g. [en]
+    if content.startswith("["):
+        # fmt: off
+        lang = content[content.find("[")+1:content.find("]")]
+        content = content[content.find["]"]+2:]
+        # fmt: on
+
+    return lang, content
+
+
+def parse_example_pinyin(content, entry_pinyin):
+    # Replace ∼ in example pinyin with the entry's pinyin
+    content = content.replace("∼", entry_pinyin)
+    # Dragonmapper cannot handle punctuation
+    # And cidian.u8 does not have any examples that have more than one punctuation mark at the end
+    # So strip out the punctuation mark, and then re-add it after transcribing
+    stripped_punctuation = content[-1]
+    content = content[:-1] if content[-1] in string.punctuation else content
+    # Convert to numbered pinyin
+    content = parse_pinyin(content)
+    # Re-add stripped punctuation
+    content = (
+        content + stripped_punctuation if content[-1] in string.punctuation else content
+    )
+
+    return content
+
+
+def parse_example_hanzi(content, simp):
+    # Replace ∼ in example hanzi with entry's simplified form (all examples are in simplified)
+    content = content.replace("∼", simp)
+    return content
+
+
+def parse_example_translation(content):
+    # Assume translation is in English by default
+    lang = "en"
+
+    # If there are multiple translations for an example in different languages, they will
+    # start with the language tag enclosed in square brackets, e.g. [en]
+    if content.startswith("["):
+        # fmt: off
+        lang = content[content.find("[")+1:content.find("]")]
+        content = content[content.find["]"]+2:]
+        # fmt: on
+
+    return lang, content
+
+
+def parse_content(column_type, content):
+    if column_type == ".py":
+        pin = parse_pinyin(content)
+        return Type.PINYIN, pin
+    elif column_type == "char":
+        trad, simp = parse_char(content)
+        return Type.HANZI, (trad, simp)
+    elif column_type == "ps":
+        part_of_speech = content
+        return Type.POS, part_of_speech
+    elif column_type == "psx":
+        # not sure exactly what psx actually means
+        part_of_speech_extended = content
+        return Type.POSX, part_of_speech_extended
+    elif column_type == "df":
+        language, definition = parse_definition(content)
+        return Type.DEFINITION, (language, definition)
+    elif column_type == "ex":
+        example_pinyin = parse_example_pinyin(content, pin)
+        return Type.EXAMPLE_PINYIN, example_pinyin
+    elif column_type == "hz":
+        example_hanzi = parse_example_hanzi(content, simp)
+        return Type.EXAMPLE_HANZI, example_hanzi
+    elif column_type == "tr":
+        language, translation = parse_example_translation(content)
+        return Type.EXAMPLE_TRANSLATION, (language, translation)
+    elif column_type[0].isdigit():
+        # In entries with multiple parts of speech and definitions per part of speech,
+        # part-of-speech number, definition number, example number, and type are smushed together
+        # e.g. "312hz": part-of-speech #3, definition #1 of pos #3, example #2 for definition #1, type = hanzi
+        if EXAMPLE_TYPE.search(column_type):
+            match = EXAMPLE_TYPE.match(column_type).groupdict()
+            parsed = parse_content(match["type"], content)
+            return Type.SMUSHED, (
+                match["pos_index"],
+                match["def_index"],
+                match["ex_index"],
+                parsed,
+            )
+
+
+def parse_line(line):
+    if not line or line in IGNORED_LINES:
+        return Type.NONE, None
+
+    if line == "\n":
+        return Type.FINISHED_ENTRY, None
+
+    line = line.split("   ")
+    if len(line) >= 2:
+        try:
+            column_type, content = line[0], line[1]
+        except Exception as e:
+            logging.error(f"Couldn't parse line: '{line}'")
+            return Type.ERROR, None
+    else:
+        return Type.IGNORED, None
+
+    content = content.strip()
+
+    return parse_content(column_type, content)
+
+
 def parse_file(filename, words):
+    current_entry = None
+
+    current_pos = None
+    part_of_speech_index = 0
+
+    current_posx = None
+
+    current_definition = None
+    definition_index = 0
+
+    current_example = None
+    example_index = 0
+
     with open(filename) as file:
         for line in file.readlines():
-            if not line or line in IGNORED_LINES:
+            parsed_type, parsed = parse_line(line)
+
+            if parsed_type in (Type.NONE, Type.IGNORED, Type.ERROR):
                 continue
 
-            if line == "\n":
-                # Write down parsed entry, start new entry
-                continue
+            elif parsed_type == Type.FINISHED_ENTRY:
+                if current_entry:
+                    words[current_entry.traditional].append(current_entry)
+                current_entry = objects.Entry()
+                current_pos = current_definition = current_example = None
+                pos_index = definition_index = example_index = 0
 
-            line = line.split("   ")
-            if len(line) >= 2:
-                try:
-                    column_type, content = line[0], line[1]
-                except Exception as e:
-                    logging.error(f"Couldn't parse line: '{line}'")
-                    continue
-            else:
-                continue
+            elif parsed_type == Type.PINYIN:
+                current_entry.add_pinyin(parsed)
+            elif parsed_type == Type.HANZI:
+                current_entry.add_traditional(parsed[0])
+                current_entry.add_simplified(parsed[1])
+            elif parsed_type == Type.POS:
+                current_pos = parsed
+            elif parsed_type == Type.POSX:
+                current_posx = parsed
+                current_definition = objects.Definition(definition=current_posx, label=current_pos)
+            elif parsed_type == Type.DEFINITION:
+                # The PSX field should be prepended to all definitions that have a PSX field
+                definition = current_posx + parsed if current_posx else parsed
+                current_definition = objects.Definition(definition=definition, label=current_pos)
 
-            content = content.strip()
+            elif parsed_type == Type.SMUSHED:
+                pos_index, def_index, ex_index, parsed_content = parsed
 
-            if column_type == ".py":
-                pin = parse_pinyin(content)
-                print(f"pin: {pin}")
-            elif column_type == "char":
-                trad, simp = parse_char(content)
-                print(f"trad: {trad}, simp: {simp}")
-            elif column_type == "ps":
-                part_of_speech = content
-                print(f"pos: {part_of_speech}")
-            elif column_type[0].isdigit():
-                # Example number and column type are smushed together in examples
-                # e.g. "1ex": example_number = 1, column_type = example
-                match = re.match(EXAMPLE_TYPE, column_type)
-                example_number, example_type = match.group(1), match.group(2)
-                print(f"ex_num: {example_number}, ex_type: {example_type}")
+                if pos_index == part_of_speech_index + 1:
+                    if pos_index > 0:
+                        # Done parsing the last part of speech; write down current definition and move on
+                        current_entry.append_to_defs(current_definition)
+                    current_definition = objects.Definition()
+                part_of_speech_index = pos_index if pos_index else 0
+
+                if def_index == definition_index + 1:
+                    if def_index > 0:
+                        # We are now parsing the next definition; write down the current definition and move on
+                        current_entry.append_to_defs(current_definition)
+                    current_definition = objects.Definition()
+                elif def_index > definition_index + 1:
+                    logging.error("Uh oh, def_index went wrong: {current_entry}, expected {definition_index}, got {def_index}")
+                definition_index = def_index if def_index else 0
+
+                if ex_index == example_index + 1:
+                    current_definition.examples.append([current_example])
+                    current_example = objects.Example(lang="cmn")
+                elif ex_index > example_index + 1:
+                    logging.error("Uh oh, ex_index went wrong: {current_entry}, expected {example_index}, got {ex_index}")
+                example_index = ex_index if ex_index else 0
+
+                parsed_type, parsed = parsed_content
+                if parsed_type == Type.POS:
+                    current_pos = parsed
+                elif parsed_type == Type.POSX:
+                    current_definition.definition = parsed
+                elif parsed_type == Type.EXAMPLE_PINYIN:
+                    current_example.pron = parsed
+                elif parsed_type == Type.EXAMPLE_HANZI:
+                    current_example.content = parsed
+                elif parsed_type == Type.EXAMPLE_TRANSLATION:
+                    lang = parsed[0]
+                    if lang != "en":
+                        # Only keep English translations for now
+                        continue
+
+                    current_definitions.examples[-1].append(objects.Example(lang="eng", content=parsed[1]))
 
 
 
@@ -91,10 +294,10 @@ if __name__ == "__main__":
                 "e.g. python3 -m abc_.parse abc.db abc/data/cidian.u8 "
                 '"ABC Chinese-English Dictionary" ABC 2015-12-18 '
                 '"This dictionary is an expansion of the ground breaking '
-                'ABC Chinese-English Dictionary, the first strictly '
-                'alphabetically ordered and Pinyin computerized dictionary. '
-                'It contains over 196,000 entries, compared to the 71,486 '
-                'entries of the earlier work, making it the most '
+                "ABC Chinese-English Dictionary, the first strictly "
+                "alphabetically ordered and Pinyin computerized dictionary. "
+                "It contains over 196,000 entries, compared to the 71,486 "
+                "entries of the earlier work, making it the most "
                 'comprehensive one-volume dictionary of Chinese." '
                 '"Copyright © 1996-2019 University of Hawai‘i Press, All Rights Reserved" '
                 '"https://wenlin.com/abc" "" "words,sentences"'
@@ -102,7 +305,7 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    entries = {}
+    entries = defaultdict(list)
     source = objects.SourceTuple(
         sys.argv[3],
         sys.argv[4],
@@ -111,7 +314,7 @@ if __name__ == "__main__":
         sys.argv[7],
         sys.argv[8],
         sys.argv[9],
-        sys.argv[10]
+        sys.argv[10],
     )
     parse_file(sys.argv[2], entries)
-    # write(entries, sys.argv[1])
+    write(entries, sys.argv[1])

--- a/src/dictionaries/abc_/requirements.txt
+++ b/src/dictionaries/abc_/requirements.txt
@@ -1,4 +1,5 @@
 dragonmapper==0.2.6
+hanziconv==0.3.2
 jieba==0.42.1
 pinyin_jyutping_sentence==1.0
 wordfreq==2.5.1

--- a/src/dictionaries/abc_/requirements.txt
+++ b/src/dictionaries/abc_/requirements.txt
@@ -1,0 +1,4 @@
+dragonmapper==0.2.6
+jieba==0.42.1
+pinyin_jyutping_sentence==1.0
+wordfreq==2.5.1

--- a/src/dictionaries/database/objects.py
+++ b/src/dictionaries/database/objects.py
@@ -53,6 +53,12 @@ class Entry(object):
     def __hash__(self):
         return hash(self.__str__())
 
+    def add_traditional(self, trad):
+        self.traditional = trad
+
+    def add_simplified(self, simp):
+        self.simplified = simp
+
     def add_pinyin(self, pin):
         self.pinyin = pin
 


### PR DESCRIPTION
# Description

This commit adds a script to parse the `cidian.u8` file provided by the Wenlin's ABC Chinese-English dictionary obtained by signing a developer agreement. The parsed data is then written to a SQLite file, which can then be added using the program's UI as a new dictionary source for the application.

It **does not** include data contained in that file to this repository.

Closes #52.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have tested this by using the script to generate a SQLite database containing data from the `cidian.u8` file, which I have then added as a data source to the program.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python code, none currently for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
