### PR TITLE
#33: Fix compilation on Windows and Linux

### DIFF
--- a/src/jyut-dict/components/entryview/entryheaderwidget.cpp
+++ b/src/jyut-dict/components/entryview/entryheaderwidget.cpp
@@ -55,8 +55,8 @@ void EntryHeaderWidget::changeEvent(QEvent *event)
 {
 #ifdef Q_OS_WIN
     if (event->type() == QEvent::FontChange) {
-        _jyutpingLabel->setFixedWidth(_jyutpingLabel->fontMetrics().boundingRect("JP").width());
-        _pinyinLabel->setFixedWidth(_pinyinLabel->fontMetrics().boundingRect("PY").width());
+        // This is just to correctly resize the JP/PY etc. labels
+        translateUI();
     }
 #endif
     if (event->type() == QEvent::PaletteChange && !_paletteRecentlyChanged) {
@@ -210,7 +210,6 @@ void EntryHeaderWidget::setStyle(bool use_dark)
                                           LABEL_TEXT_COLOUR_LIGHT_R};
     for (const auto& label : _pronunciationTypeLabels) {
         label->setAttribute(Qt::WA_TranslucentBackground);
-        label->setVisible(false);
         label->setStyleSheet(styleSheet.arg(textColour.name()));
     }
 

--- a/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
+++ b/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
@@ -31,8 +31,8 @@ void SentenceViewHeaderWidget::changeEvent(QEvent *event)
 {
 #ifdef Q_OS_WIN
     if (event->type() == QEvent::FontChange) {
-        _jyutpingLabel->setFixedWidth(_jyutpingLabel->fontMetrics().boundingRect("JP").width());
-        _pinyinLabel->setFixedWidth(_pinyinLabel->fontMetrics().boundingRect("PY").width());
+        // This is just to correctly resize the JP/PY etc. labels
+        translateUI();
     }
 #endif
     if (event->type() == QEvent::PaletteChange && !_paletteRecentlyChanged) {
@@ -240,7 +240,6 @@ void SentenceViewHeaderWidget::setStyle(bool use_dark)
                                           LABEL_TEXT_COLOUR_LIGHT_R};
    for (const auto& label : _pronunciationTypeLabels) {
         label->setAttribute(Qt::WA_TranslucentBackground);
-        label->setVisible(false);
         label->setStyleSheet(styleSheet.arg(textColour.name()));
     }
 


### PR DESCRIPTION
This commit:
- Fixes compilation on Windows and Linux.
- Also fixes weird JP/PY/YL/ZY resizing bug on Windows and Linux when switching between light/dark mode.

This is the third PR in the #33 series.

# Description

This commit re-enables compilation on Windows and Linux. It also fixes a bug that crept in where the romanization type label (e.g. JP/PY/YL/ZY in the header) would resize to half the width of the window when a theme change was detected.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Built on Windows, Linux, and macOS. Manually verified by changing theme type using advanced settings on Windows and Linux, or the system light/dark mode control on macOS.

**Test Configuration**:
* OS and version: Windows 10, elementary OS 5.1 Hera, macOS Monterey 12.3.1
* Toolchain: mingw, gcc, clang respectively
* Qt Version: Qt 5.15.2

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python code, none currently for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
