### PR TITLE
#33: Add support for Mandarin Sinological IPA

### DIFF
--- a/src/jyut-dict/components/entryview/entryheaderwidget.cpp
+++ b/src/jyut-dict/components/entryview/entryheaderwidget.cpp
@@ -135,6 +135,10 @@ void EntryHeaderWidget::translateUI()
         } else if (label->objectName() == "zhuyinTypeLabel") {
             label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                                        Strings::ZHUYIN_SHORT));
+        } else if (label->objectName() == "mandarinIPATypeLabel") {
+            label->setText(
+                QCoreApplication::translate(Strings::STRINGS_CONTEXT,
+                                            Strings::MANDARIN_IPA_SHORT));
         }
 
         label->setFixedWidth(
@@ -416,6 +420,33 @@ void EntryHeaderWidget::displayPronunciationLabels(
         if (!_mandarinTTSVisible) {
             _entryHeaderLayout
                 ->addWidget(_mandarinTTS, row, 1, 1, 1);
+            _mandarinTTS->setVisible(true);
+            _mandarinTTSVisible = true;
+        }
+
+        row++;
+    }
+
+    if ((mandarinOptions & MandarinOptions::MANDARIN_IPA)
+        == MandarinOptions::MANDARIN_IPA) {
+        _pronunciationTypeLabels.emplace_back(new QLabel{this});
+        _pronunciationTypeLabels.back()->setObjectName("mandarinIPATypeLabel");
+        _entryHeaderLayout->addWidget(_pronunciationTypeLabels.back(),
+                                      row,
+                                      0,
+                                      1,
+                                      1,
+                                      Qt::AlignTop);
+        _pronunciationTypeLabels.back()->setVisible(true);
+
+        _pronunciationLabels.emplace_back(new QLabel{this});
+        _pronunciationLabels.back()->setText(
+            entry.getMandarinPhonetic(MandarinOptions::MANDARIN_IPA).c_str());
+        _entryHeaderLayout->addWidget(_pronunciationLabels.back(), row, 2, 1, 1);
+        _pronunciationLabels.back()->setVisible(true);
+
+        if (!_mandarinTTSVisible) {
+            _entryHeaderLayout->addWidget(_mandarinTTS, row, 1, 1, 1);
             _mandarinTTS->setVisible(true);
             _mandarinTTSVisible = true;
         }

--- a/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
+++ b/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
@@ -167,6 +167,10 @@ void SentenceViewHeaderWidget::translateUI(void)
         } else if (label->objectName() == "zhuyinTypeLabel") {
             label->setText(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                                        Strings::ZHUYIN_SHORT));
+        } else if (label->objectName() == "mandarinIPATypeLabel") {
+            label->setText(
+                QCoreApplication::translate(Strings::STRINGS_CONTEXT,
+                                            Strings::MANDARIN_IPA_SHORT));
         }
 
         label->setFixedWidth(
@@ -503,6 +507,39 @@ void SentenceViewHeaderWidget::displayPronunciationLabels(
         _pronunciationLabels.back()->setText(
             sentence.getMandarinPhonetic(MandarinOptions::ZHUYIN)
                 .c_str());
+        _sentenceHeaderLayout->addWidget(_pronunciationLabels.back(),
+                                         row,
+                                         2,
+                                         1,
+                                         1);
+        _pronunciationLabels.back()->setVisible(true);
+
+        if (!_mandarinTTSVisible) {
+            _sentenceHeaderLayout
+                ->addWidget(_mandarinTTS, row, 1, 1, 1, Qt::AlignTop);
+            _mandarinTTS->setVisible(true);
+            _mandarinTTSVisible = true;
+        }
+
+        row++;
+    }
+
+    if ((mandarinOptions & MandarinOptions::MANDARIN_IPA)
+        == MandarinOptions::MANDARIN_IPA) {
+        _pronunciationTypeLabels.emplace_back(new QLabel{this});
+        _pronunciationTypeLabels.back()->setObjectName(
+            "numberedPinyinTypeLabel");
+        _sentenceHeaderLayout->addWidget(_pronunciationTypeLabels.back(),
+                                         row,
+                                         0,
+                                         1,
+                                         1,
+                                         Qt::AlignTop);
+        _pronunciationTypeLabels.back()->setVisible(true);
+
+        _pronunciationLabels.emplace_back(new QLabel{this});
+        _pronunciationLabels.back()->setText(
+            sentence.getMandarinPhonetic(MandarinOptions::MANDARIN_IPA).c_str());
         _sentenceHeaderLayout->addWidget(_pronunciationLabels.back(),
                                          row,
                                          2,

--- a/src/jyut-dict/components/settings/settingstab.cpp
+++ b/src/jyut-dict/components/settings/settingstab.cpp
@@ -115,6 +115,10 @@ void SettingsTab::setupUI()
     _previewZhuyin = new QRadioButton{this};
     _previewZhuyin->setProperty("data",
                                 QVariant::fromValue(MandarinOptions::ZHUYIN));
+    _previewMandarinIPA = new QRadioButton{this};
+    _previewMandarinIPA->setProperty("data",
+                                     QVariant::fromValue(
+                                         MandarinOptions::MANDARIN_IPA));
     initializeSearchResultsMandarinPronunciation(*_previewMandarinPronunciation);
 
     QFrame *_entryDivider = new QFrame{this};
@@ -163,6 +167,11 @@ void SettingsTab::setupUI()
     _entryZhuyin->setTristate(false);
     _entryZhuyin->setProperty("data",
                               QVariant::fromValue(MandarinOptions::ZHUYIN));
+    _entryMandarinIPA = new QCheckBox{this};
+    _entryMandarinIPA->setTristate(false);
+    _entryMandarinIPA->setProperty("data",
+                                   QVariant::fromValue(
+                                       MandarinOptions::MANDARIN_IPA));
     initializeEntryMandarinPronunciation(*_entryMandarinPronunciation);
 
     QFrame *_divider = new QFrame{this};
@@ -266,6 +275,7 @@ void SettingsTab::translateUI()
     _previewPinyin->setText(tr("Pinyin"));
     _previewNumberedPinyin->setText(tr("Pinyin with digits"));
     _previewZhuyin->setText(tr("Zhuyin"));
+    _previewMandarinIPA->setText(tr("Mandarin IPA"));
 
     _entryTitleLabel->setText(
         "<b>" + tr("In the header at the top of an entry:") + "</b>");
@@ -280,6 +290,7 @@ void SettingsTab::translateUI()
     _entryPinyin->setText(tr("Pinyin"));
     _entryNumberedPinyin->setText(tr("Pinyin with digits"));
     _entryZhuyin->setText(tr("Zhuyin"));
+    _entryMandarinIPA->setText(tr("Mandarin IPA"));
 
     _colourTitleLabel->setText(
         "<b>" + tr("Tone colouring:") + "</b>");
@@ -448,6 +459,7 @@ void SettingsTab::initializeSearchResultsMandarinPronunciation(
     mandarinPronunciationWidget.layout()->addWidget(_previewPinyin);
     mandarinPronunciationWidget.layout()->addWidget(_previewNumberedPinyin);
     mandarinPronunciationWidget.layout()->addWidget(_previewZhuyin);
+    mandarinPronunciationWidget.layout()->addWidget(_previewMandarinIPA);
 
     connect(_previewPinyin, &QRadioButton::clicked, this, [&]() {
         _settings->setValue("Preview/mandarinPronunciationOptions",
@@ -467,6 +479,13 @@ void SettingsTab::initializeSearchResultsMandarinPronunciation(
         _settings->setValue("Preview/mandarinPronunciationOptions",
                             QVariant::fromValue<MandarinOptions>(
                                 MandarinOptions::ZHUYIN));
+        _settings->sync();
+    });
+
+    connect(_previewMandarinIPA, &QRadioButton::clicked, this, [&]() {
+        _settings->setValue("Preview/mandarinPronunciationOptions",
+                            QVariant::fromValue<MandarinOptions>(
+                                MandarinOptions::MANDARIN_IPA));
         _settings->sync();
     });
 
@@ -549,6 +568,7 @@ void SettingsTab::initializeEntryMandarinPronunciation(
     mandarinPronunciationWidget.layout()->addWidget(_entryPinyin);
     mandarinPronunciationWidget.layout()->addWidget(_entryNumberedPinyin);
     mandarinPronunciationWidget.layout()->addWidget(_entryZhuyin);
+    mandarinPronunciationWidget.layout()->addWidget(_entryMandarinIPA);
 
     connect(_entryPinyin, &QCheckBox::stateChanged, this, [&]() {
         MandarinOptions options
@@ -606,6 +626,25 @@ void SettingsTab::initializeEntryMandarinPronunciation(
                                 QVariant::fromValue<MandarinOptions>(
                                     options
                                     & ~(MandarinOptions::ZHUYIN)));
+        }
+        _settings->sync();
+    });
+
+    connect(_entryMandarinIPA, &QCheckBox::stateChanged, this, [&]() {
+        MandarinOptions options
+            = _settings
+                  ->value("Entry/mandarinPronunciationOptions",
+                          QVariant::fromValue(MandarinOptions::PRETTY_PINYIN))
+                  .value<MandarinOptions>();
+
+        if (_entryMandarinIPA->isChecked()) {
+            _settings->setValue("Entry/mandarinPronunciationOptions",
+                                QVariant::fromValue<MandarinOptions>(
+                                    options | MandarinOptions::MANDARIN_IPA));
+        } else {
+            _settings->setValue("Entry/mandarinPronunciationOptions",
+                                QVariant::fromValue<MandarinOptions>(
+                                    options & ~(MandarinOptions::MANDARIN_IPA)));
         }
         _settings->sync();
     });

--- a/src/jyut-dict/components/settings/settingstab.h
+++ b/src/jyut-dict/components/settings/settingstab.h
@@ -105,6 +105,7 @@ private:
     QRadioButton *_previewPinyin;
     QRadioButton *_previewNumberedPinyin;
     QRadioButton *_previewZhuyin;
+    QRadioButton *_previewMandarinIPA;
 
     QLabel *_entryTitleLabel;
     QWidget *_entryCantonesePronunciation;
@@ -112,12 +113,12 @@ private:
     QCheckBox *_entryJyutping;
     QCheckBox *_entryYale;
     QCheckBox *_entryCantoneseIPA;
-
     QWidget *_entryMandarinPronunciation;
     QVBoxLayout *_entryMandarinPronunciationLayout;
     QCheckBox *_entryPinyin;
     QCheckBox *_entryNumberedPinyin;
     QCheckBox *_entryZhuyin;
+    QCheckBox *_entryMandarinIPA;
 
     QLabel *_colourTitleLabel;
     QComboBox *_colourCombobox;

--- a/src/jyut-dict/logic/entry/entry.cpp
+++ b/src/jyut-dict/logic/entry/entry.cpp
@@ -44,6 +44,8 @@ Entry::Entry(const Entry &entry)
       _numberedPinyin{entry._numberedPinyin},
       _isNumberedPinyinValid{entry._isNumberedPinyinValid},
       _zhuyin{entry._zhuyin}, _isZhuyinValid{entry._isZhuyinValid},
+      _mandarinIPA{entry._mandarinIPA},
+      _isMandarinIPAValid{entry._isMandarinIPAValid},
       _definitions{entry._definitions},
       _isWelcome{entry._isWelcome}, _isEmpty{entry._isEmpty}
 {}
@@ -69,8 +71,10 @@ Entry::Entry(Entry &&entry)
       _numberedPinyin{std::move(entry._numberedPinyin)},
       _isNumberedPinyinValid{entry._isNumberedPinyinValid}, _zhuyin{std::move(
                                                                 entry._zhuyin)},
-      _isZhuyinValid{entry._isZhuyinValid}, _definitions{std::move(
-                                                entry._definitions)},
+      _isZhuyinValid{entry._isZhuyinValid}, _mandarinIPA{std::move(
+                                                entry._mandarinIPA)},
+      _isMandarinIPAValid{entry._isMandarinIPAValid}, _definitions{std::move(
+                                                          entry._definitions)},
       _isWelcome{entry._isWelcome}, _isEmpty{entry._isEmpty}
 {}
 
@@ -100,6 +104,8 @@ Entry &Entry::operator=(const Entry &entry)
     _isNumberedPinyinValid = entry._isNumberedPinyinValid;
     _zhuyin = entry._zhuyin;
     _isZhuyinValid = entry._isZhuyinValid;
+    _mandarinIPA = entry._mandarinIPA;
+    _isMandarinIPAValid = entry._isMandarinIPAValid;
     _definitions = entry._definitions;
     _isWelcome = entry._isWelcome;
     _isEmpty = entry._isEmpty;
@@ -133,6 +139,8 @@ Entry &Entry::operator=(Entry &&entry)
     _isNumberedPinyinValid = entry._isNumberedPinyinValid;
     _zhuyin = std::move(entry._zhuyin);
     _isZhuyinValid = entry._isZhuyinValid;
+    _mandarinIPA = std::move(entry._mandarinIPA);
+    _isMandarinIPAValid = entry._isMandarinIPAValid;
     _definitions = std::move(entry._definitions);
     _isWelcome = entry._isWelcome;
     _isEmpty = entry._isEmpty;
@@ -272,8 +280,6 @@ bool Entry::generatePhonetic(CantoneseOptions cantoneseOptions,
             == MandarinOptions::PRETTY_PINYIN && !_isPrettyPinyinValid) {
         _prettyPinyin = ChineseUtils::createPrettyPinyin(_pinyin);
         _isPrettyPinyinValid = true;
-
-        std::cout << ChineseUtils::convertPinyinToIPA(_pinyin) << std::endl;
     }
 
     if ((mandarinOptions & MandarinOptions::NUMBERED_PINYIN)
@@ -286,6 +292,13 @@ bool Entry::generatePhonetic(CantoneseOptions cantoneseOptions,
         && !_isZhuyinValid) {
         _zhuyin = ChineseUtils::convertPinyinToZhuyin(_pinyin);
         _isZhuyinValid = true;
+    }
+
+    if ((mandarinOptions & MandarinOptions::MANDARIN_IPA)
+            == MandarinOptions::MANDARIN_IPA
+        && !_isMandarinIPAValid) {
+        _mandarinIPA = ChineseUtils::convertPinyinToIPA(_pinyin);
+        _isMandarinIPAValid = true;
     }
 
     return true;
@@ -368,6 +381,9 @@ std::string Entry::getMandarinPhonetic(MandarinOptions mandarinOptions) const
     }
     case MandarinOptions::ZHUYIN: {
         return _zhuyin;
+    }
+    case MandarinOptions::MANDARIN_IPA: {
+        return _mandarinIPA;
     }
     default: {
         return _pinyin;

--- a/src/jyut-dict/logic/entry/entry.cpp
+++ b/src/jyut-dict/logic/entry/entry.cpp
@@ -272,6 +272,8 @@ bool Entry::generatePhonetic(CantoneseOptions cantoneseOptions,
             == MandarinOptions::PRETTY_PINYIN && !_isPrettyPinyinValid) {
         _prettyPinyin = ChineseUtils::createPrettyPinyin(_pinyin);
         _isPrettyPinyinValid = true;
+
+        std::cout << ChineseUtils::convertPinyinToIPA(_pinyin) << std::endl;
     }
 
     if ((mandarinOptions & MandarinOptions::NUMBERED_PINYIN)

--- a/src/jyut-dict/logic/entry/entry.h
+++ b/src/jyut-dict/logic/entry/entry.h
@@ -115,6 +115,8 @@ private:
     bool _isNumberedPinyinValid = false;
     std::string _zhuyin;
     bool _isZhuyinValid = false;
+    std::string _mandarinIPA;
+    bool _isMandarinIPAValid = false;
 
     std::vector<DefinitionsSet> _definitions;
 

--- a/src/jyut-dict/logic/entry/entryphoneticoptions.h
+++ b/src/jyut-dict/logic/entry/entryphoneticoptions.h
@@ -48,8 +48,9 @@ enum class MandarinOptions : uint32_t {
     PRETTY_PINYIN = (0x1 << 1),
     NUMBERED_PINYIN = (0x1 << 2),
     ZHUYIN = (0x1 << 3),
+    MANDARIN_IPA = (0x1 << 4),
 
-    SENTRY = (0x1 << 2),
+    SENTRY = (0x1 << 5),
 };
 
 constexpr inline MandarinOptions operator~ (MandarinOptions a) { return static_cast<MandarinOptions>( ~static_cast<std::underlying_type<MandarinOptions>::type>(a) ); }

--- a/src/jyut-dict/logic/sentence/sourcesentence.cpp
+++ b/src/jyut-dict/logic/sentence/sourcesentence.cpp
@@ -117,6 +117,15 @@ bool SourceSentence::generatePhonetic(CantoneseOptions cantoneseOptions,
         _isZhuyinValid = true;
     }
 
+    if ((mandarinOptions & MandarinOptions::MANDARIN_IPA)
+            == MandarinOptions::MANDARIN_IPA
+        && !_isMandarinIPAValid) {
+        _mandarinIPA
+            = ChineseUtils::convertPinyinToIPA(_pinyin,
+                                               /* useSpacesToSegment */ true);
+        _isMandarinIPAValid = true;
+    }
+
     return true;
 
 }
@@ -164,6 +173,9 @@ std::string SourceSentence::getMandarinPhonetic(
     }
     case MandarinOptions::ZHUYIN: {
         return _zhuyin;
+    }
+    case MandarinOptions::MANDARIN_IPA: {
+        return _mandarinIPA;
     }
     default: {
         return _pinyin;

--- a/src/jyut-dict/logic/sentence/sourcesentence.h
+++ b/src/jyut-dict/logic/sentence/sourcesentence.h
@@ -80,6 +80,8 @@ private:
     bool _isNumberedPinyinValid = false;
     std::string _zhuyin;
     bool _isZhuyinValid = false;
+    std::string _mandarinIPA;
+    bool _isMandarinIPAValid = false;
 
     std::vector<SentenceSet> _sentences;
 

--- a/src/jyut-dict/logic/strings/strings.h
+++ b/src/jyut-dict/logic/strings/strings.h
@@ -18,6 +18,7 @@ constexpr auto YALE_SHORT = QT_TRANSLATE_NOOP("strings", "YL");
 constexpr auto CANTONESE_IPA_SHORT = QT_TRANSLATE_NOOP("strings", "YI");
 constexpr auto PINYIN_SHORT = QT_TRANSLATE_NOOP("strings", "PY");
 constexpr auto ZHUYIN_SHORT = QT_TRANSLATE_NOOP("strings", "ZY");
+constexpr auto MANDARIN_IPA_SHORT = QT_TRANSLATE_NOOP("strings", "ZI");
 constexpr auto DEFINITIONS_ALL_CAPS = QT_TRANSLATE_NOOP("strings",
                                                         "DEFINITIONS");
 constexpr auto SENTENCES_ALL_CAPS = QT_TRANSLATE_NOOP("strings", "SENTENCES");

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -899,6 +899,7 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
                 pinyinCopy += character_utf8;
             }
         }
+        Utils::split(pinyinCopy, ' ', syllables);
     } else {
         syllables = segmentPinyin(QString{pinyin.c_str()});
     }

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -17,6 +17,7 @@ static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
 
 const static std::unordered_set<std::string> specialCharacters = {
     ".",
+    "。",
     ",",
     "，",
     "!",
@@ -31,6 +32,7 @@ const static std::unordered_set<std::string> specialCharacters = {
     "·",
     "\"",
     "“",
+    "”",
 };
 
 const static std::unordered_map<std::string, std::string>
@@ -985,18 +987,25 @@ std::tuple<std::string, std::string> convertIPAMandarinSyllable(
             return std::make_tuple("", syllable);
         }
 
+        std::cout << "syllable: " << syllable << std::endl;
         bool found_initial = !(mandarinIPAInitials.find(ipa_match[1])
                                == mandarinIPAInitials.end());
         bool found_final = !(mandarinIPAFinals.find(ipa_match[2])
                              == mandarinIPAFinals.end());
         if (!found_initial && !found_final) {
+            std::cout << "returning, no initial and no final found"
+                      << std::endl;
             return std::make_tuple("", syllable);
         }
         if (found_initial) {
+            std::cout << "initial: " << ipa_match[1] << std::endl;
             ipa_initial = mandarinIPAInitials.at(ipa_match[1]);
+            std::cout << "IPA initial: " << ipa_initial << std::endl;
         }
         if (found_final) {
+            std::cout << "final: " << ipa_match[2] << std::endl;
             ipa_final = mandarinIPAFinals.at(ipa_match[2]);
+            std::cout << "IPA final: " << ipa_final << std::endl;
         }
     }
 
@@ -1080,7 +1089,15 @@ std::string convertPinyinToIPA(const std::string &pinyin,
         std::string ipa_final;
         std::string ipa_tone;
 
-        // Filter out special characters
+        // Most numbers, single characters, etc. are not Pinyin.
+        // Filter those out.
+        if (syllable.size() == 1) {
+            ipa_syllables.emplace_back(syllable);
+            continue;
+        }
+
+        // Filter out special characters separately, as those may
+        // sometimes be more than one byte long.
         if (specialCharacters.find(syllable) != specialCharacters.end()) {
             ipa_syllables.emplace_back(syllable);
             continue;
@@ -1158,6 +1175,9 @@ std::string convertPinyinToIPA(const std::string &pinyin,
             } else {
                 ipa_tone = mandarinIPATones[static_cast<unsigned long>(tone) - 1];
             }
+            break;
+        }
+        case -1: {
             break;
         }
         default: {

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -13,11 +13,7 @@
 
 namespace ChineseUtils {
 
-#ifdef _MSC_VER
-static std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
-#else
 static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
-#endif
 
 const static std::unordered_set<std::string> specialCharacters = {
     ".",
@@ -35,16 +31,6 @@ const static std::unordered_set<std::string> specialCharacters = {
     "·",
 };
 
-const static std::unordered_map<std::string, std::vector<std::string>> replacementMap
-    = {
-        {"a", {"ā", "á", "ǎ", "à", "a"}},
-        {"e", {"ē", "é", "ě", "è", "e"}},
-        {"i", {"ī", "í", "ǐ", "ì", "i"}},
-        {"o", {"ō", "ó", "ǒ", "ò", "o"}},
-        {"u", {"ū", "ú", "ǔ", "ù", "u"}},
-        {"ü", {"ǖ", "ǘ", "ǚ", "ǜ", "ü"}},
-};
-
 const static std::unordered_map<std::string, std::string>
     jyutpingToYaleSpecialFinals = {
         {"aa", "a"},
@@ -56,54 +42,54 @@ const static std::unordered_map<std::string, std::string>
         {"eot", "eut"},
 };
 
-const static std::unordered_map<std::string, std::vector<std::string>>
+const static std::unordered_map<std::string, std::vector<std::string> >
     jyutpingToYaleSpecialSyllables = {
         {"m", {"m̄", "ḿ", "m", "m̀h", "ḿh", "mh"}},
         {"ng", {"n̄g", "ńg", "ng", "ǹgh", "ńgh", "ngh"}},
 };
 
-const static std::unordered_map<std::string, std::vector<std::string>>
-    yaleReplacementMap = {{"a", {"ā", "á", "a", "à", "á", "a"}},
-                          {"e", {"ē", "é", "e", "è", "é", "e"}},
-                          {"i", {"ī", "í", "i", "ì", "í", "i"}},
-                          {"o", {"ō", "ó", "o", "ò", "ó", "o"}},
-                          {"u", {"ū", "ú", "u", "ù", "ú", "u"}},
+const static std::unordered_map<std::string, std::vector<std::string> >
+    yaleToneReplacements = {
+        {"a", {"ā", "á", "a", "à", "á", "a"}},
+        {"e", {"ē", "é", "e", "è", "é", "e"}},
+        {"i", {"ī", "í", "i", "ì", "í", "i"}},
+        {"o", {"ō", "ó", "o", "ò", "ó", "o"}},
+        {"u", {"ū", "ú", "u", "ù", "ú", "u"}},
 };
 
 // The original Wiktionary module uses breves to indicate a special letter (e.g.
 // ă), but the base C++ regex engine can't match against chars outside of the
 // basic set. As a workaround, I'm just replacing them with other symbols.
 const static std::vector<std::pair<std::string, std::string> >
-    jyutpingToIPASpecialSyllables = {{"a", "@"},
-                                     {"yu", "y"},
-                                     {"@@", "a"},
-                                     {"uk", "^k"},
-                                     {"ik", "|k"},
-                                     {"ou", "~u"},
-                                     {"eoi", "eoy"},
-                                     {"ung", "^ng"},
-                                     {"ing", "|ng"},
-                                     {"ei", ">i"}};
+    cantoneseIPASpecialSyllables = {{"a", "@"},
+                                    {"yu", "y"},
+                                    {"@@", "a"},
+                                    {"uk", "^k"},
+                                    {"ik", "|k"},
+                                    {"ou", "~u"},
+                                    {"eoi", "eoy"},
+                                    {"ung", "^ng"},
+                                    {"ing", "|ng"},
+                                    {"ei", ">i"}};
 
-const static std::unordered_map<std::string, std::string> jyutpingToIPAInitials
-    = {
-        {"b", "p"},
-        {"p", "pʰ"},
-        {"d", "t"},
-        {"t", "tʰ"},
-        {"g", "k"},
-        {"k", "kʰ"},
-        {"ng", "ŋ"},
-        {"gw", "kʷ"},
-        {"kw", "kʷʰ"},
-        {"zh", "t͡ʃ"},
-        {"ch", "t͡ʃʰ"},
-        {"sh", "ʃ"},
-        {"z", "t͡s"},
-        {"c", "t͡sʰ"},
+const static std::unordered_map<std::string, std::string> cantoneseIPAInitials = {
+    {"b", "p"},
+    {"p", "pʰ"},
+    {"d", "t"},
+    {"t", "tʰ"},
+    {"g", "k"},
+    {"k", "kʰ"},
+    {"ng", "ŋ"},
+    {"gw", "kʷ"},
+    {"kw", "kʷʰ"},
+    {"zh", "t͡ʃ"},
+    {"ch", "t͡ʃʰ"},
+    {"sh", "ʃ"},
+    {"z", "t͡s"},
+    {"c", "t͡sʰ"},
 };
 
-const static std::unordered_map<std::string, std::string> jyutpingToIPANuclei = {
+const static std::unordered_map<std::string, std::string> cantoneseIPANuclei = {
     {"a", "äː"},
     {"@", "ɐ"},
     {"e", "ɛː"},
@@ -119,7 +105,7 @@ const static std::unordered_map<std::string, std::string> jyutpingToIPANuclei = 
     {"y", "yː"},
 };
 
-const static std::unordered_map<std::string, std::string> jyutpingToIPACodas = {
+const static std::unordered_map<std::string, std::string> cantoneseIPACodas = {
     {"i", "i̯"},
     {"u", "u̯"},
     {"y", "y̯"},
@@ -139,7 +125,17 @@ const static std::vector<std::string> jyutpingToIPATones
     = {"˥", "˧˥", "˧", "˨˩", "˩˧", "˨", "˥", "˧", "˨"};
 #endif
 
-const static std::unordered_map<std::string, std::string> zhuyinInitialMap = {
+const static std::unordered_map<std::string, std::vector<std::string> >
+    pinyinToneReplacements = {
+        {"a", {"ā", "á", "ǎ", "à", "a"}},
+        {"e", {"ē", "é", "ě", "è", "e"}},
+        {"i", {"ī", "í", "ǐ", "ì", "i"}},
+        {"o", {"ō", "ó", "ǒ", "ò", "o"}},
+        {"u", {"ū", "ú", "ǔ", "ù", "u"}},
+        {"ü", {"ǖ", "ǘ", "ǚ", "ǜ", "ü"}},
+};
+
+const static std::unordered_map<std::string, std::string> zhuyinInitials = {
     {"b", "ㄅ"},  {"p", "ㄆ"}, {"m", "ㄇ"}, {"f", "ㄈ"},  {"d", "ㄉ"},
     {"t", "ㄊ"},  {"n", "ㄋ"}, {"l", "ㄌ"}, {"g", "ㄍ"},  {"k", "ㄎ"},
     {"h", "ㄏ"},  {"j", "ㄐ"}, {"q", "ㄑ"}, {"x", "ㄒ"},  {"z", "ㄗ"},
@@ -147,7 +143,7 @@ const static std::unordered_map<std::string, std::string> zhuyinInitialMap = {
     {"sh", "ㄕ"},
 };
 
-const static std::unordered_map<std::string, std::string> zhuyinFinalMap
+const static std::unordered_map<std::string, std::string> zhuyinFinals
     = {{"yuan", "ㄩㄢ"}, {"iang", "ㄧㄤ"}, {"yang", "ㄧㄤ"}, {"uang", "ㄨㄤ"},
        {"wang", "ㄨㄤ"}, {"ying", "ㄧㄥ"}, {"weng", "ㄨㄥ"}, {"iong", "ㄩㄥ"},
        {"yong", "ㄩㄥ"}, {"uai", "ㄨㄞ"},  {"wai", "ㄨㄞ"},  {"yai", "ㄧㄞ"},
@@ -167,19 +163,87 @@ const static std::unordered_map<std::string, std::string> zhuyinFinalMap
 
 const static std::vector<std::string> zhuyinTones = {"", "", "ˊ", "ˇ", "ˋ", "˙"};
 
-std::string applyColours(
-    const std::string original,
-    const std::vector<int> &tones,
-    const std::vector<std::string> &jyutpingToneColours,
-    const std::vector<std::string> &pinyinToneColours,
-    const EntryColourPhoneticType type)
+const static std::unordered_set<std::string> mandarinIPAGlottal = {
+    "a", "o", "e", "ai", "ei", "ao", "ou", "an", "en", "er", "ang", "ong", "eng"};
+
+const static std::unordered_map<std::string, std::string> mandarinIPAInitials = {
+    {"b", "p"},  {"c", "t͡sʰ"}, {"ch", "ʈ͡ʂʰ"}, {"d", "t"},  {"f", "f"},
+    {"g", "k"},  {"h", "x"},   {"j", "t͡ɕ"},   {"k", "kʰ"}, {"l", "l"},
+    {"m", "m"},  {"n", "n"},   {"ng", "ŋ"},   {"p", "pʰ"}, {"q", "t͡ɕʰ"},
+    {"r", "ʐ"},  {"s", "s"},   {"sh", "ʂ"},   {"t", "tʰ"}, {"x", "ɕ"},
+    {"z", "t͡s"}, {"zh", "ʈ͡ʂ"},
+};
+
+const static std::unordered_map<std::string, std::string> mandarinIPAFinals = {
+    {"a", "ä"},       {"ai", "aɪ̯"},      {"air", "ɑɻ"},     {"an", "än"},
+    {"ang", "ɑŋ"},    {"angr", "ɑ̃ɻ"},    {"anr", "ɑɻ"},     {"ao", "ɑʊ̯"},
+    {"aor", "aʊ̯ɻʷ"},  {"ar", "ɑɻ"},      {"e", "ɤ"},        {"ei", "eɪ̯"},
+    {"eir", "əɻ"},    {"en", "ən"},      {"eng", "ɤŋ"},     {"engr", "ɤ̃ɻ"},
+    {"enr", "əɻ"},    {"er", "ɤɻ"},      {"i", "i"},        {"ia", "jä"},
+    {"ian", "jɛn"},   {"iang", "jɑŋ"},   {"iangr", "jɑ̃ɻ"},  {"ianr", "jɑɻ"},
+    {"iao", "jɑʊ̯"},   {"iaor", "jaʊ̯ɻʷ"}, {"iar", "jɑɻ"},    {"ie", "jɛ"},
+    {"ier", "jɛɻ"},   {"in", "in"},      {"ing", "iŋ"},     {"ingr", "iɤ̯̃ɻ"},
+    {"inr", "iə̯ɻ"},   {"io", "jɔ"},      {"iong", "jʊŋ"},   {"iongr", "jʊ̃ɻ"},
+    {"ir", "iə̯ɻ"},    {"iu", "joʊ̯"},     {"iur", "jɤʊ̯ɻʷ"},  {"m", "m̩"},
+    {"n", "n̩"},       {"ng", "ŋ̍"},       {"o", "wɔ"},       {"ong", "ʊŋ"},
+    {"ongr", "ʊ̃ɻ"},   {"or", "wɔɻ"},     {"ou", "oʊ̯"},      {"our", "ɤʊ̯ɻʷ"},
+    {"u", "u"},       {"ua", "wä"},      {"uai", "waɪ̯"},    {"uair", "wɑɻ"},
+    {"uan", "wän"},   {"uang", "wɑŋ"},   {"uangr", "wɑ̃ɻ"},  {"uanr", "wɑɻ"},
+    {"uar", "wɑɻ"},   {"ue", "ɥɛ"},      {"ui", "weɪ̯"},     {"uir", "wəɻ"},
+    {"un", "wən"},    {"unr", "wəɻ"},    {"uo", "wɔ"},      {"uor", "wɔɻ"},
+    {"ur", "uɻʷ"},    {"v", "y"},        {"van", "ɥɛn"},    {"vanr", "ɥɑɻ"},
+    {"ve", "ɥɛ"},     {"ver", "ɥɛɻ"},    {"vn", "yn"},      {"vnr", "yə̯ɻ"},
+    {"vr", "yə̯ɻ"},    {"wa", "wä"},      {"wai", "waɪ̯"},    {"wair", "wɑɻ"},
+    {"wan", "wän"},   {"wang", "wɑŋ"},   {"wangr", "wɑ̃ɻ"},  {"wanr", "wɑɻ"},
+    {"war", "wɑɻ"},   {"wei", "weɪ̯"},    {"weir", "wəɻ"},   {"wen", "wən"},
+    {"weng", "wəŋ"},  {"wengr", "ʊ̃ɻ"},   {"wenr", "wəɻ"},   {"wo", "wɔ"},
+    {"wor", "wɔɻ"},   {"wu", "u"},       {"wur", "uɻʷ"},    {"ya", "jä"},
+    {"yai", "jaɪ̯"},   {"yan", "jɛn"},    {"yang", "jɑŋ"},   {"yangr", "jɑ̃ɻ"},
+    {"yanr", "jɑɻ"},  {"yao", "jɑʊ̯"},    {"yaor", "jaʊ̯ɻʷ"}, {"yar", "jɑɻ"},
+    {"ye", "jɛ"},     {"yer", "jɛɻ"},    {"yi", "i"},       {"yin", "in"},
+    {"ying", "iŋ"},   {"yingr", "iɤ̯̃ɻ"},  {"yinr", "iə̯ɻ"},   {"yir", "iə̯ɻ"},
+    {"yo", "jɔ"},     {"yong", "jʊŋ"},   {"yongr", "jʊ̃ɻ"},  {"yor", "jɔɻ"},
+    {"you", "joʊ̯"},   {"your", "jɤʊ̯ɻʷ"}, {"yu", "y"},       {"yuan", "ɥɛn"},
+    {"yuanr", "ɥɑɻ"}, {"yue", "ɥɛ"},     {"yuer", "ɥɛɻ"},   {"yun", "yn"},
+    {"yunr", "yə̯ɻ"},  {"yur", "yə̯ɻ"},
+};
+
+const static std::unordered_map<std::string, std::string>
+    mandarinIPAVoicelessInitials = {
+        {"k", "g̊"},
+        {"p", "b̥"},
+        {"t", "d̥"},
+        {"t͡s", "d͡z̥"},
+        {"t͡ɕ", "d͡ʑ̥"},
+        {"ʈ͡ʂ", "ɖ͡ʐ̥"},
+};
+
+const static std::vector<std::string> mandarinIPANeutralTone = {"˨",
+                                                                "˧",
+                                                                "˦",
+                                                                "˩",
+                                                                "˩"};
+
+const static std::vector<std::string> mandarinIPAThirdTone = {"˨˩˦-˨˩˩",
+                                                              "˨˩˦-˨˩˩",
+                                                              "˨˩˦-˧˥",
+                                                              "˨˩˦-˨˩˩",
+                                                              "˨˩˦"};
+
+const static std::vector<std::string> mandarinIPATones = {"˥˥",
+                                                          "˧˥",
+                                                          "˨˩˦",
+                                                          "˥˩",
+                                                          ""};
+
+std::string applyColours(const std::string original,
+                         const std::vector<int> &tones,
+                         const std::vector<std::string> &jyutpingToneColours,
+                         const std::vector<std::string> &pinyinToneColours,
+                         const EntryColourPhoneticType type)
 {
     std::string coloured_string;
-#ifdef _MSC_VER
-    std::wstring converted_original = converter.from_bytes(original);
-#else
     std::u32string converted_original = converter.from_bytes(original);
-#endif
     size_t pos = 0;
     for (const auto &character : converted_original) {
         std::string originalCharacter = converter.to_bytes(character);
@@ -255,14 +319,9 @@ std::string compareStrings(const std::string &original,
                            const std::string &comparison)
 {
     std::string result;
-
-#ifdef _MSC_VER
-    std::wstring convertedOriginal = converter.from_bytes(original);
-    std::wstring convertedComparison = converter.from_bytes(comparison);
-#else
     std::u32string convertedOriginal = converter.from_bytes(original);
     std::u32string convertedComparison = converter.from_bytes(comparison);
-#endif
+
     if (convertedOriginal.size() != convertedComparison.size()) {
         return result;
     }
@@ -335,9 +394,9 @@ static std::string convertYaleFinal(const std::string &syllable)
     // Replace the first vowel in the final with its accented version
     auto replacement_location = yale_syllable.find_first_of("aeiou");
     std::string first_vowel = yale_syllable.substr(replacement_location, 1);
-    auto replacement_vowel_search = yaleReplacementMap.find(first_vowel);
+    auto replacement_vowel_search = yaleToneReplacements.find(first_vowel);
     std::string replacement_vowel = (replacement_vowel_search
-                                     == yaleReplacementMap.end())
+                                     == yaleToneReplacements.end())
                                         ? first_vowel
                                         : replacement_vowel_search->second.at(
                                             static_cast<size_t>(tone - 1));
@@ -429,7 +488,7 @@ std::string convertJyutpingToYale(const std::string &jyutping,
     return result;
 }
 
-std::string convertIPASyllable(const std::string &syllable)
+std::string convertIPACantoneseSyllable(const std::string &syllable)
 {
     std::string initial;
     std::string nucleus;
@@ -449,9 +508,8 @@ std::string convertIPASyllable(const std::string &syllable)
 
     // Get equivalent to matched initial
     if (match[1].length()) {
-        if (jyutpingToIPAInitials.find(match[1])
-            != jyutpingToIPAInitials.end()) {
-            initial = jyutpingToIPAInitials.at(match[1]);
+        if (cantoneseIPAInitials.find(match[1]) != cantoneseIPAInitials.end()) {
+            initial = cantoneseIPAInitials.at(match[1]);
         } else {
             initial = match[1];
         }
@@ -459,8 +517,8 @@ std::string convertIPASyllable(const std::string &syllable)
 
     // Get equivalent to matched nucleus
     if (match[2].length()) {
-        if (jyutpingToIPANuclei.find(match[2]) != jyutpingToIPANuclei.end()) {
-            nucleus = jyutpingToIPANuclei.at(match[2]);
+        if (cantoneseIPANuclei.find(match[2]) != cantoneseIPANuclei.end()) {
+            nucleus = cantoneseIPANuclei.at(match[2]);
         } else {
             nucleus = match[2];
         }
@@ -468,8 +526,8 @@ std::string convertIPASyllable(const std::string &syllable)
 
     // Get equivalent to matched final
     if (match[3].length()) {
-        if (jyutpingToIPACodas.find(match[3]) != jyutpingToIPACodas.end()) {
-            coda = jyutpingToIPACodas.at(match[3]);
+        if (cantoneseIPACodas.find(match[3]) != cantoneseIPACodas.end()) {
+            coda = cantoneseIPACodas.at(match[3]);
         } else {
             coda = match[3];
         }
@@ -579,13 +637,13 @@ std::string convertJyutpingToIPA(const std::string &jyutping,
         }
 
         // Do some more preprocessing
-        for (const auto &pair : jyutpingToIPASpecialSyllables) {
+        for (const auto &pair : cantoneseIPASpecialSyllables) {
             ipa_syllable = std::regex_replace(ipa_syllable,
                                               std::regex{pair.first},
                                               pair.second);
         }
 
-        ipa_syllables.emplace_back(convertIPASyllable(ipa_syllable));
+        ipa_syllables.emplace_back(convertIPACantoneseSyllable(ipa_syllable));
     }
 
     std::ostringstream ipa;
@@ -596,7 +654,7 @@ std::string convertJyutpingToIPA(const std::string &jyutping,
 
     // Remove trailing space
     std::string result = ipa.str();
-    result.erase(result.end() - double_space.length());
+    result.erase(result.end() - static_cast<long>(double_space.length()));
 
     return result;
 }
@@ -665,9 +723,9 @@ std::string createPrettyPinyin(const std::string &pinyin)
         }
 
         // replacementMap maps a character to its replacements with diacritics.
-        auto search = replacementMap.find(
+        auto search = pinyinToneReplacements.find(
             syllable.substr(location, character_size));
-        if (search != replacementMap.end()) {
+        if (search != pinyinToneReplacements.end()) {
             std::string replacement = search->second.at(
                 static_cast<size_t>(tone) - 1);
             syllable.erase(location, character_size);
@@ -751,11 +809,6 @@ std::string createPinyinWithV(const std::string &pinyin)
     return result;
 }
 
-std::string convertPinyinToZhuyin(const std::string &pinyin)
-{
-    return convertPinyinToZhuyin(pinyin, /* useSpacesToSegment */ false);
-}
-
 // Note that the majority of this code is derivative of Wiktionary's conversion
 // code, contained in the module cmn-pron
 // (https://en.wiktionary.org/wiki/Module:cmn-pron)
@@ -768,17 +821,19 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
 
     std::vector<std::string> syllables;
     if (useSpacesToSegment) {
+        std::string pinyinCopy;
         // Insert a space before and after every special character, so that the
-        // Yale conversion doesn't attempt to convert special characters.
-        std::string pinyinCopy = pinyin;
-        for (const auto &specialCharacter : specialCharacters) {
-            size_t location = pinyinCopy.find(specialCharacter);
-            if (location != std::string::npos) {
-                pinyinCopy.erase(location, specialCharacter.length());
-                pinyinCopy.insert(location, " " + specialCharacter + " ");
+        // Zhuyin conversion doesn't attempt to convert special characters.
+        std::u32string pinyin_utf32 = converter.from_bytes(pinyin);
+        for (const auto &character : pinyin_utf32) {
+            std::string character_utf8 = converter.to_bytes(character);
+            if (specialCharacters.find(character_utf8)
+                != specialCharacters.end()) {
+                pinyinCopy += " " + character_utf8 + " ";
+            } else {
+                pinyinCopy += character_utf8;
             }
         }
-        Utils::split(pinyinCopy, ' ', syllables);
     } else {
         syllables = segmentPinyin(QString{pinyin.c_str()});
     }
@@ -837,7 +892,7 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
             if (initial_match[1].length()) {
                 zhuyin_syllable = std::regex_replace(zhuyin_syllable,
                                                      pinyin_initial,
-                                                     zhuyinInitialMap.at(
+                                                     zhuyinInitials.at(
                                                          initial_match[1]));
             }
         }
@@ -849,7 +904,7 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
             std::string final;
             std::string er;
             if (final_match[1].length()) {
-                final = zhuyinFinalMap.at(final_match[1]);
+                final = zhuyinFinals.at(final_match[1]);
             }
             if (final_match[2].length()) {
                 er = "ㄦ";
@@ -882,6 +937,210 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
     // Remove trailing space
     std::string result = zhuyin.str();
     result.erase(result.end() - 1);
+
+    return result;
+}
+
+std::tuple<std::string, std::string> convertIPAMandarinSyllable(
+    std::string &syllable)
+{
+    std::string ipa_initial;
+    std::string ipa_final;
+
+    // Check for special-case "ng", otherwise get replacement initial and final as normal
+    if (syllable == "ng") {
+        ipa_final = mandarinIPAFinals.at("ng");
+    } else {
+        std::regex initial_final_regex{"^([bcdfghjklmnpqrstxz]?h?)(.+)$"};
+        std::smatch ipa_match;
+
+        auto regex_res = std::regex_match(syllable,
+                                          ipa_match,
+                                          initial_final_regex);
+
+        if (!regex_res) {
+            std::cerr << "Invalid pinyin for IPA conversion!" << std::endl;
+            return std::make_tuple("", syllable);
+        }
+
+        if ((mandarinIPAInitials.find(ipa_match[1]) == mandarinIPAInitials.end())
+            || (mandarinIPAFinals.find(ipa_match[2])
+                == mandarinIPAFinals.end())) {
+            return std::make_tuple("", syllable);
+        }
+        ipa_initial = mandarinIPAInitials.at(ipa_match[1]);
+        ipa_final = mandarinIPAFinals.at(ipa_match[2]);
+    }
+
+    // Replace close front unrounded vowel with syllabic retroflex sibilant
+    // fricative (+ voiced retroflex approximant if erhua)
+    // in Pinyin starting with ch, sh, zh, or r
+    if (ipa_initial == "ʈ͡ʂʰ" || ipa_initial == "ʂ" || ipa_initial == "ʈ͡ʂ"
+        || ipa_initial == "ʐ") {
+        if (ipa_final == "ir") {
+            ipa_final = "ʐ̩ɻ";
+        } else if (ipa_final == "i") {
+            ipa_final = "ʐ̩";
+        }
+    }
+
+    // Replace close front unrounded vowel with syllabic alveolar sibilant
+    // fricative (+ voiced retroflex approximant if erhua)
+    // in Pinyin starting with c, s, or z
+    if (ipa_initial == "t͡sʰ" || ipa_initial == "s" || ipa_initial == "t͡s") {
+        if (ipa_final == "ir") {
+            ipa_final = "z̩ɻ";
+        } else if (ipa_final == "i") {
+            ipa_final = "z̩";
+        }
+    }
+
+    // Do some cleanup for Pinyin like "ri"
+    if (ipa_initial == "ʐ" && ipa_final == "ʐ̩") {
+        ipa_initial = "";
+    }
+
+    return std::make_tuple(ipa_initial, ipa_final);
+}
+
+std::string convertPinyinToIPA(const std::string &pinyin,
+                               bool useSpacesToSegment)
+{
+    if (pinyin.empty()) {
+        return pinyin;
+    }
+
+    std::vector<std::string> syllables;
+    if (useSpacesToSegment) {
+        std::string pinyinCopy;
+        // Insert a space before and after every special character, so that the
+        // IPA conversion doesn't attempt to convert special characters.
+        std::u32string pinyin_utf32 = converter.from_bytes(pinyin);
+        for (const auto &character : pinyin_utf32) {
+            std::string character_utf8 = converter.to_bytes(character);
+            if (specialCharacters.find(character_utf8)
+                != specialCharacters.end()) {
+                pinyinCopy += " " + character_utf8 + " ";
+            } else {
+                pinyinCopy += character_utf8;
+            }
+        }
+        Utils::split(pinyinCopy, ' ', syllables);
+    } else {
+        syllables = segmentPinyin(QString{pinyin.c_str()});
+    }
+
+    std::vector<std::string> ipa_syllables;
+
+    // Pre-compute list of tones corresponding to each syllable
+    // This is used for tone sandhi reasons (3->3 sandhi, x->5 sandhi, etc.)
+    std::vector<std::pair<int, unsigned long> > syllable_tones;
+    for (const auto &syllable : syllables) {
+        auto tone_location = syllable.find_first_of("12345");
+        if (tone_location == std::string::npos) {
+            syllable_tones.push_back({-1, -1});
+        } else {
+            int tone = std::stoi(syllable.substr(tone_location, 1));
+            syllable_tones.push_back({tone, tone_location});
+        }
+    }
+
+    for (size_t i = 0; i < syllables.size(); i++) {
+        const auto &syllable = syllables[i];
+        std::string ipa_glottal;
+        std::string ipa_initial;
+        std::string ipa_final;
+        std::string ipa_tone;
+
+        // Filter out special characters
+        if (specialCharacters.find(syllable) != specialCharacters.end()) {
+            ipa_syllables.emplace_back(syllable);
+            continue;
+        }
+
+        // Get syllable without tone
+        auto tone_location = syllable_tones[i].second;
+        std::string syllable_without_tone = syllable.substr(0, tone_location);
+
+        // Figure out whether this syllable needs a glottal stop
+        if (mandarinIPAGlottal.find(syllable_without_tone)
+            != mandarinIPAGlottal.end()) {
+            ipa_glottal = "ˀ";
+        }
+
+        // Mark close front rounded vowel with v instead of "u" or "u:"
+        syllable_without_tone = std::regex_replace(syllable_without_tone,
+                                                   std::regex{"u\\:"},
+                                                   "v");
+        syllable_without_tone = std::regex_replace(syllable_without_tone,
+                                                   std::regex{"([jqx])u"},
+                                                   "$1v");
+
+        // Convert initial and final
+        std::tie(ipa_initial, ipa_final) = convertIPAMandarinSyllable(
+            syllable_without_tone);
+
+        // Convert tones
+        int tone = syllable_tones[i].first;
+        int next_tone = (i == syllables.size() - 1)
+                            ? -1
+                            : syllable_tones[i + 1].first;
+        int prev_tone = (i == 0) ? -1 : syllable_tones[i - 1].first;
+
+        switch (tone) {
+        case 5: {
+            // When neutral tone, replace some initials with voiceless versions
+            if (mandarinIPAVoicelessInitials.find(ipa_initial)
+                != mandarinIPAVoicelessInitials.end()) {
+                ipa_initial = mandarinIPAVoicelessInitials.at(ipa_initial);
+            }
+            if (ipa_final == "ɤ") {
+                ipa_final = "ə";
+            }
+            ipa_tone = prev_tone == -1
+                           ? ""
+                           : mandarinIPANeutralTone
+                               [static_cast<unsigned long>(prev_tone) - 1];
+            break;
+        }
+        case 3: {
+            if (i == syllables.size() - 1) {
+                ipa_tone = (i == 0) ? "˨˩˦" : "˨˩˦-˨˩(˦)";
+            } else {
+                ipa_tone = next_tone == -1
+                               ? ""
+                               : mandarinIPAThirdTone
+                                   [static_cast<unsigned long>(next_tone) - 1];
+            }
+            break;
+        }
+        case 4: {
+            if (next_tone == 4) {
+                ipa_tone = "˥˩-˥˧";
+            } else {
+                ipa_tone = mandarinIPATones[static_cast<unsigned long>(tone) - 1];
+            }
+            break;
+        }
+        default: {
+            ipa_tone = mandarinIPATones[static_cast<unsigned long>(tone) - 1];
+            break;
+        }
+        }
+
+        ipa_syllables.push_back(ipa_glottal + ipa_initial + ipa_final
+                                + ipa_tone);
+    }
+
+    std::ostringstream ipa;
+    std::string double_space = "  ";
+    for (const auto &ipa_syllable : ipa_syllables) {
+        ipa << ipa_syllable << double_space;
+    }
+
+    // Remove trailing space
+    std::string result = ipa.str();
+    result.erase(result.end() - static_cast<long>(double_space.length()));
 
     return result;
 }

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -1091,7 +1091,7 @@ std::string convertPinyinToIPA(const std::string &pinyin,
 
     // Pre-compute list of tones corresponding to each syllable
     // This is used for tone sandhi reasons (3->3 sandhi, x->5 sandhi, etc.)
-    std::vector<std::pair<int, unsigned long> > syllable_tones;
+    std::vector<std::pair<int, signed long> > syllable_tones;
     for (const auto &syllable : syllables) {
         auto tone_location = syllable.find_first_of("12345");
         if (tone_location == std::string::npos || syllable.size() == 1) {
@@ -1125,7 +1125,12 @@ std::string convertPinyinToIPA(const std::string &pinyin,
 
         // Get syllable without tone
         auto tone_location = syllable_tones[i].second;
-        std::string syllable_without_tone = syllable.substr(0, tone_location);
+        if (tone_location < 0) {
+            ipa_syllables.emplace_back(syllable);
+            continue;
+        }
+        std::string syllable_without_tone
+            = syllable.substr(0, static_cast<unsigned long>(tone_location));
 
         // Figure out whether this syllable needs a glottal stop
         if (mandarinIPAGlottal.find(syllable_without_tone)
@@ -1199,9 +1204,6 @@ std::string convertPinyinToIPA(const std::string &pinyin,
             } else {
                 ipa_tone = mandarinIPATones[static_cast<unsigned long>(tone) - 1];
             }
-            break;
-        }
-        case -1: {
             break;
         }
         default: {

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -222,11 +222,21 @@ const static std::unordered_map<std::string, std::string>
         {"ʈ͡ʂ", "ɖ͡ʐ̥"},
 };
 
+#if defined(Q_OS_WIN)
+// For consistency with other reasonings below, use superscript numbers instead
+// of tone letters on Windows.
+const static std::vector<std::string> mandarinIPANeutralTone = {"²",
+                                                                "³",
+                                                                "⁴",
+                                                                "¹",
+                                                                "¹"};
+#else
 const static std::vector<std::string> mandarinIPANeutralTone = {"˨",
                                                                 "˧",
                                                                 "˦",
                                                                 "˩",
                                                                 "˩"};
+#endif
 
 #if defined(Q_OS_MAC)
 // Added a six-per-em space (U+2006) between adjacent tone markers, because Qt's
@@ -236,6 +246,15 @@ const static std::vector<std::string> mandarinIPAThirdTone = {"˨ ˩ ˦ �
                                                               "˨ ˩ ˦ ꜔ ꜒",
                                                               "˨ ˩ ˦ ꜕ ꜖ ꜖",
                                                               "˨ ˩ ˦"};
+#elif defined(Q_OS_WIN)
+// On Windows, the reverse tone letters are not the same height as the "normal"
+// tone letters. In addition, the Segoe UI font cannot handle three tone-letter
+// ligatures. As such, use superscript numbers instead.
+const static std::vector<std::string> mandarinIPAThirdTone = {"²¹⁴⁻²¹¹",
+                                                              "²¹⁴⁻²¹¹",
+                                                              "²¹⁴⁻³⁵",
+                                                              "²¹⁴⁻²¹¹",
+                                                              "²¹⁴"};
 #else
 const static std::vector<std::string> mandarinIPAThirdTone = {"˨˩˦꜕꜖꜖",
                                                               "˨˩˦꜕꜖꜖",
@@ -251,6 +270,14 @@ const static std::vector<std::string> mandarinIPATones = {"˥ ˥",
                                                           "˧ ˥",
                                                           "˨ ˩ ˦",
                                                           "˥ ˩",
+                                                          ""};
+#elif defined(Q_OS_WIN)
+// The Segoe UI font cannot handle three tone-letter ligatures. As such, use
+// superscript numbers instead.
+const static std::vector<std::string> mandarinIPATones = {"⁵⁵",
+                                                          "³⁵",
+                                                          "²¹⁴",
+                                                          "⁵¹",
                                                           ""};
 #else
 const static std::vector<std::string> mandarinIPATones = {"˥˥",
@@ -987,25 +1014,18 @@ std::tuple<std::string, std::string> convertIPAMandarinSyllable(
             return std::make_tuple("", syllable);
         }
 
-        std::cout << "syllable: " << syllable << std::endl;
         bool found_initial = !(mandarinIPAInitials.find(ipa_match[1])
                                == mandarinIPAInitials.end());
         bool found_final = !(mandarinIPAFinals.find(ipa_match[2])
                              == mandarinIPAFinals.end());
         if (!found_initial && !found_final) {
-            std::cout << "returning, no initial and no final found"
-                      << std::endl;
             return std::make_tuple("", syllable);
         }
         if (found_initial) {
-            std::cout << "initial: " << ipa_match[1] << std::endl;
             ipa_initial = mandarinIPAInitials.at(ipa_match[1]);
-            std::cout << "IPA initial: " << ipa_initial << std::endl;
         }
         if (found_final) {
-            std::cout << "final: " << ipa_match[2] << std::endl;
             ipa_final = mandarinIPAFinals.at(ipa_match[2]);
-            std::cout << "IPA final: " << ipa_final << std::endl;
         }
     }
 
@@ -1152,6 +1172,8 @@ std::string convertPinyinToIPA(const std::string &pinyin,
             if (i == syllables.size() - 1) {
 #if defined(Q_OS_MAC)
                 ipa_tone = (i == 0) ? "˨ ˩ ˦" : "˨ ˩ ˦ ꜕ ꜖ ( ꜓ )";
+#elif defined(Q_OS_WIN)
+                ipa_tone = (i == 0) ? "²¹⁴" : "²¹⁴⁻²¹⁽⁴⁾";
 #else
                 ipa_tone = (i == 0) ? "˨˩˦" : "˨˩˦꜕꜖(꜓)";
 #endif
@@ -1169,6 +1191,8 @@ std::string convertPinyinToIPA(const std::string &pinyin,
             if (next_tone == 4) {
 #if defined(Q_OS_MAC)
                 ipa_tone = "˥ ˩ ꜒ ꜔";
+#elif defined(Q_OS_WIN)
+                ipa_tone = "⁵¹⁻⁵³";
 #else
                 ipa_tone = "˥˩꜒꜔";
 #endif

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -494,6 +494,13 @@ std::string convertJyutpingToYale(const std::string &jyutping,
     std::vector<std::string> yale_syllables;
 
     for (const auto &syllable : syllables) {
+        // Most numbers, single characters, etc. are not Jyutping.
+        // Filter those out.
+        if (syllable.size() == 1) {
+            yale_syllables.emplace_back(syllable);
+            continue;
+        }
+
         // Skip syllables that are just punctuation
         if (specialCharacters.find(syllable) != specialCharacters.end()) {
             yale_syllables.push_back(syllable);
@@ -631,6 +638,13 @@ std::string convertJyutpingToIPA(const std::string &jyutping,
     std::vector<std::string> ipa_syllables;
 
     for (const auto &syllable : syllables) {
+        // Most numbers, single characters, etc. are not Jyutping.
+        // Filter those out.
+        if (syllable.size() == 1) {
+            ipa_syllables.emplace_back(syllable);
+            continue;
+        }
+
         // Skip syllables that are just punctuation
         if (specialCharacters.find(syllable) != specialCharacters.end()) {
             ipa_syllables.push_back(syllable);
@@ -892,6 +906,13 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
     std::vector<std::string> zhuyin_syllables;
 
     for (const auto &syllable : syllables) {
+        // Most numbers, single characters, etc. are not Pinyin.
+        // Filter those out.
+        if (syllable.size() == 1) {
+            zhuyin_syllables.emplace_back(syllable);
+            continue;
+        }
+
         // Skip syllables that are just punctuation
         if (specialCharacters.find(syllable) != specialCharacters.end()) {
             zhuyin_syllables.push_back(syllable);

--- a/src/jyut-dict/logic/utils/chineseutils.h
+++ b/src/jyut-dict/logic/utils/chineseutils.h
@@ -1,7 +1,6 @@
 #ifndef CHINESEUTILS_H
 #define CHINESEUTILS_H
 
-#include "logic/entry/entrycharactersoptions.h"
 #include "logic/entry/entryphoneticoptions.h"
 
 #include <QString>
@@ -55,9 +54,10 @@ std::string createPrettyPinyin(const std::string &pinyin);
 std::string createNumberedPinyin(const std::string &pinyin);
 std::string createPinyinWithV(const std::string &pinyin);
 
-std::string convertPinyinToZhuyin(const std::string &pinyin);
 std::string convertPinyinToZhuyin(const std::string &pinyin,
-                                  bool useSpacesToSegment);
+                                  bool useSpacesToSegment = false);
+std::string convertPinyinToIPA(const std::string &pinyin,
+                               bool useSpacesToSegment = false);
 
 // constructRomanisationQuery takes a vector of strings and stitches them
 // together with a delimiter.

--- a/src/jyut-dict/main.cpp
+++ b/src/jyut-dict/main.cpp
@@ -60,8 +60,6 @@ int main(int argc, char *argv[])
     QApplication a{argc, argv};
 #endif
 
-    std::cout << __cplusplus << std::endl;
-
     MainWindow w;
     w.show();
 

--- a/src/jyut-dict/main.cpp
+++ b/src/jyut-dict/main.cpp
@@ -60,6 +60,8 @@ int main(int argc, char *argv[])
     QApplication a{argc, argv};
 #endif
 
+    std::cout << __cplusplus << std::endl;
+
     MainWindow w;
     w.show();
 


### PR DESCRIPTION
# Description

This PR adds conversion from Pinyin to Sinological IPA, as well as the hooks in settings and elsewhere to display them throughout the application.

![Screenshot from 2022-12-28 03 17 46@2x](https://user-images.githubusercontent.com/14353716/209781926-2ef7f78e-d299-4359-950f-1b9c7fc1a533.png)

This is the fifth PR in the #33 series.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have built the application on Windows 10, elementary OS 5.1 Hera, and macOS 12.3.1. Monterey. IPA displays as expected when the setting is chosen.

Note that on Windows, the IPA is displayed using superscript digits; on Linux, only "normal" tone letters are ligatured together (reverse tone letters are not), and on macOS, no tone letters are ligatured.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python code, none currently for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
