### PR TITLE
#33: Add support for Bopomofo/Zhuyin romanization

### DIFF
--- a/src/jyut-dict/components/entryview/entryheaderwidget.cpp
+++ b/src/jyut-dict/components/entryview/entryheaderwidget.cpp
@@ -128,6 +128,9 @@ void EntryHeaderWidget::translateUI()
                    || label->objectName() == "prettyPinyinTypeLabel") {
             label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                                        Strings::PINYIN_SHORT));
+        } else if (label->objectName() == "zhuyinTypeLabel") {
+            label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
+                                                       Strings::ZHUYIN_SHORT));
         }
 
         label->setFixedWidth(
@@ -240,7 +243,6 @@ void EntryHeaderWidget::setStyle(bool use_dark)
     _mandarinTTS->setCursor(Qt::PointingHandCursor);
 }
 
-
 void EntryHeaderWidget::displayPronunciationLabels(
     const Entry& entry,
     const CantoneseOptions &cantoneseOptions,
@@ -350,6 +352,33 @@ void EntryHeaderWidget::displayPronunciationLabels(
         _pronunciationLabels.emplace_back(new QLabel{this});
         _pronunciationLabels.back()->setText(
             entry.getMandarinPhonetic(MandarinOptions::NUMBERED_PINYIN).c_str());
+        _entryHeaderLayout->addWidget(_pronunciationLabels.back(), row, 2, 1, 1);
+        _pronunciationLabels.back()->setVisible(true);
+
+        if (!_mandarinTTSVisible) {
+            _entryHeaderLayout
+                ->addWidget(_mandarinTTS, row, 1, 1, 1);
+            _mandarinTTS->setVisible(true);
+            _mandarinTTSVisible = true;
+        }
+
+        row++;
+    }
+
+    if ((mandarinOptions & MandarinOptions::ZHUYIN) == MandarinOptions::ZHUYIN) {
+        _pronunciationTypeLabels.emplace_back(new QLabel{this});
+        _pronunciationTypeLabels.back()->setObjectName("zhuyinTypeLabel");
+        _entryHeaderLayout->addWidget(_pronunciationTypeLabels.back(),
+                                      row,
+                                      0,
+                                      1,
+                                      1,
+                                      Qt::AlignTop);
+        _pronunciationTypeLabels.back()->setVisible(true);
+
+        _pronunciationLabels.emplace_back(new QLabel{this});
+        _pronunciationLabels.back()->setText(
+            entry.getMandarinPhonetic(MandarinOptions::ZHUYIN).c_str());
         _entryHeaderLayout->addWidget(_pronunciationLabels.back(), row, 2, 1, 1);
         _pronunciationLabels.back()->setVisible(true);
 

--- a/src/jyut-dict/components/entryview/entryscrollarea.cpp
+++ b/src/jyut-dict/components/entryview/entryscrollarea.cpp
@@ -39,9 +39,6 @@ void EntryScrollArea::setEntry(const Entry &entry)
     _updateUITimer->stop();
     disconnect(_updateUITimer, nullptr, nullptr, nullptr);
 
-    // Is it OK to have entry as a reference? It seems like this doesn't cause
-    // any problems, but theoretically the timer could keep on running
-    // even after the entry object is deleted...?
     _updateUITimer->setInterval(25);
     QObject::connect(_updateUITimer, &QTimer::timeout, this, [=]() {
         if (_enableUIUpdate) {

--- a/src/jyut-dict/components/mainwindow/mainsplitter.cpp
+++ b/src/jyut-dict/components/mainwindow/mainsplitter.cpp
@@ -156,7 +156,6 @@ void MainSplitter::prepareEntry(Entry &entry, bool addToHistory) const
               .value<MandarinOptions>();
     entry.generatePhonetic(cantoneseOptions, mandarinOptions);
 
-
     cantoneseOptions
         = Settings::getSettings()
               ->value("Preview/cantonesePronunciationOptions",

--- a/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
+++ b/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
@@ -160,6 +160,9 @@ void SentenceViewHeaderWidget::translateUI(void)
                    || label->objectName() == "prettyPinyinTypeLabel") {
             label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                                        Strings::PINYIN_SHORT));
+        } else if (label->objectName() == "zhuyinTypeLabel") {
+            label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
+                                                       Strings::ZHUYIN_SHORT));
         }
 
         label->setFixedWidth(
@@ -429,6 +432,40 @@ void SentenceViewHeaderWidget::displayPronunciationLabels(
         _pronunciationLabels.emplace_back(new QLabel{this});
         _pronunciationLabels.back()->setText(
             sentence.getMandarinPhonetic(MandarinOptions::NUMBERED_PINYIN)
+                .c_str());
+        _sentenceHeaderLayout->addWidget(_pronunciationLabels.back(),
+                                         row,
+                                         2,
+                                         1,
+                                         1);
+        _pronunciationLabels.back()->setVisible(true);
+
+        if (!_mandarinTTSVisible) {
+            _sentenceHeaderLayout
+                ->addWidget(_mandarinTTS, row, 1, 1, 1, Qt::AlignTop);
+            _mandarinTTS->setVisible(true);
+            _mandarinTTSVisible = true;
+        }
+
+        row++;
+    }
+
+    if ((mandarinOptions & MandarinOptions::ZHUYIN)
+        == MandarinOptions::ZHUYIN) {
+        _pronunciationTypeLabels.emplace_back(new QLabel{this});
+        _pronunciationTypeLabels.back()->setObjectName(
+            "numberedPinyinTypeLabel");
+        _sentenceHeaderLayout->addWidget(_pronunciationTypeLabels.back(),
+                                         row,
+                                         0,
+                                         1,
+                                         1,
+                                         Qt::AlignTop);
+        _pronunciationTypeLabels.back()->setVisible(true);
+
+        _pronunciationLabels.emplace_back(new QLabel{this});
+        _pronunciationLabels.back()->setText(
+            sentence.getMandarinPhonetic(MandarinOptions::ZHUYIN)
                 .c_str());
         _sentenceHeaderLayout->addWidget(_pronunciationLabels.back(),
                                          row,

--- a/src/jyut-dict/components/settings/settingstab.cpp
+++ b/src/jyut-dict/components/settings/settingstab.cpp
@@ -108,6 +108,9 @@ void SettingsTab::setupUI()
     _previewNumberedPinyin->setProperty("data",
                                         QVariant::fromValue(
                                             MandarinOptions::NUMBERED_PINYIN));
+    _previewZhuyin = new QRadioButton{this};
+    _previewZhuyin->setProperty("data",
+                                QVariant::fromValue(MandarinOptions::ZHUYIN));
     initializeSearchResultsMandarinPronunciation(*_previewMandarinPronunciation);
 
     QFrame *_entryDivider = new QFrame{this};
@@ -147,6 +150,10 @@ void SettingsTab::setupUI()
     _entryNumberedPinyin->setProperty("data",
                                  QVariant::fromValue(
                                      MandarinOptions::NUMBERED_PINYIN));
+    _entryZhuyin = new QCheckBox{this};
+    _entryZhuyin->setTristate(false);
+    _entryZhuyin->setProperty("data",
+                              QVariant::fromValue(MandarinOptions::ZHUYIN));
     initializeEntryMandarinPronunciation(*_entryMandarinPronunciation);
 
     QFrame *_divider = new QFrame{this};
@@ -248,6 +255,7 @@ void SettingsTab::translateUI()
         ->setText(tr("Show Mandarin:"));
     _previewPinyin->setText(tr("Pinyin"));
     _previewNumberedPinyin->setText(tr("Pinyin with digits"));
+    _previewZhuyin->setText(tr("Zhuyin"));
 
     _entryTitleLabel->setText(
         "<b>" + tr("In the header at the top of an entry:") + "</b>");
@@ -260,6 +268,7 @@ void SettingsTab::translateUI()
         ->setText(tr("Show Mandarin:"));
     _entryPinyin->setText(tr("Pinyin"));
     _entryNumberedPinyin->setText(tr("Pinyin with digits"));
+    _entryZhuyin->setText(tr("Zhuyin"));
 
     _colourTitleLabel->setText(
         "<b>" + tr("Tone colouring:") + "</b>");
@@ -419,6 +428,7 @@ void SettingsTab::initializeSearchResultsMandarinPronunciation(
 {
     mandarinPronunciationWidget.layout()->addWidget(_previewPinyin);
     mandarinPronunciationWidget.layout()->addWidget(_previewNumberedPinyin);
+    mandarinPronunciationWidget.layout()->addWidget(_previewZhuyin);
 
     connect(_previewPinyin, &QRadioButton::clicked, this, [&]() {
         _settings->setValue("Preview/mandarinPronunciationOptions",
@@ -431,6 +441,13 @@ void SettingsTab::initializeSearchResultsMandarinPronunciation(
         _settings->setValue("Preview/mandarinPronunciationOptions",
                             QVariant::fromValue<MandarinOptions>(
                                 MandarinOptions::NUMBERED_PINYIN));
+        _settings->sync();
+    });
+
+    connect(_previewZhuyin, &QRadioButton::clicked, this, [&]() {
+        _settings->setValue("Preview/mandarinPronunciationOptions",
+                            QVariant::fromValue<MandarinOptions>(
+                                MandarinOptions::ZHUYIN));
         _settings->sync();
     });
 
@@ -491,6 +508,7 @@ void SettingsTab::initializeEntryMandarinPronunciation(
 {
     mandarinPronunciationWidget.layout()->addWidget(_entryPinyin);
     mandarinPronunciationWidget.layout()->addWidget(_entryNumberedPinyin);
+    mandarinPronunciationWidget.layout()->addWidget(_entryZhuyin);
 
     connect(_entryPinyin, &QCheckBox::stateChanged, this, [&]() {
         MandarinOptions options
@@ -528,6 +546,26 @@ void SettingsTab::initializeEntryMandarinPronunciation(
                                 QVariant::fromValue<MandarinOptions>(
                                     options
                                     & ~(MandarinOptions::NUMBERED_PINYIN)));
+        }
+        _settings->sync();
+    });
+
+    connect(_entryZhuyin, &QCheckBox::stateChanged, this, [&]() {
+        MandarinOptions options
+            = _settings
+                  ->value("Entry/mandarinPronunciationOptions",
+                          QVariant::fromValue(MandarinOptions::PRETTY_PINYIN))
+                  .value<MandarinOptions>();
+
+        if (_entryZhuyin->isChecked()) {
+            _settings->setValue("Entry/mandarinPronunciationOptions",
+                                QVariant::fromValue<MandarinOptions>(
+                                    options | MandarinOptions::ZHUYIN));
+        } else {
+            _settings->setValue("Entry/mandarinPronunciationOptions",
+                                QVariant::fromValue<MandarinOptions>(
+                                    options
+                                    & ~(MandarinOptions::ZHUYIN)));
         }
         _settings->sync();
     });

--- a/src/jyut-dict/components/settings/settingstab.h
+++ b/src/jyut-dict/components/settings/settingstab.h
@@ -103,6 +103,7 @@ private:
     QHBoxLayout *_previewMandarinPronunciationLayout;
     QRadioButton *_previewPinyin;
     QRadioButton *_previewNumberedPinyin;
+    QRadioButton *_previewZhuyin;
 
     QLabel *_entryTitleLabel;
     QWidget *_entryCantonesePronunciation;
@@ -114,6 +115,7 @@ private:
     QVBoxLayout *_entryMandarinPronunciationLayout;
     QCheckBox *_entryPinyin;
     QCheckBox *_entryNumberedPinyin;
+    QCheckBox *_entryZhuyin;
 
     QLabel *_colourTitleLabel;
     QComboBox *_colourCombobox;

--- a/src/jyut-dict/logic/entry/entry.cpp
+++ b/src/jyut-dict/logic/entry/entry.cpp
@@ -45,6 +45,8 @@ Entry::Entry(const Entry &entry)
     , _isPrettyPinyinValid{entry._isPrettyPinyinValid}
     , _numberedPinyin{entry._numberedPinyin}
     , _isNumberedPinyinValid{entry._isNumberedPinyinValid}
+    , _zhuyin{entry._zhuyin}
+    , _isZhuyinValid{entry._isZhuyinValid}
     , _definitions{entry._definitions}
     , _isWelcome{entry._isWelcome}
     , _isEmpty{entry._isEmpty}
@@ -70,6 +72,8 @@ Entry::Entry(Entry &&entry)
     , _isPrettyPinyinValid{entry._isPrettyPinyinValid}
     , _numberedPinyin{std::move(entry._numberedPinyin)}
     , _isNumberedPinyinValid{entry._isNumberedPinyinValid}
+    , _zhuyin{std::move(entry._zhuyin)}
+    , _isZhuyinValid{entry._isZhuyinValid}
     , _definitions{std::move(entry._definitions)}
     , _isWelcome{entry._isWelcome}
     , _isEmpty{entry._isEmpty}
@@ -98,6 +102,8 @@ Entry &Entry::operator=(const Entry &entry)
     _isPrettyPinyinValid = entry._isPrettyPinyinValid;
     _numberedPinyin = entry._numberedPinyin;
     _isNumberedPinyinValid = entry._isNumberedPinyinValid;
+    _zhuyin = entry._zhuyin;
+    _isZhuyinValid = entry._isZhuyinValid;
     _definitions = entry._definitions;
     _isWelcome = entry._isWelcome;
     _isEmpty = entry._isEmpty;
@@ -127,6 +133,8 @@ Entry &Entry::operator=(Entry &&entry)
     _isPrettyPinyinValid = entry._isPrettyPinyinValid;
     _numberedPinyin = std::move(entry._numberedPinyin);
     _isNumberedPinyinValid = entry._isNumberedPinyinValid;
+    _zhuyin = std::move(entry._zhuyin);
+    _isZhuyinValid = entry._isZhuyinValid;
     _definitions = std::move(entry._definitions);
     _isWelcome = entry._isWelcome;
     _isEmpty = entry._isEmpty;
@@ -267,6 +275,12 @@ bool Entry::generatePhonetic(CantoneseOptions cantoneseOptions,
         _isNumberedPinyinValid = true;
     }
 
+    if ((mandarinOptions & MandarinOptions::ZHUYIN) == MandarinOptions::ZHUYIN
+        && !_isZhuyinValid) {
+        _zhuyin = ChineseUtils::convertPinyinToZhuyin(_pinyin);
+        _isZhuyinValid = true;
+    }
+
     return true;
 }
 
@@ -336,12 +350,18 @@ std::string Entry::getCantonesePhonetic(CantoneseOptions cantoneseOptions) const
 std::string Entry::getMandarinPhonetic(MandarinOptions mandarinOptions) const
 {
     switch (mandarinOptions) {
-        case MandarinOptions::PRETTY_PINYIN:
-            return _prettyPinyin;
-        case MandarinOptions::NUMBERED_PINYIN:
-            return _numberedPinyin;
-        default:
-            return _pinyin;
+    case MandarinOptions::PRETTY_PINYIN: {
+        return _prettyPinyin;
+    }
+    case MandarinOptions::NUMBERED_PINYIN: {
+        return _numberedPinyin;
+    }
+    case MandarinOptions::ZHUYIN: {
+        return _zhuyin;
+    }
+    default: {
+        return _pinyin;
+    }
     }
 }
 
@@ -400,7 +420,6 @@ void Entry::setPinyin(const std::string &pinyin)
 {
     _pinyin = pinyin;
     std::transform(_pinyin.begin(), _pinyin.end(), _pinyin.begin(), ::tolower);
-    _prettyPinyin = ChineseUtils::createPrettyPinyin(_pinyin);
 }
 
 std::vector<int> Entry::getPinyinNumbers() const

--- a/src/jyut-dict/logic/entry/entry.h
+++ b/src/jyut-dict/logic/entry/entry.h
@@ -111,6 +111,8 @@ private:
     bool _isPrettyPinyinValid = false;
     std::string _numberedPinyin;
     bool _isNumberedPinyinValid = false;
+    std::string _zhuyin;
+    bool _isZhuyinValid = false;
 
     std::vector<DefinitionsSet> _definitions;
 

--- a/src/jyut-dict/logic/entry/entryphoneticoptions.h
+++ b/src/jyut-dict/logic/entry/entryphoneticoptions.h
@@ -46,6 +46,7 @@ enum class MandarinOptions : uint32_t {
     RAW_PINYIN = (0x1 << 0), // DEPRECATED, DO NOT USE
     PRETTY_PINYIN = (0x1 << 1),
     NUMBERED_PINYIN = (0x1 << 2),
+    ZHUYIN = (0x1 << 3),
 
     SENTRY = (0x1 << 2),
 };

--- a/src/jyut-dict/logic/sentence/sourcesentence.cpp
+++ b/src/jyut-dict/logic/sentence/sourcesentence.cpp
@@ -100,6 +100,14 @@ bool SourceSentence::generatePhonetic(CantoneseOptions cantoneseOptions,
         _isNumberedPinyinValid = true;
     }
 
+    if ((mandarinOptions & MandarinOptions::ZHUYIN) == MandarinOptions::ZHUYIN
+        && !_isZhuyinValid) {
+        _zhuyin
+            = ChineseUtils::convertPinyinToZhuyin(_pinyin,
+                                                  /* useSpacesToSegment */ true);
+        _isZhuyinValid = true;
+    }
+
     return true;
 
 }
@@ -136,11 +144,18 @@ std::string SourceSentence::getMandarinPhonetic(
     MandarinOptions mandarinOptions) const
 {
     switch (mandarinOptions) {
-    case MandarinOptions::PRETTY_PINYIN:
+    case MandarinOptions::PRETTY_PINYIN: {
         return _prettyPinyin;
-    case MandarinOptions::NUMBERED_PINYIN:
-    default:
+    }
+    case MandarinOptions::NUMBERED_PINYIN: {
+        return _numberedPinyin;
+    }
+    case MandarinOptions::ZHUYIN: {
+        return _zhuyin;
+    }
+    default: {
         return _pinyin;
+    }
     }
 }
 

--- a/src/jyut-dict/logic/sentence/sourcesentence.h
+++ b/src/jyut-dict/logic/sentence/sourcesentence.h
@@ -76,6 +76,8 @@ private:
     bool _isPrettyPinyinValid = false;
     std::string _numberedPinyin;
     bool _isNumberedPinyinValid = false;
+    std::string _zhuyin;
+    bool _isZhuyinValid = false;
 
     std::vector<SentenceSet> _sentences;
 

--- a/src/jyut-dict/logic/strings/strings.h
+++ b/src/jyut-dict/logic/strings/strings.h
@@ -16,6 +16,7 @@ constexpr auto STRINGS_CONTEXT = "strings";
 constexpr auto JYUTPING_SHORT = QT_TRANSLATE_NOOP("strings", "JP");
 constexpr auto YALE_SHORT = QT_TRANSLATE_NOOP("strings", "YL");
 constexpr auto PINYIN_SHORT = QT_TRANSLATE_NOOP("strings", "PY");
+constexpr auto ZHUYIN_SHORT = QT_TRANSLATE_NOOP("strings", "ZY");
 constexpr auto DEFINITIONS_ALL_CAPS = QT_TRANSLATE_NOOP("strings",
                                                         "DEFINITIONS");
 constexpr auto SENTENCES_ALL_CAPS = QT_TRANSLATE_NOOP("strings", "SENTENCES");

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -84,17 +84,18 @@ const static std::unordered_map<std::string, std::string> zhuyinFinalMap
        {"wang", "ㄨㄤ"}, {"ying", "ㄧㄥ"}, {"weng", "ㄨㄥ"}, {"iong", "ㄩㄥ"},
        {"yong", "ㄩㄥ"}, {"uai", "ㄨㄞ"},  {"wai", "ㄨㄞ"},  {"yai", "ㄧㄞ"},
        {"iao", "ㄧㄠ"},  {"yao", "ㄧㄠ"},  {"ian", "ㄧㄢ"},  {"yan", "ㄧㄢ"},
-       {"uan", "ㄨㄢ"},  {"wan", "ㄨㄢ"},  {"üan", "ㄩㄢ"},  {"ang", "ㄤ"},
+       {"uan", "ㄨㄢ"},  {"wan", "ㄨㄢ"},  {"van", "ㄩㄢ"},  {"ang", "ㄤ"},
        {"yue", "ㄩㄝ"},  {"wei", "ㄨㄟ"},  {"you", "ㄧㄡ"},  {"yin", "ㄧㄣ"},
        {"wen", "ㄨㄣ"},  {"yun", "ㄩㄣ"},  {"eng", "ㄥ"},    {"ing", "ㄧㄥ"},
+       {"ong", "ㄨㄥ"},  {"io", "ㄧㄛ"},   {"yo", "ㄧㄛ"},   {"ia", "ㄧㄚ"},
        {"ya", "ㄧㄚ"},   {"ua", "ㄨㄚ"},   {"wa", "ㄨㄚ"},   {"ai", "ㄞ"},
        {"ao", "ㄠ"},     {"an", "ㄢ"},     {"ie", "ㄧㄝ"},   {"ye", "ㄧㄝ"},
-       {"uo", "ㄨㄛ"},   {"wo", "ㄨㄛ"},   {"ue", "ㄩㄝ"},   {"üe", "ㄩㄝ"},
+       {"uo", "ㄨㄛ"},   {"wo", "ㄨㄛ"},   {"ue", "ㄩㄝ"},   {"ve", "ㄩㄝ"},
        {"ei", "ㄟ"},     {"ui", "ㄨㄟ"},   {"ou", "ㄡ"},     {"iu", "ㄧㄡ"},
-       {"en", "ㄣ"},     {"in", "ㄧㄣ"},   {"un", "ㄨㄣ"},   {"ün", "ㄩㄣ"},
+       {"en", "ㄣ"},     {"in", "ㄧㄣ"},   {"un", "ㄨㄣ"},   {"vn", "ㄩㄣ"},
        {"yi", "ㄧ"},     {"wu", "ㄨ"},     {"yu", "ㄩ"},     {"a", "ㄚ"},
        {"e", "ㄜ"},      {"o", "ㄛ"},      {"i", "ㄧ"},      {"u", "ㄨ"},
-       {"ü", "ㄩ"},      {"ê", "ㄝ"}};
+       {"v", "ㄩ"},      {"ê", "ㄝ"}};
 
 const static std::vector<std::string> zhuyinTones = {"", "", "ˊ", "ˇ", "ˋ", "˙"};
 
@@ -563,53 +564,55 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
 
         std::string zhuyin_syllable{syllable};
         zhuyin_syllable = std::regex_replace(zhuyin_syllable,
-                                             std::regex{"u:"},
-                                             "ü");
+                                             std::regex{"u\\:"},
+                                             "v");
         zhuyin_syllable = std::regex_replace(zhuyin_syllable,
                                              std::regex{"([jqx])u"},
-                                             "$&ü");
+                                             "$1v");
         zhuyin_syllable = std::regex_replace(zhuyin_syllable,
                                              std::regex{"([zcs]h?)i"},
-                                             "$&");
+                                             "$1");
         zhuyin_syllable = std::regex_replace(zhuyin_syllable,
                                              std::regex{"([r])i"},
-                                             "$&");
+                                             "$1");
 
         // Handle special cases
         zhuyin_syllable = std::regex_replace(zhuyin_syllable,
                                              std::regex{"^ng([012345])$"},
-                                             "ㄫ$&");
+                                             "ㄫ$1");
         zhuyin_syllable = std::regex_replace(zhuyin_syllable,
                                              std::regex{"^hm([012345])$"},
-                                             "ㄏㄇ$&");
+                                             "ㄏㄇ$1");
         zhuyin_syllable = std::regex_replace(zhuyin_syllable,
                                              std::regex{"^hng([012345])$"},
-                                             "ㄏㄫ$&");
+                                             "ㄏㄫ$1");
         zhuyin_syllable = std::regex_replace(zhuyin_syllable,
                                              std::regex{"^er([012345])$"},
-                                             "ㄦ$&");
+                                             "ㄦ$1");
 
         // Handle general case
         // Convert Pinyin initial
         std::smatch initial_match;
         std::regex pinyin_initial = std::regex{"^([bpmfdtnlgkhjqxzcsr]?h?)"};
         if (std::regex_search(zhuyin_syllable, initial_match, pinyin_initial)) {
-            zhuyin_syllable = std::regex_replace(zhuyin_syllable,
-                                                 pinyin_initial,
-                                                 zhuyinInitialMap.at(
-                                                     initial_match[1]));
+            if (initial_match[1].length()) {
+                zhuyin_syllable = std::regex_replace(zhuyin_syllable,
+                                                     pinyin_initial,
+                                                     zhuyinInitialMap.at(
+                                                         initial_match[1]));
+            }
         }
         // Convert Pinyin final
         std::smatch final_match;
         std::regex pinyin_final = std::regex{
-            "([aeiouêüyw]?[aeioun]?[aeioung]?[ng]?)(r?)([012345])$"};
+            "([aeiouêvyw]?[aeioun]?[aeioung]?[ng]?)(r?)([012345])$"};
         if (std::regex_search(zhuyin_syllable, final_match, pinyin_final)) {
             std::string final;
             std::string er;
-            if (final_match[1].matched) {
+            if (final_match[1].length()) {
                 final = zhuyinFinalMap.at(final_match[1]);
             }
-            if (final_match[2].matched && final_match[2].length()) {
+            if (final_match[2].length()) {
                 er = "ㄦ";
             }
             zhuyin_syllable = std::regex_replace(zhuyin_syllable,
@@ -622,7 +625,7 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
             zhuyin_syllable = zhuyinTones[tone] + zhuyin_syllable;
         } else {
             auto er_pos = zhuyin_syllable.find("ㄦ");
-            if (er_pos != std::string::npos) {
+            if (er_pos != std::string::npos && zhuyin_syllable != "ㄦ") {
                 zhuyin_syllable.insert(er_pos, zhuyinTones[tone]);
             } else {
                 zhuyin_syllable = zhuyin_syllable + zhuyinTones[tone];

--- a/src/jyut-dict/logic/utils/chineseutils.h
+++ b/src/jyut-dict/logic/utils/chineseutils.h
@@ -54,6 +54,10 @@ std::string createPrettyPinyin(const std::string &pinyin);
 std::string createNumberedPinyin(const std::string &pinyin);
 std::string createPinyinWithV(const std::string &pinyin);
 
+std::string convertPinyinToZhuyin(const std::string &pinyin);
+std::string convertPinyinToZhuyin(const std::string &pinyin,
+                                  bool useSpacesToSegment);
+
 // constructRomanisationQuery takes a vector of strings and stitches them
 // together with a delimiter.
 //


### PR DESCRIPTION
# Description

This commit adds:
- utilities to convert from Pinyin to Bopomofo/Zhuyin in the backend
- functions in Entry and SourceSentence that use those utilities to generate a Bopomofo/Zhuyin representation of entries and sentences
- settings to display or hide Bopomofo/Zhuyin romanization


This is the second PR that begins to tackle parts of #33.

<img width="912" alt="Screen Shot 2022-12-10 at 1 59 32 PM" src="https://user-images.githubusercontent.com/14353716/208068929-cd98d658-a949-4302-b090-f1148333715f.png">

<img width="845" alt="Screen Shot 2022-12-10 at 1 59 56 PM" src="https://user-images.githubusercontent.com/14353716/208068951-e6ef757a-3200-4f9a-889d-487fecdddb32.png">

<img width="838" alt="Screen Shot 2022-12-10 at 2 00 00 PM" src="https://user-images.githubusercontent.com/14353716/208068974-9e289206-7773-4fbd-8c00-34c5371aab28.png">

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've built and run the new program, checking that the settings apply correctly. As I currently only have access to a Mac, this change has only been verified to run correctly on macOS.

I've also verified that settings from previous versions of Jyut Dictionary are correctly migrated to the new V2 settings schema.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python code, none currently for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
