### PR TITLE
#33: Add support for Cantonese Sinological IPA

### DIFF
--- a/src/jyut-dict/components/definitioncard/definitioncontentwidget.cpp
+++ b/src/jyut-dict/components/definitioncard/definitioncontentwidget.cpp
@@ -182,10 +182,10 @@ void DefinitionContentWidget::setEntry(const std::vector<Definition::Definition>
             }
 
             if (!pronunciationText.isEmpty()) {
+                // Don't use the "list-style-type:none;" stylesheet here; for some
+                // reason it changes all double-spaces (e.g. "  ") to single spaces
                 _examplePronunciationLabels.push_back(
-                    new QLabel{"<ul style=\"list-style-type:none;\"><li>"
-                                   + pronunciationText + "</li></ul>",
-                               this});
+                    new QLabel{pronunciationText, this});
                 _examplePronunciationLabels.back()->setContentsMargins(0, 0, 0, 0);
                 _examplePronunciationLabels.back()->setWordWrap(true);
                 _examplePronunciationLabels.back()->setTextInteractionFlags(
@@ -257,7 +257,7 @@ void DefinitionContentWidget::setStyle(bool use_dark)
     }
 
     QString examplePronunciationStyleSheet = "QLabel { color: %1; "
-                                             "padding-left: 0px; "
+                                             "padding-left: 38px; "
                                              "margin-left: 0px; } ";
     for (const auto &label : _examplePronunciationLabels) {
         label->setStyleSheet(

--- a/src/jyut-dict/components/entryview/entryheaderwidget.cpp
+++ b/src/jyut-dict/components/entryview/entryheaderwidget.cpp
@@ -124,6 +124,10 @@ void EntryHeaderWidget::translateUI()
         } else if (label->objectName() == "yaleTypeLabel") {
             label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                                        Strings::YALE_SHORT));
+        } else if (label->objectName() == "cantoneseIPATypeLabel") {
+            label->setText(
+                QCoreApplication::translate(Strings::STRINGS_CONTEXT,
+                                            Strings::CANTONESE_IPA_SHORT));
         } else if (label->objectName() == "numberedPinyinTypeLabel"
                    || label->objectName() == "prettyPinyinTypeLabel") {
             label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
@@ -294,6 +298,34 @@ void EntryHeaderWidget::displayPronunciationLabels(
         _pronunciationLabels.emplace_back(new QLabel{this});
         _pronunciationLabels.back()->setText(
             entry.getCantonesePhonetic(CantoneseOptions::PRETTY_YALE).c_str());
+        _entryHeaderLayout->addWidget(_pronunciationLabels.back(), row, 2, 1, 1);
+        _pronunciationLabels.back()->setVisible(true);
+
+        if (!_cantoneseTTSVisible) {
+            _entryHeaderLayout
+                ->addWidget(_cantoneseTTS, row, 1, 1, 1, Qt::AlignTop);
+            _cantoneseTTS->setVisible(true);
+            _cantoneseTTSVisible = true;
+        }
+
+        row++;
+    }
+
+    if ((cantoneseOptions & CantoneseOptions::CANTONESE_IPA)
+        == CantoneseOptions::CANTONESE_IPA) {
+        _pronunciationTypeLabels.emplace_back(new QLabel{this});
+        _pronunciationTypeLabels.back()->setObjectName("cantoneseIPATypeLabel");
+        _entryHeaderLayout->addWidget(_pronunciationTypeLabels.back(),
+                                      row,
+                                      0,
+                                      1,
+                                      1,
+                                      Qt::AlignTop);
+        _pronunciationTypeLabels.back()->setVisible(true);
+
+        _pronunciationLabels.emplace_back(new QLabel{this});
+        _pronunciationLabels.back()->setText(
+            entry.getCantonesePhonetic(CantoneseOptions::CANTONESE_IPA).c_str());
         _entryHeaderLayout->addWidget(_pronunciationLabels.back(), row, 2, 1, 1);
         _pronunciationLabels.back()->setVisible(true);
 

--- a/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
+++ b/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
@@ -156,6 +156,10 @@ void SentenceViewHeaderWidget::translateUI(void)
         } else if (label->objectName() == "yaleTypeLabel") {
             label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                                        Strings::YALE_SHORT));
+        } else if (label->objectName() == "cantoneseIPATypeLabel") {
+            label->setText(
+                QCoreApplication::translate(Strings::STRINGS_CONTEXT,
+                                            Strings::CANTONESE_IPA_SHORT));
         } else if (label->objectName() == "numberedPinyinTypeLabel"
                    || label->objectName() == "prettyPinyinTypeLabel") {
             label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
@@ -366,6 +370,39 @@ void SentenceViewHeaderWidget::displayPronunciationLabels(
         _pronunciationLabels.emplace_back(new QLabel{this});
         _pronunciationLabels.back()->setText(
             sentence.getCantonesePhonetic(CantoneseOptions::PRETTY_YALE).c_str());
+        _sentenceHeaderLayout->addWidget(_pronunciationLabels.back(),
+                                         row,
+                                         2,
+                                         1,
+                                         1);
+        _pronunciationLabels.back()->setVisible(true);
+
+        if (!_cantoneseTTSVisible) {
+            _sentenceHeaderLayout
+                ->addWidget(_cantoneseTTS, row, 1, 1, 1, Qt::AlignTop);
+            _cantoneseTTS->setVisible(true);
+            _cantoneseTTSVisible = true;
+        }
+
+        row++;
+    }
+
+    if ((cantoneseOptions & CantoneseOptions::CANTONESE_IPA)
+        == CantoneseOptions::CANTONESE_IPA) {
+        _pronunciationTypeLabels.emplace_back(new QLabel{this});
+        _pronunciationTypeLabels.back()->setObjectName("cantoneseIPATypeLabel");
+        _sentenceHeaderLayout->addWidget(_pronunciationTypeLabels.back(),
+                                         row,
+                                         0,
+                                         1,
+                                         1,
+                                         Qt::AlignTop);
+        _pronunciationTypeLabels.back()->setVisible(true);
+
+        _pronunciationLabels.emplace_back(new QLabel{this});
+        _pronunciationLabels.back()->setText(
+            sentence.getCantonesePhonetic(CantoneseOptions::CANTONESE_IPA)
+                .c_str());
         _sentenceHeaderLayout->addWidget(_pronunciationLabels.back(),
                                          row,
                                          2,

--- a/src/jyut-dict/components/settings/settingstab.cpp
+++ b/src/jyut-dict/components/settings/settingstab.cpp
@@ -93,6 +93,10 @@ void SettingsTab::setupUI()
     _previewYale->setProperty("data",
                               QVariant::fromValue(
                                   CantoneseOptions::PRETTY_YALE));
+    _previewCantoneseIPA = new QRadioButton{this};
+    _previewCantoneseIPA->setProperty("data",
+                                      QVariant::fromValue(
+                                          CantoneseOptions::CANTONESE_IPA));
     initializeSearchResultsCantonesePronunciation(
         *_previewCantonesePronunciation);
 
@@ -134,6 +138,11 @@ void SettingsTab::setupUI()
     _entryYale->setTristate(false);
     _entryYale->setProperty("data",
                             QVariant::fromValue(CantoneseOptions::PRETTY_YALE));
+    _entryCantoneseIPA = new QCheckBox{this};
+    _entryCantoneseIPA->setTristate(false);
+    _entryCantoneseIPA->setProperty("data",
+                                    QVariant::fromValue(
+                                        CantoneseOptions::CANTONESE_IPA));
     initializeEntryCantonesePronunciation(*_entryCantonesePronunciation);
 
     _entryMandarinPronunciation = new QWidget{this};
@@ -250,6 +259,7 @@ void SettingsTab::translateUI()
         ->setText(tr("Show Cantonese:"));
     _previewJyutping->setText(tr("Jyutping"));
     _previewYale->setText(tr("Yale"));
+    _previewCantoneseIPA->setText(tr("Cantonese IPA"));
     static_cast<QLabel *>(
         _tabLayout->labelForField(_previewMandarinPronunciation))
         ->setText(tr("Show Mandarin:"));
@@ -264,6 +274,7 @@ void SettingsTab::translateUI()
         ->setText(tr("Show Cantonese:"));
     _entryJyutping->setText(tr("Jyutping"));
     _entryYale->setText(tr("Yale"));
+    _entryCantoneseIPA->setText(tr("Cantonese IPA"));
     static_cast<QLabel *>(_tabLayout->labelForField(_entryMandarinPronunciation))
         ->setText(tr("Show Mandarin:"));
     _entryPinyin->setText(tr("Pinyin"));
@@ -405,6 +416,7 @@ void SettingsTab::initializeSearchResultsCantonesePronunciation(
 {
     cantonesePronunciationWidget.layout()->addWidget(_previewJyutping);
     cantonesePronunciationWidget.layout()->addWidget(_previewYale);
+    cantonesePronunciationWidget.layout()->addWidget(_previewCantoneseIPA);
 
     connect(_previewJyutping, &QRadioButton::clicked, this, [&]() {
         _settings->setValue("Preview/cantonesePronunciationOptions",
@@ -417,6 +429,13 @@ void SettingsTab::initializeSearchResultsCantonesePronunciation(
         _settings->setValue("Preview/cantonesePronunciationOptions",
                             QVariant::fromValue<CantoneseOptions>(
                                 CantoneseOptions::PRETTY_YALE));
+        _settings->sync();
+    });
+
+    connect(_previewCantoneseIPA, &QRadioButton::clicked, this, [&]() {
+        _settings->setValue("Preview/cantonesePronunciationOptions",
+                            QVariant::fromValue<CantoneseOptions>(
+                                CantoneseOptions::CANTONESE_IPA));
         _settings->sync();
     });
 
@@ -459,6 +478,7 @@ void SettingsTab::initializeEntryCantonesePronunciation(
 {
     cantonesePronunciationWidget.layout()->addWidget(_entryJyutping);
     cantonesePronunciationWidget.layout()->addWidget(_entryYale);
+    cantonesePronunciationWidget.layout()->addWidget(_entryCantoneseIPA);
 
     connect(_entryJyutping, &QCheckBox::stateChanged, this, [&]() {
         CantoneseOptions options
@@ -496,6 +516,26 @@ void SettingsTab::initializeEntryCantonesePronunciation(
                                 QVariant::fromValue<CantoneseOptions>(
                                     options
                                     & ~(CantoneseOptions::PRETTY_YALE)));
+        }
+        _settings->sync();
+    });
+
+    connect(_entryCantoneseIPA, &QCheckBox::stateChanged, this, [&]() {
+        CantoneseOptions options
+            = _settings
+                  ->value("Entry/cantonesePronunciationOptions",
+                          QVariant::fromValue(CantoneseOptions::RAW_JYUTPING))
+                  .value<CantoneseOptions>();
+
+        if (_entryCantoneseIPA->isChecked()) {
+            _settings->setValue("Entry/cantonesePronunciationOptions",
+                                QVariant::fromValue<CantoneseOptions>(
+                                    options | CantoneseOptions::CANTONESE_IPA));
+        } else {
+            _settings->setValue("Entry/cantonesePronunciationOptions",
+                                QVariant::fromValue<CantoneseOptions>(
+                                    options
+                                    & ~(CantoneseOptions::CANTONESE_IPA)));
         }
         _settings->sync();
     });

--- a/src/jyut-dict/components/settings/settingstab.h
+++ b/src/jyut-dict/components/settings/settingstab.h
@@ -99,6 +99,7 @@ private:
     QHBoxLayout *_previewCantonesePronunciationLayout;
     QRadioButton *_previewJyutping;
     QRadioButton *_previewYale;
+    QRadioButton *_previewCantoneseIPA;
     QWidget *_previewMandarinPronunciation;
     QHBoxLayout *_previewMandarinPronunciationLayout;
     QRadioButton *_previewPinyin;
@@ -110,6 +111,7 @@ private:
     QVBoxLayout *_entryCantonesePronunciationLayout;
     QCheckBox *_entryJyutping;
     QCheckBox *_entryYale;
+    QCheckBox *_entryCantoneseIPA;
 
     QWidget *_entryMandarinPronunciation;
     QVBoxLayout *_entryMandarinPronunciationLayout;

--- a/src/jyut-dict/logic/entry/entry.cpp
+++ b/src/jyut-dict/logic/entry/entry.cpp
@@ -259,8 +259,11 @@ bool Entry::generatePhonetic(CantoneseOptions cantoneseOptions,
     if ((cantoneseOptions & CantoneseOptions::PRETTY_YALE)
             == CantoneseOptions::PRETTY_YALE
         && !_isYaleValid) {
-        _yale = ChineseUtils::convertJyutpingToYale(_jyutping);
-        _isYaleValid = true;
+            _yale = ChineseUtils::convertJyutpingToYale(_jyutping);
+            std::string ipa = ChineseUtils::convertJyutpingToIPA(_jyutping);
+            std::cout << "Jyutping: " << _jyutping << " IPA: " << ipa
+                      << std::endl;
+            _isYaleValid = true;
     }
 
     if ((mandarinOptions & MandarinOptions::PRETTY_PINYIN)

--- a/src/jyut-dict/logic/entry/entry.cpp
+++ b/src/jyut-dict/logic/entry/entry.cpp
@@ -28,57 +28,51 @@ Entry::Entry(const std::string &simplified, const std::string &traditional,
 }
 
 Entry::Entry(const Entry &entry)
-    : QObject()
-    , _simplified{entry._simplified}
-    , _simplifiedDifference{entry._simplifiedDifference}
-    , _traditional{entry._traditional}
-    , _traditionalDifference{entry._traditionalDifference}
-    , _colouredSimplified{entry._colouredSimplified}
-    , _colouredSimplifiedDifference{entry._colouredSimplifiedDifference}
-    , _colouredTraditional{entry._colouredTraditional}
-    , _colouredTraditionalDifference{entry._colouredTraditionalDifference}
-    , _jyutping{entry._jyutping}
-    , _yale{entry._yale}
-    , _isYaleValid{entry._isYaleValid}
-    , _pinyin{entry._pinyin}
-    , _prettyPinyin{entry._prettyPinyin}
-    , _isPrettyPinyinValid{entry._isPrettyPinyinValid}
-    , _numberedPinyin{entry._numberedPinyin}
-    , _isNumberedPinyinValid{entry._isNumberedPinyinValid}
-    , _zhuyin{entry._zhuyin}
-    , _isZhuyinValid{entry._isZhuyinValid}
-    , _definitions{entry._definitions}
-    , _isWelcome{entry._isWelcome}
-    , _isEmpty{entry._isEmpty}
-{
-}
+    : QObject(), _simplified{entry._simplified},
+      _simplifiedDifference{entry._simplifiedDifference},
+      _traditional{entry._traditional},
+      _traditionalDifference{entry._traditionalDifference},
+      _colouredSimplified{entry._colouredSimplified},
+      _colouredSimplifiedDifference{entry._colouredSimplifiedDifference},
+      _colouredTraditional{entry._colouredTraditional},
+      _colouredTraditionalDifference{entry._colouredTraditionalDifference},
+      _jyutping{entry._jyutping}, _yale{entry._yale},
+      _isYaleValid{entry._isYaleValid}, _cantoneseIPA{entry._cantoneseIPA},
+      _isCantoneseIPAValid{entry._isCantoneseIPAValid}, _pinyin{entry._pinyin},
+      _prettyPinyin{entry._prettyPinyin},
+      _isPrettyPinyinValid{entry._isPrettyPinyinValid},
+      _numberedPinyin{entry._numberedPinyin},
+      _isNumberedPinyinValid{entry._isNumberedPinyinValid},
+      _zhuyin{entry._zhuyin}, _isZhuyinValid{entry._isZhuyinValid},
+      _definitions{entry._definitions},
+      _isWelcome{entry._isWelcome}, _isEmpty{entry._isEmpty}
+{}
 
 Entry::Entry(Entry &&entry)
-    : _simplified{std::move(entry._simplified)}
-    , _simplifiedDifference{std::move(entry._simplifiedDifference)}
-    , _traditional{std::move(entry._traditional)}
-    , _traditionalDifference{std::move(entry._traditionalDifference)}
-    , _colouredSimplified{std::move(entry._colouredSimplified)}
-    , _colouredSimplifiedDifference{std::move(
-          entry._colouredSimplifiedDifference)}
-    , _colouredTraditional{std::move(entry._colouredTraditional)}
-    , _colouredTraditionalDifference{std::move(
-          entry._colouredTraditionalDifference)}
-    , _jyutping{std::move(entry._jyutping)}
-    , _yale{std::move(entry._yale)}
-    , _isYaleValid{entry._isYaleValid}
-    , _pinyin{std::move(entry._pinyin)}
-    , _prettyPinyin{std::move(entry._prettyPinyin)}
-    , _isPrettyPinyinValid{entry._isPrettyPinyinValid}
-    , _numberedPinyin{std::move(entry._numberedPinyin)}
-    , _isNumberedPinyinValid{entry._isNumberedPinyinValid}
-    , _zhuyin{std::move(entry._zhuyin)}
-    , _isZhuyinValid{entry._isZhuyinValid}
-    , _definitions{std::move(entry._definitions)}
-    , _isWelcome{entry._isWelcome}
-    , _isEmpty{entry._isEmpty}
-{
-}
+    : _simplified{std::move(entry._simplified)},
+      _simplifiedDifference{std::move(entry._simplifiedDifference)},
+      _traditional{std::move(entry._traditional)},
+      _traditionalDifference{std::move(entry._traditionalDifference)},
+      _colouredSimplified{std::move(entry._colouredSimplified)},
+      _colouredSimplifiedDifference{
+          std::move(entry._colouredSimplifiedDifference)},
+      _colouredTraditional{std::move(entry._colouredTraditional)},
+      _colouredTraditionalDifference{
+          std::move(entry._colouredTraditionalDifference)},
+      _jyutping{std::move(entry._jyutping)}, _yale{std::move(entry._yale)},
+      _isYaleValid{entry._isYaleValid}, _cantoneseIPA{std::move(
+                                            entry._cantoneseIPA)},
+      _isCantoneseIPAValid{entry._isCantoneseIPAValid}, _pinyin{std::move(
+                                                            entry._pinyin)},
+      _prettyPinyin{std::move(entry._prettyPinyin)},
+      _isPrettyPinyinValid{entry._isPrettyPinyinValid},
+      _numberedPinyin{std::move(entry._numberedPinyin)},
+      _isNumberedPinyinValid{entry._isNumberedPinyinValid}, _zhuyin{std::move(
+                                                                entry._zhuyin)},
+      _isZhuyinValid{entry._isZhuyinValid}, _definitions{std::move(
+                                                entry._definitions)},
+      _isWelcome{entry._isWelcome}, _isEmpty{entry._isEmpty}
+{}
 
 Entry &Entry::operator=(const Entry &entry)
 {
@@ -97,6 +91,8 @@ Entry &Entry::operator=(const Entry &entry)
     _jyutping = entry._jyutping;
     _yale = entry._yale;
     _isYaleValid = entry._isYaleValid;
+    _cantoneseIPA = entry._cantoneseIPA;
+    _isCantoneseIPAValid = entry._isCantoneseIPAValid;
     _pinyin = entry._pinyin;
     _prettyPinyin = entry._prettyPinyin;
     _isPrettyPinyinValid = entry._isPrettyPinyinValid;
@@ -128,6 +124,8 @@ Entry &Entry::operator=(Entry &&entry)
     _jyutping = std::move(entry._jyutping);
     _yale = std::move(entry._yale);
     _isYaleValid = entry._isYaleValid;
+    _cantoneseIPA = std::move(entry._cantoneseIPA);
+    _isCantoneseIPAValid = entry._isCantoneseIPAValid;
     _pinyin = std::move(entry._pinyin);
     _prettyPinyin = std::move(entry._prettyPinyin);
     _isPrettyPinyinValid = entry._isPrettyPinyinValid;
@@ -260,10 +258,14 @@ bool Entry::generatePhonetic(CantoneseOptions cantoneseOptions,
             == CantoneseOptions::PRETTY_YALE
         && !_isYaleValid) {
             _yale = ChineseUtils::convertJyutpingToYale(_jyutping);
-            std::string ipa = ChineseUtils::convertJyutpingToIPA(_jyutping);
-            std::cout << "Jyutping: " << _jyutping << " IPA: " << ipa
-                      << std::endl;
             _isYaleValid = true;
+    }
+
+    if ((cantoneseOptions & CantoneseOptions::CANTONESE_IPA)
+            == CantoneseOptions::CANTONESE_IPA
+        && !_isCantoneseIPAValid) {
+            _cantoneseIPA = ChineseUtils::convertJyutpingToIPA(_jyutping);
+            _isCantoneseIPAValid = true;
     }
 
     if ((mandarinOptions & MandarinOptions::PRETTY_PINYIN)
@@ -343,6 +345,9 @@ std::string Entry::getCantonesePhonetic(CantoneseOptions cantoneseOptions) const
     switch (cantoneseOptions) {
     case CantoneseOptions::PRETTY_YALE: {
         return _yale;
+    }
+    case CantoneseOptions::CANTONESE_IPA: {
+        return _cantoneseIPA;
     }
     case CantoneseOptions::RAW_JYUTPING:
     default:

--- a/src/jyut-dict/logic/entry/entry.h
+++ b/src/jyut-dict/logic/entry/entry.h
@@ -105,6 +105,8 @@ private:
     std::string _jyutping;
     std::string _yale;
     bool _isYaleValid = false;
+    std::string _cantoneseIPA;
+    bool _isCantoneseIPAValid = false;
 
     std::string _pinyin;
     std::string _prettyPinyin;

--- a/src/jyut-dict/logic/entry/entryphoneticoptions.h
+++ b/src/jyut-dict/logic/entry/entryphoneticoptions.h
@@ -31,8 +31,9 @@ enum class CantoneseOptions : uint32_t {
     NONE = (0x0),
     RAW_JYUTPING = (0x1 << 0),
     PRETTY_YALE = (0x1 << 1),
+    CANTONESE_IPA = (0x1 << 2),
 
-    SENTRY = (0x1 << 2),
+    SENTRY = (0x1 << 3),
 };
 
 // These are required so that bitwise operations are allowed on the enum class

--- a/src/jyut-dict/logic/sentence/sourcesentence.cpp
+++ b/src/jyut-dict/logic/sentence/sourcesentence.cpp
@@ -88,6 +88,15 @@ bool SourceSentence::generatePhonetic(CantoneseOptions cantoneseOptions,
         _isYaleValid = true;
     }
 
+    if ((cantoneseOptions & CantoneseOptions::CANTONESE_IPA)
+            == CantoneseOptions::CANTONESE_IPA
+        && !_isCantoneseIPAValid) {
+        _cantoneseIPA
+            = ChineseUtils::convertJyutpingToIPA(_jyutping,
+                                                 /* useSpacesToSegment */ true);
+        _isCantoneseIPAValid = true;
+    }
+
     if ((mandarinOptions & MandarinOptions::PRETTY_PINYIN)
             == MandarinOptions::PRETTY_PINYIN && !_isPrettyPinyinValid) {
         _prettyPinyin = ChineseUtils::createPrettyPinyin(_pinyin);
@@ -133,6 +142,9 @@ std::string SourceSentence::getCantonesePhonetic(
     switch (cantoneseOptions) {
     case CantoneseOptions::PRETTY_YALE: {
         return _yale;
+    }
+    case CantoneseOptions::CANTONESE_IPA: {
+        return _cantoneseIPA;
     }
     case CantoneseOptions::RAW_JYUTPING:
     default:

--- a/src/jyut-dict/logic/sentence/sourcesentence.h
+++ b/src/jyut-dict/logic/sentence/sourcesentence.h
@@ -70,6 +70,8 @@ private:
     std::string _jyutping;
     std::string _yale;
     bool _isYaleValid = false;
+    std::string _cantoneseIPA;
+    bool _isCantoneseIPAValid = false;
 
     std::string _pinyin;
     std::string _prettyPinyin;

--- a/src/jyut-dict/logic/strings/strings.h
+++ b/src/jyut-dict/logic/strings/strings.h
@@ -15,6 +15,7 @@ constexpr auto STRINGS_CONTEXT = "strings";
 
 constexpr auto JYUTPING_SHORT = QT_TRANSLATE_NOOP("strings", "JP");
 constexpr auto YALE_SHORT = QT_TRANSLATE_NOOP("strings", "YL");
+constexpr auto CANTONESE_IPA_SHORT = QT_TRANSLATE_NOOP("strings", "YI");
 constexpr auto PINYIN_SHORT = QT_TRANSLATE_NOOP("strings", "PY");
 constexpr auto ZHUYIN_SHORT = QT_TRANSLATE_NOOP("strings", "ZY");
 constexpr auto DEFINITIONS_ALL_CAPS = QT_TRANSLATE_NOOP("strings",

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -71,6 +71,68 @@ const static std::unordered_map<std::string, std::vector<std::string>>
                           {"u", {"ū", "ú", "u", "ù", "ú", "u"}},
 };
 
+// The original Wiktionary module uses breves to indicate a special letter (e.g.
+// ă), but the base C++ regex engine can't match against chars outside of the
+// basic set. As a workaround, I'm just replacing them with other symbols.
+const static std::vector<std::pair<std::string, std::string> >
+    jyutpingToIPASpecialSyllables = {{"a", "@"},
+                                     {"yu", "y"},
+                                     {"@@", "a"},
+                                     {"uk", "^k"},
+                                     {"ik", "|k"},
+                                     {"ou", "~u"},
+                                     {"eoi", "eoy"},
+                                     {"ung", "^ng"},
+                                     {"ing", "|ng"},
+                                     {"ei", ">i"}};
+
+const static std::unordered_map<std::string, std::string> jyutpingToIPAInitials
+    = {
+        {"b", "p"},
+        {"p", "pʰ"},
+        {"d", "t"},
+        {"t", "tʰ"},
+        {"g", "k"},
+        {"k", "kʰ"},
+        {"ng", "ŋ"},
+        {"gw", "kʷ"},
+        {"kw", "kʷʰ"},
+        {"zh", "t͡ʃ"},
+        {"ch", "t͡ʃʰ"},
+        {"sh", "ʃ"},
+        {"z", "t͡s"},
+        {"c", "t͡sʰ"},
+};
+
+const static std::unordered_map<std::string, std::string> jyutpingToIPANuclei = {
+    {"a", "äː"},
+    {"@", "ɐ"},
+    {"e", "ɛː"},
+    {">", "e"},
+    {"i", "iː"},
+    {"|", "ɪ"},
+    {"o", "ɔː"},
+    {"~", "o"},
+    {"oe", "œ̽ː"},
+    {"eo", "ɵ"},
+    {"u", "uː"},
+    {"^", "ʊ"},
+    {"y", "yː"},
+};
+
+const static std::unordered_map<std::string, std::string> jyutpingToIPACodas = {
+    {"i", "i̯"},
+    {"u", "u̯"},
+    {"y", "y̯"},
+    {"ng", "ŋ"},
+    {"p", "p̚"},
+    {"t", "t̚"},
+    {"k", "k̚"},
+};
+
+const static std::vector<std::string> jyutpingToIPATones
+    = {"⁵⁵", "³⁵", "³³", "²¹", "¹³", "²²", "⁵", "³", "²"};
+
 const static std::unordered_map<std::string, std::string> zhuyinInitialMap = {
     {"b", "ㄅ"},  {"p", "ㄆ"}, {"m", "ㄇ"}, {"f", "ㄈ"},  {"d", "ㄉ"},
     {"t", "ㄊ"},  {"n", "ㄋ"}, {"l", "ㄌ"}, {"g", "ㄍ"},  {"k", "ㄎ"},
@@ -282,14 +344,9 @@ static std::string convertYaleFinal(const std::string &syllable)
     return yale_syllable;
 }
 
-std::string convertJyutpingToYale(const std::string &jyutping)
-{
-    return convertJyutpingToYale(jyutping, /* useSpacesToSegment */ false);
-}
-
-// Note that the majority of this code is derivative of Wiktionary's conversion
-// code, contained in the module yue-pron
-// (https://en.wiktionary.org/wiki/Module:yue-pron)
+// Note that the majority of this function and the convertToIPA function
+// is derivative of Wiktionary's conversion code, contained in the module
+// "yue-pron" (https://en.wiktionary.org/wiki/Module:yue-pron)
 std::string convertJyutpingToYale(const std::string &jyutping,
                                   bool useSpacesToSegment)
 {
@@ -363,6 +420,159 @@ std::string convertJyutpingToYale(const std::string &jyutping,
     return result;
 }
 
+std::string convertIPASyllable(const std::string &syllable)
+{
+    std::string initial;
+    std::string nucleus;
+    std::string coda;
+    std::string tone;
+
+    std::regex syllable_regex{"([bcdfghjklmnpqrstvwxyz]?[bcdfghjklmnpqrstvwxyz]"
+                              "?)([a@e>i|o~u^y][eo]?)([iuymngptk]?g?)([1-9])"};
+    std::smatch match;
+
+    auto regex_res = std::regex_match(syllable, match, syllable_regex);
+
+    if (!regex_res) {
+        // No valid Jyutping found
+        return syllable;
+    }
+
+    // Get equivalent to matched initial
+    if (match[1].length()) {
+        if (jyutpingToIPAInitials.find(match[1])
+            != jyutpingToIPAInitials.end()) {
+            initial = jyutpingToIPAInitials.at(match[1]);
+        } else {
+            initial = match[1];
+        }
+    }
+
+    // Get equivalent to matched nucleus
+    if (match[2].length()) {
+        if (jyutpingToIPANuclei.find(match[2]) != jyutpingToIPANuclei.end()) {
+            nucleus = jyutpingToIPANuclei.at(match[2]);
+        } else {
+            nucleus = match[2];
+        }
+    }
+
+    // Get equivalent to matched final
+    if (match[3].length()) {
+        if (jyutpingToIPACodas.find(match[3]) != jyutpingToIPACodas.end()) {
+            coda = jyutpingToIPACodas.at(match[3]);
+        } else {
+            coda = match[3];
+        }
+    }
+
+    // Get equivalent to matched tone
+    if (match[4].length()) {
+        tone = jyutpingToIPATones.at(
+            static_cast<size_t>(std::stoi(match[4]) - 1));
+    }
+
+    std::string ipa_syllable = initial + nucleus + coda + tone;
+    return ipa_syllable;
+}
+
+std::string convertJyutpingToIPA(const std::string &jyutping,
+                                 bool useSpacesToSegment)
+{
+    if (jyutping.empty()) {
+        return jyutping;
+    }
+
+    std::vector<std::string> syllables;
+    if (useSpacesToSegment) {
+        // Insert a space before and after every special character, so that the
+        // IPA conversion doesn't attempt to convert special characters.
+        std::string jyutpingCopy = jyutping;
+        for (const auto &specialCharacter : specialCharacters) {
+            size_t location = jyutpingCopy.find(specialCharacter);
+            if (location != std::string::npos) {
+                jyutpingCopy.erase(location, specialCharacter.length());
+                jyutpingCopy.insert(location, " " + specialCharacter + " ");
+            }
+        }
+        Utils::split(jyutpingCopy, ' ', syllables);
+    } else {
+        syllables = segmentJyutping(QString{jyutping.c_str()},
+                                    /* ignoreSpecialCharacters */ false);
+    }
+
+    std::vector<std::string> ipa_syllables;
+
+    for (const auto &syllable : syllables) {
+        // Skip syllables that are just punctuation
+        if (specialCharacters.find(syllable) != specialCharacters.end()) {
+            ipa_syllables.push_back(syllable);
+            continue;
+        }
+
+        // Skip syllables that don't have tone
+        auto location = syllable.find_first_of("123456");
+        if (location == std::string::npos) {
+            ipa_syllables.push_back(syllable);
+            continue;
+        }
+
+        // Do some pre-processing
+        std::string ipa_syllable{syllable};
+        ipa_syllable = std::regex_replace(ipa_syllable,
+                                          std::regex{"([zcs])yu"},
+                                          "$1hyu");
+        ipa_syllable = std::regex_replace(ipa_syllable,
+                                          std::regex{"([zc])oe"},
+                                          "$1hoe");
+        ipa_syllable = std::regex_replace(ipa_syllable,
+                                          std::regex{"([zc])eo"},
+                                          "$1heo");
+
+        // Convert special syllables
+        std::smatch match;
+        if (std::regex_match(ipa_syllable,
+                             match,
+                             std::regex{"^(h?)([mn]g?)([1-6])$"})) {
+            ipa_syllable = std::regex_replace(ipa_syllable,
+                                              std::regex{"m"},
+                                              "m̩");
+            ipa_syllable = std::regex_replace(ipa_syllable,
+                                              std::regex{"ng"},
+                                              "ŋ̍");
+        }
+
+        // Replace checked tones
+        if (std::regex_search(ipa_syllable,
+                              match,
+                              std::regex{"([ptk])([136])"})) {
+            std::replace(ipa_syllable.begin(), ipa_syllable.end(), '1', '7');
+            std::replace(ipa_syllable.begin(), ipa_syllable.end(), '3', '8');
+            std::replace(ipa_syllable.begin(), ipa_syllable.end(), '6', '9');
+        }
+
+        // Do some more preprocessing
+        for (const auto &pair : jyutpingToIPASpecialSyllables) {
+            ipa_syllable = std::regex_replace(ipa_syllable,
+                                              std::regex{pair.first},
+                                              pair.second);
+        }
+
+        ipa_syllables.emplace_back(convertIPASyllable(ipa_syllable));
+    }
+
+    std::ostringstream ipa;
+    for (const auto &ipa_syllable : ipa_syllables) {
+        ipa << ipa_syllable << " ";
+    }
+
+    // Remove trailing space
+    std::string result = ipa.str();
+    result.erase(result.end() - 1);
+
+    return result;
+}
+
 std::string createPrettyPinyin(const std::string &pinyin)
 {
     if (pinyin.empty()) {
@@ -427,7 +637,8 @@ std::string createPrettyPinyin(const std::string &pinyin)
         }
 
         // replacementMap maps a character to its replacements with diacritics.
-        auto search = replacementMap.find(syllable.substr(location, character_size));
+        auto search = replacementMap.find(
+            syllable.substr(location, character_size));
         if (search != replacementMap.end()) {
             std::string replacement = search->second.at(
                 static_cast<size_t>(tone) - 1);
@@ -651,7 +862,7 @@ std::string constructRomanisationQuery(const std::vector<std::string> &words,
                                        const char *delimiter,
                                        const bool surroundWithQuotes)
 {
-    const char *quotes = surroundWithQuotes ? "\"": "";
+    const char *quotes = surroundWithQuotes ? "\"" : "";
     std::ostringstream string;
     for (size_t i = 0; i < words.size() - 1; i++) {
         if (std::isdigit(words[i].back())) {
@@ -807,7 +1018,8 @@ std::vector<std::string> segmentJyutping(const QString &string,
         bool isSpecialCharacter = (specialCharacters.find(
                                        stringToExamine.toStdString())
                                    != specialCharacters.end());
-        if (stringToExamine == " " || stringToExamine == "'" || isSpecialCharacter) {
+        if (stringToExamine == " " || stringToExamine == "'"
+            || isSpecialCharacter) {
             if (initial_found) { // Add any incomplete word to the vector
                 QString previous_initial = string.mid(start_index,
                                                       end_index - start_index);
@@ -921,5 +1133,4 @@ std::vector<std::string> segmentJyutping(const QString &string,
 
     return words;
 }
-
-}
+} // namespace ChineseUtils

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -534,12 +534,18 @@ std::string convertJyutpingToIPA(const std::string &jyutping,
         if (std::regex_match(ipa_syllable,
                              match,
                              std::regex{"^(h?)([mn]g?)([1-6])$"})) {
+            int tone = std::stoi(match[3]);
             ipa_syllable = std::regex_replace(ipa_syllable,
                                               std::regex{"m"},
                                               "m̩");
             ipa_syllable = std::regex_replace(ipa_syllable,
                                               std::regex{"ng"},
                                               "ŋ̍");
+            ipa_syllable = std::regex_replace(ipa_syllable,
+                                              std::regex{"[1-6]"},
+                                              jyutpingToIPATones.at(
+                                                  static_cast<size_t>(tone
+                                                                      - 1)));
         }
 
         // Replace checked tones

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -1,7 +1,6 @@
 #include "chineseutils.h"
 
 #include "logic/utils/utils.h"
-#include "logic/settings/settings.h"
 
 #include <cctype>
 #include <codecvt>
@@ -560,15 +559,14 @@ std::string convertJyutpingToIPA(const std::string &jyutping,
             ipa_syllable = std::regex_replace(ipa_syllable,
                                               std::regex{"ng"},
                                               "ŋ̍");
-            ipa_syllable = std::regex_replace(ipa_syllable,
-                                              std::regex{"[1-6]"},
+            ipa_syllable = std::regex_replace(
+                ipa_syllable,
+                std::regex{"[1-6]"},
 #if defined(Q_OS_MAC)
-                                              " " +
-#else
-                                              jyutpingToIPATones.at(
-                                                  static_cast<size_t>(tone
-                                                                      - 1)));
+                // Only macOS needs this space to fix weird kerning
+                " " +
 #endif
+                    jyutpingToIPATones.at(static_cast<size_t>(tone - 1)));
         }
 
         // Replace checked tones

--- a/src/jyut-dict/logic/utils/chineseutils.h
+++ b/src/jyut-dict/logic/utils/chineseutils.h
@@ -46,9 +46,10 @@ std::string applyColours(
 std::string compareStrings(const std::string &original,
                            const std::string &comparison);
 
-std::string convertJyutpingToYale(const std::string &jyutping);
 std::string convertJyutpingToYale(const std::string &jyutping,
-                                  bool useSpacesToSegment);
+                                  bool useSpacesToSegment = false);
+std::string convertJyutpingToIPA(const std::string &jyutping,
+                                 bool useSpacesToSegment = false);
 
 std::string createPrettyPinyin(const std::string &pinyin);
 std::string createNumberedPinyin(const std::string &pinyin);

--- a/src/jyut-dict/logic/utils/utils.cpp
+++ b/src/jyut-dict/logic/utils/utils.cpp
@@ -13,7 +13,9 @@ namespace Utils {
         std::string word;
 
         while (std::getline(ss, word, delimiter)) {
-            result.push_back(word);
+            if (word.length() > 0 && word[0] != delimiter) {
+                result.push_back(word);
+            }
         }
     }
 
@@ -27,7 +29,10 @@ namespace Utils {
         size_t current = 0;
         while ((current = string.find(delimiter, previous))
                != std::string::npos) {
-            result.push_back(string.substr(previous, current - previous));
+            std::string substr = string.substr(previous, current - previous);
+            if (substr != delimiter) {
+                result.push_back(substr);
+            }
             previous = current + delimiter.length();
         }
         result.push_back(string.substr(previous));


### PR DESCRIPTION
This PR adds conversion from Jyutping to Sinological IPA, as well as the hooks in settings and elsewhere to display them throughout the application.

![cantonese-ipa](https://user-images.githubusercontent.com/14353716/209522257-25527682-b051-496d-aeb0-db8270a188db.png)

This is the fourth PR in the #33 series.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have built the application on Windows 10, elementary OS 5.1 Hera, and macOS 12.3.1. Monterey. IPA displays as expected when the setting is chosen.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python code, none currently for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
