### PR TITLE
#62: Add ability to search for exact phrase

### DIFF
--- a/src/jyut-dict/logic/search/sqlsearch.cpp
+++ b/src/jyut-dict/logic/search/sqlsearch.cpp
@@ -197,10 +197,11 @@ void SQLSearch::runThread(void (SQLSearch::*threadFunction)(const QString &searc
 void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
                                        const unsigned long long queryID)
 {
-    bool searchExactMatch = (searchTerm.at(0) == "\""
-                             && searchTerm.at(searchTerm.size() - 1) == "\"")
-                            || (searchTerm.startsWith("”")
-                                && searchTerm.endsWith("“"));
+    bool searchExactMatch = ((searchTerm.at(0) == "\""
+                              && searchTerm.at(searchTerm.size() - 1) == "\"")
+                             || (searchTerm.startsWith("”")
+                                 && searchTerm.endsWith("“")))
+                            && searchTerm.length() >= 3;
     QString searchTermWithoutQuotes;
     if (searchExactMatch) {
         // When the search term is surrounded by quotes, search for exact match
@@ -220,8 +221,7 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         //// Get the list of all definitions for those entries
         //// This CTE is used multiple times; would be nice if could materialize it
         "matching_definition_ids AS ( "
-        "  SELECT definition_id, definition FROM definitions WHERE "
-        "fk_entry_id "
+        "  SELECT definition_id, definition FROM definitions WHERE fk_entry_id "
         "    IN matching_entry_ids "
         "), "
         " "
@@ -231,7 +231,7 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         "  SELECT definition_id, fk_chinese_sentence_id "
         "  FROM matching_definition_ids AS mdi "
         "  JOIN definitions_chinese_sentences_links AS dcsl ON "
-        "mdi.definition_id = dcsl.fk_definition_id "
+        "    mdi.definition_id = dcsl.fk_definition_id "
         "), "
         " "
         //// Get translations for each of the sentences
@@ -244,9 +244,9 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         "    )) AS translation "
         "  FROM matching_chinese_sentence_ids AS mcsi "
         "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = "
-        "sl.fk_chinese_sentence_id "
+        "    sl.fk_chinese_sentence_id "
         "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id "
-        "= sl.fk_non_chinese_sentence_id "
+        "    = sl.fk_non_chinese_sentence_id "
         "  GROUP BY mcsi.fk_chinese_sentence_id "
         "), "
         " "
@@ -257,7 +257,7 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         " FROM chinese_sentences AS cs "
         " WHERE chinese_sentence_id IN ( "
         "   SELECT fk_chinese_sentence_id FROM "
-        "matching_chinese_sentence_ids "
+        "     matching_chinese_sentence_ids "
         " ) "
         "),"
         " "
@@ -272,7 +272,7 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         "                'translations', json(translation)) AS sentence "
         "  FROM matching_sentences AS ms "
         "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id "
-        "= mt.fk_chinese_sentence_id "
+        "    = mt.fk_chinese_sentence_id "
         "), "
         " "
         //// Get definition data for each matching definition
@@ -293,9 +293,9 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         "                json_group_array(json(sentence))) AS definition "
         "  FROM matching_definitions AS md "
         "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON "
-        "md.definition_id = mcsi.definition_id "
+        "    md.definition_id = mcsi.definition_id "
         "  LEFT JOIN matching_sentences_with_translations AS mswt ON "
-        "mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
+        "    mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
         "  GROUP BY md.definition_id "
         "), "
         " "
@@ -304,8 +304,7 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         "  SELECT fk_entry_id, "
         "    json_object('source', sourcename, "
         "                'definitions', "
-        "                json_group_array(json(definition))) AS "
-        "definitions "
+        "                json_group_array(json(definition))) AS definitions "
         "  FROM matching_definitions_with_sentences AS mdws "
         "  LEFT JOIN sources ON sources.source_id = mdws.fk_source_id "
         "  GROUP BY fk_entry_id, fk_source_id "
@@ -314,7 +313,7 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         //// Construct the final entry object
         "matching_entries AS ( "
         "  SELECT simplified, traditional, jyutping, pinyin, "
-        "json_group_array(json(definitions)) AS definitions "
+        "    json_group_array(json(definitions)) AS definitions "
         "  FROM matching_definition_groups AS mdg "
         "  LEFT JOIN entries ON entries.entry_id = mdg.fk_entry_id "
         "  GROUP BY entry_id "
@@ -345,10 +344,11 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
 void SQLSearch::searchTraditionalThread(const QString &searchTerm,
                                         const unsigned long long queryID)
 {
-    bool searchExactMatch = (searchTerm.at(0) == "\""
-                             && searchTerm.at(searchTerm.size() - 1) == "\"")
-                            || (searchTerm.startsWith("“")
-                                && searchTerm.endsWith("”"));
+    bool searchExactMatch = ((searchTerm.at(0) == "\""
+                              && searchTerm.at(searchTerm.size() - 1) == "\"")
+                             || (searchTerm.startsWith("“")
+                                 && searchTerm.endsWith("”")))
+                            && searchTerm.length() >= 3;
     QString searchTermWithoutQuotes;
     if (searchExactMatch) {
         // When the search term is surrounded by quotes, search for exact match
@@ -368,8 +368,7 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         //// Get the list of all definitions for those entries
         //// This CTE is used multiple times; would be nice if could materialize it
         "matching_definition_ids AS ( "
-        "  SELECT definition_id, definition FROM definitions WHERE "
-        "fk_entry_id "
+        "  SELECT definition_id, definition FROM definitions WHERE fk_entry_id "
         "    IN matching_entry_ids "
         "), "
         " "
@@ -379,7 +378,7 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         "  SELECT definition_id, fk_chinese_sentence_id "
         "  FROM matching_definition_ids AS mdi "
         "  JOIN definitions_chinese_sentences_links AS dcsl ON "
-        "mdi.definition_id = dcsl.fk_definition_id "
+        "    mdi.definition_id = dcsl.fk_definition_id "
         "), "
         " "
         //// Get translations for each of the sentences
@@ -392,9 +391,9 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         "    )) AS translation "
         "  FROM matching_chinese_sentence_ids AS mcsi "
         "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = "
-        "sl.fk_chinese_sentence_id "
+        "    sl.fk_chinese_sentence_id "
         "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id "
-        "= sl.fk_non_chinese_sentence_id "
+        "    = sl.fk_non_chinese_sentence_id "
         "  GROUP BY mcsi.fk_chinese_sentence_id "
         "), "
         " "
@@ -405,7 +404,7 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         " FROM chinese_sentences AS cs "
         " WHERE chinese_sentence_id IN ( "
         "   SELECT fk_chinese_sentence_id FROM "
-        "matching_chinese_sentence_ids "
+        "     matching_chinese_sentence_ids "
         " ) "
         "),"
         " "
@@ -420,7 +419,7 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         "                'translations', json(translation)) AS sentence "
         "  FROM matching_sentences AS ms "
         "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id "
-        "= mt.fk_chinese_sentence_id "
+        "    = mt.fk_chinese_sentence_id "
         "), "
         " "
         //// Get definition data for each matching definition
@@ -441,9 +440,9 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         "                json_group_array(json(sentence))) AS definition "
         "  FROM matching_definitions AS md "
         "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON "
-        "md.definition_id = mcsi.definition_id "
+        "    md.definition_id = mcsi.definition_id "
         "  LEFT JOIN matching_sentences_with_translations AS mswt ON "
-        "mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
+        "    mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
         "  GROUP BY md.definition_id "
         "), "
         " "
@@ -452,8 +451,7 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         "  SELECT fk_entry_id, "
         "    json_object('source', sourcename, "
         "                'definitions', "
-        "                json_group_array(json(definition))) AS "
-        "definitions "
+        "                json_group_array(json(definition))) AS definitions "
         "  FROM matching_definitions_with_sentences AS mdws "
         "  LEFT JOIN sources ON sources.source_id = mdws.fk_source_id "
         "  GROUP BY fk_entry_id, fk_source_id "
@@ -462,7 +460,7 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         //// Construct the final entry object
         "matching_entries AS ( "
         "  SELECT simplified, traditional, jyutping, pinyin, "
-        "json_group_array(json(definitions)) AS definitions "
+        "    json_group_array(json(definitions)) AS definitions "
         "  FROM matching_definition_groups AS mdg "
         "  LEFT JOIN entries ON entries.entry_id = mdg.fk_entry_id "
         "  GROUP BY entry_id "
@@ -523,7 +521,7 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         //// Get list of entry ids whose jyutping starts with the queried string
         "WITH matching_entry_ids AS ( "
         "  SELECT rowid FROM entries_fts WHERE entries_fts MATCH ? AND "
-        "jyutping LIKE ?"
+        "    jyutping LIKE ?"
         "), "
         " "
         //// Get the list of all definitions for those entries
@@ -539,7 +537,7 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         "  SELECT definition_id, fk_chinese_sentence_id "
         "  FROM matching_definition_ids AS mdi "
         "  JOIN definitions_chinese_sentences_links AS dcsl ON "
-        "mdi.definition_id = dcsl.fk_definition_id "
+        "    mdi.definition_id = dcsl.fk_definition_id "
         "), "
         " "
         //// Get translations for each of the sentences
@@ -552,9 +550,9 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         "    )) AS translation "
         "  FROM matching_chinese_sentence_ids AS mcsi "
         "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = "
-        "sl.fk_chinese_sentence_id "
+        "    sl.fk_chinese_sentence_id "
         "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = "
-        "sl.fk_non_chinese_sentence_id "
+        "    sl.fk_non_chinese_sentence_id "
         "  GROUP BY mcsi.fk_chinese_sentence_id "
         "), "
         " "
@@ -579,7 +577,7 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         "                'translations', json(translation)) AS sentence "
         "  FROM matching_sentences AS ms "
         "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = "
-        "mt.fk_chinese_sentence_id "
+        "    mt.fk_chinese_sentence_id "
         "), "
         " "
         //// Get definition data for each matching definition
@@ -600,9 +598,9 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         "                json_group_array(json(sentence))) AS definition "
         "  FROM matching_definitions AS md "
         "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON md.definition_id "
-        "= mcsi.definition_id "
+        "    = mcsi.definition_id "
         "  LEFT JOIN matching_sentences_with_translations AS mswt ON "
-        "mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
+        "    mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
         "  GROUP BY md.definition_id "
         "), "
         " "
@@ -620,7 +618,7 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         //// Construct the final entry object
         "matching_entries AS ( "
         "  SELECT simplified, traditional, jyutping, pinyin, "
-        "json_group_array(json(definitions)) AS definitions "
+        "    json_group_array(json(definitions)) AS definitions "
         "  FROM matching_definition_groups AS mdg "
         "  LEFT JOIN entries ON entries.entry_id = mdg.fk_entry_id "
         "  GROUP BY entry_id "
@@ -818,6 +816,16 @@ void SQLSearch::searchPinyinThread(const QString &searchTerm,
 void SQLSearch::searchEnglishThread(const QString &searchTerm,
                                     const unsigned long long queryID)
 {
+    bool searchExactMatch = searchTerm.at(0) == "\""
+                            && searchTerm.at(searchTerm.size() - 1) == "\""
+                            && searchTerm.length() >= 3;
+    QString searchTermWithoutQuotes;
+    if (searchExactMatch) {
+        // When the search term is surrounded by quotes, do not process any
+        // further than checking for spaces
+        searchTermWithoutQuotes = searchTerm.mid(1, searchTerm.size() - 2);
+    }
+
     std::vector<Entry> results;
 
     QSqlQuery query{_manager->getDatabase()};
@@ -825,7 +833,7 @@ void SQLSearch::searchEnglishThread(const QString &searchTerm,
         //// Get list of entry ids where at least one definition matches the query
         "WITH matching_entry_ids AS ( "
         "  SELECT fk_entry_id FROM definitions_fts WHERE definitions_fts MATCH "
-        "  ? "
+        "  ? AND definition LIKE ? "
         "), "
         " "
         //// Get the list of all definitions for those entries
@@ -840,7 +848,8 @@ void SQLSearch::searchEnglishThread(const QString &searchTerm,
         "matching_chinese_sentence_ids AS ( "
         "  SELECT definition_id, fk_chinese_sentence_id "
         "  FROM matching_definition_ids AS mdi "
-        "  JOIN definitions_chinese_sentences_links AS dcsl ON mdi.definition_id = dcsl.fk_definition_id "
+        "  JOIN definitions_chinese_sentences_links AS dcsl ON "
+        "    mdi.definition_id = dcsl.fk_definition_id "
         "), "
         " "
         //// Get translations for each of the sentences
@@ -852,8 +861,10 @@ void SQLSearch::searchEnglishThread(const QString &searchTerm,
         "                  'direct', direct "
         "    )) AS translation "
         "  FROM matching_chinese_sentence_ids AS mcsi "
-        "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = sl.fk_chinese_sentence_id "
-        "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = sl.fk_non_chinese_sentence_id "
+        "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = "
+        "	 sl.fk_chinese_sentence_id "
+        "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = "
+        "    sl.fk_non_chinese_sentence_id "
         "  GROUP BY mcsi.fk_chinese_sentence_id "
         "), "
         " "
@@ -877,7 +888,8 @@ void SQLSearch::searchEnglishThread(const QString &searchTerm,
         "                'language', language, "
         "                'translations', json(translation)) AS sentence "
         "  FROM matching_sentences AS ms "
-        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = mt.fk_chinese_sentence_id "
+        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = "
+        "    mt.fk_chinese_sentence_id "
         "), "
         " "
         //// Get definition data for each matching definition
@@ -897,8 +909,10 @@ void SQLSearch::searchEnglishThread(const QString &searchTerm,
         "                'label', label, 'sentences', "
         "                json_group_array(json(sentence))) AS definition "
         "  FROM matching_definitions AS md "
-        "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON md.definition_id = mcsi.definition_id "
-        "  LEFT JOIN matching_sentences_with_translations AS mswt ON mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
+        "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON md.definition_id "
+        "    = mcsi.definition_id "
+        "  LEFT JOIN matching_sentences_with_translations AS mswt ON "
+        "    mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
         "  GROUP BY md.definition_id "
         "), "
         " "
@@ -915,24 +929,35 @@ void SQLSearch::searchEnglishThread(const QString &searchTerm,
         " "
         //// Construct the final entry object
         "matching_entries AS ( "
-        "  SELECT simplified, traditional, jyutping, pinyin, json_group_array(json(definitions)) AS definitions "
+        "  SELECT simplified, traditional, jyutping, pinyin, "
+        "    json_group_array(json(definitions)) AS definitions "
         "  FROM matching_definition_groups AS mdg "
         "  LEFT JOIN entries ON entries.entry_id = mdg.fk_entry_id "
         "  GROUP BY entry_id "
         "  ORDER BY frequency DESC "
         ") "
         " "
-        "SELECT simplified, traditional, jyutping, pinyin, definitions from matching_entries"
-    );
-    query.addBindValue("\"" + searchTerm + "\"");
+        "SELECT simplified, traditional, jyutping, pinyin, definitions from "
+        "matching_entries");
+    if (searchExactMatch) {
+        query.addBindValue("\"" + searchTermWithoutQuotes + "\"");
+        query.addBindValue(searchTermWithoutQuotes);
+    } else {
+        query.addBindValue("\"" + searchTerm + "\"");
+        query.addBindValue("%" + searchTerm + "%");
+    }
     query.setForwardOnly(true);
     query.exec();
 
     // Do not parse results if new query has been made
-    if (!checkQueryIDCurrent(queryID)) { return; }
+    if (!checkQueryIDCurrent(queryID)) {
+        return;
+    }
     results = QueryParseUtils::parseEntries(query);
 
-    if (!checkQueryIDCurrent(queryID)) { return; }
+    if (!checkQueryIDCurrent(queryID)) {
+        return;
+    }
     notifyObserversIfQueryIdCurrent(results, /*emptyQuery=*/false, queryID);
 }
 

--- a/src/jyut-dict/logic/search/sqlsearch.cpp
+++ b/src/jyut-dict/logic/search/sqlsearch.cpp
@@ -674,17 +674,19 @@ void SQLSearch::searchPinyinThread(const QString &searchTerm,
         location = processedSearchTerm.indexOf("ü", location);
     }
 
-    bool searchExactMatch = searchTerm.at(0) == "\""
-                            && searchTerm.at(searchTerm.size() - 1) == "\""
-                            && searchTerm.length() >= 3;
+    bool searchExactMatch = processedSearchTerm.at(0) == "\""
+                            && processedSearchTerm.at(processedSearchTerm.size()
+                                                      - 1)
+                                   == "\""
+                            && processedSearchTerm.length() >= 3;
 
     std::vector<std::string> pinyinWords;
     if (searchExactMatch) {
-        QString searchTermWithoutQuotes = searchTerm.mid(1,
-                                                         searchTerm.size() - 2);
+        QString searchTermWithoutQuotes
+            = processedSearchTerm.mid(1, processedSearchTerm.size() - 2);
         Utils::split(searchTermWithoutQuotes.toStdString(), ' ', pinyinWords);
     } else {
-        pinyinWords = ChineseUtils::segmentPinyin(searchTerm);
+        pinyinWords = ChineseUtils::segmentPinyin(processedSearchTerm);
     }
 
     std::vector<Entry> results;

--- a/src/jyut-dict/logic/search/sqlsearch.cpp
+++ b/src/jyut-dict/logic/search/sqlsearch.cpp
@@ -222,7 +222,7 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         //// This CTE is used multiple times; would be nice if could materialize it
         "matching_definition_ids AS ( "
         "  SELECT definition_id, definition FROM definitions WHERE fk_entry_id "
-        "    IN matching_entry_ids "
+        "  IN matching_entry_ids "
         "), "
         " "
         //// Get corresponding sentence ids for each of those definitions
@@ -245,8 +245,8 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         "  FROM matching_chinese_sentence_ids AS mcsi "
         "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = "
         "    sl.fk_chinese_sentence_id "
-        "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id "
-        "    = sl.fk_non_chinese_sentence_id "
+        "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = "
+        "    sl.fk_non_chinese_sentence_id "
         "  GROUP BY mcsi.fk_chinese_sentence_id "
         "), "
         " "
@@ -271,8 +271,8 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         "                'language', language, "
         "                'translations', json(translation)) AS sentence "
         "  FROM matching_sentences AS ms "
-        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id "
-        "    = mt.fk_chinese_sentence_id "
+        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = "
+        "    mt.fk_chinese_sentence_id "
         "), "
         " "
         //// Get definition data for each matching definition
@@ -320,8 +320,8 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         "  ORDER BY frequency DESC "
         ") "
         " "
-        "SELECT simplified, traditional, jyutping, pinyin, definitions "
-        "from matching_entries");
+        "SELECT simplified, traditional, jyutping, pinyin, definitions FROM "
+        "  matching_entries");
     if (searchExactMatch) {
         query.addBindValue(searchTermWithoutQuotes);
     } else {
@@ -369,7 +369,7 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         //// This CTE is used multiple times; would be nice if could materialize it
         "matching_definition_ids AS ( "
         "  SELECT definition_id, definition FROM definitions WHERE fk_entry_id "
-        "    IN matching_entry_ids "
+        "  IN matching_entry_ids "
         "), "
         " "
         //// Get corresponding sentence ids for each of those definitions
@@ -392,8 +392,8 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         "  FROM matching_chinese_sentence_ids AS mcsi "
         "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = "
         "    sl.fk_chinese_sentence_id "
-        "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id "
-        "    = sl.fk_non_chinese_sentence_id "
+        "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = "
+        "    sl.fk_non_chinese_sentence_id "
         "  GROUP BY mcsi.fk_chinese_sentence_id "
         "), "
         " "
@@ -418,8 +418,8 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         "                'language', language, "
         "                'translations', json(translation)) AS sentence "
         "  FROM matching_sentences AS ms "
-        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id "
-        "    = mt.fk_chinese_sentence_id "
+        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = "
+        "    mt.fk_chinese_sentence_id "
         "), "
         " "
         //// Get definition data for each matching definition
@@ -467,8 +467,8 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         "  ORDER BY frequency DESC "
         ") "
         " "
-        "SELECT simplified, traditional, jyutping, pinyin, definitions "
-        "from matching_entries");
+        "SELECT simplified, traditional, jyutping, pinyin, definitions FROM "
+        "  matching_entries");
     if (searchExactMatch) {
         query.addBindValue(searchTermWithoutQuotes);
     } else {
@@ -522,6 +522,178 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         "WITH matching_entry_ids AS ( "
         "  SELECT rowid FROM entries_fts WHERE entries_fts MATCH ? AND "
         "    jyutping LIKE ?"
+        "), "
+        " "
+        //// Get the list of all definitions for those entries
+        //// This CTE is used multiple times; would be nice if could materialize it
+        "matching_definition_ids AS ( "
+        "  SELECT definition_id, definition FROM definitions WHERE fk_entry_id "
+        "  IN matching_entry_ids "
+        "), "
+        " "
+        //// Get corresponding sentence ids for each of those definitions
+        //// This CTE is used multiple times; would be nice if could materialize it
+        "matching_chinese_sentence_ids AS ( "
+        "  SELECT definition_id, fk_chinese_sentence_id "
+        "  FROM matching_definition_ids AS mdi "
+        "  JOIN definitions_chinese_sentences_links AS dcsl ON "
+        "    mdi.definition_id = dcsl.fk_definition_id "
+        "), "
+        " "
+        //// Get translations for each of the sentences
+        "matching_translations AS ( "
+        "  SELECT mcsi.fk_chinese_sentence_id, "
+        "    json_group_array(DISTINCT "
+        "      json_object('sentence', sentence, "
+        "                  'language', language, "
+        "                  'direct', direct "
+        "    )) AS translation "
+        "  FROM matching_chinese_sentence_ids AS mcsi "
+        "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = "
+        "    sl.fk_chinese_sentence_id "
+        "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = "
+        "    sl.fk_non_chinese_sentence_id "
+        "  GROUP BY mcsi.fk_chinese_sentence_id "
+        "), "
+        " "
+        //// Get sentence data for each of the sentence ids
+        "matching_sentences AS ( "
+        " SELECT chinese_sentence_id, traditional, simplified, pinyin, "
+        "   jyutping, language "
+        " FROM chinese_sentences AS cs "
+        " WHERE chinese_sentence_id IN ( "
+        "   SELECT fk_chinese_sentence_id FROM "
+        "     matching_chinese_sentence_ids "
+        " ) "
+        "),"
+        " "
+        //// Get translations for each of those sentences
+        "matching_sentences_with_translations AS ( "
+        "  SELECT chinese_sentence_id, "
+        "    json_object('traditional', traditional, "
+        "                'simplified', simplified, "
+        "                'pinyin', pinyin, "
+        "                'jyutping', jyutping, "
+        "                'language', language, "
+        "                'translations', json(translation)) AS sentence "
+        "  FROM matching_sentences AS ms "
+        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = "
+        "    mt.fk_chinese_sentence_id "
+        "), "
+        " "
+        //// Get definition data for each matching definition
+        "matching_definitions AS ( "
+        "  SELECT definition_id, fk_entry_id, fk_source_id, definition, "
+        "    label "
+        "  FROM definitions "
+        "  WHERE definitions.definition_id IN ( "
+        "    SELECT definition_id FROM matching_definition_ids"
+        "  ) "
+        "), "
+        " "
+        //// Create definition object with sentences for each definition
+        "matching_definitions_with_sentences AS ( "
+        "  SELECT fk_entry_id, fk_source_id, "
+        "    json_object('definition', definition, "
+        "                'label', label, 'sentences', "
+        "                json_group_array(json(sentence))) AS definition "
+        "  FROM matching_definitions AS md "
+        "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON "
+        "    md.definition_id = mcsi.definition_id "
+        "  LEFT JOIN matching_sentences_with_translations AS mswt ON "
+        "    mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
+        "  GROUP BY md.definition_id "
+        "), "
+        " "
+        //// Create definition groups for definitions of the same entry that come from the same source
+        "matching_definition_groups AS ( "
+        "  SELECT fk_entry_id, "
+        "    json_object('source', sourcename, "
+        "                'definitions', "
+        "                json_group_array(json(definition))) AS definitions "
+        "  FROM matching_definitions_with_sentences AS mdws "
+        "  LEFT JOIN sources ON sources.source_id = mdws.fk_source_id "
+        "  GROUP BY fk_entry_id, fk_source_id "
+        "), "
+        " "
+        //// Construct the final entry object
+        "matching_entries AS ( "
+        "  SELECT simplified, traditional, jyutping, pinyin, "
+        "    json_group_array(json(definitions)) AS definitions "
+        "  FROM matching_definition_groups AS mdg "
+        "  LEFT JOIN entries ON entries.entry_id = mdg.fk_entry_id "
+        "  GROUP BY entry_id "
+        "  ORDER BY frequency DESC "
+        ") "
+        " "
+        "SELECT simplified, traditional, jyutping, pinyin, definitions FROM "
+        "  matching_entries");
+
+    const char *matchJoinDelimiter = searchExactMatch ? "" : "*";
+    std::string matchTerm
+        = ChineseUtils::constructRomanisationQuery(jyutpingWords,
+                                                   matchJoinDelimiter,
+                                                   /*surroundWithQuotes=*/true);
+    const char *likeJoinDelimiter = searchExactMatch ? "" : "_";
+    std::string likeTerm
+        = ChineseUtils::constructRomanisationQuery(jyutpingWords,
+                                                   likeJoinDelimiter);
+
+    query.addBindValue("jyutping:" + QString{matchTerm.c_str()});
+    query.addBindValue(QString{likeTerm.c_str()}
+                       + QString{searchExactMatch ? "" : "%"});
+    query.exec();
+
+    // Do not parse results if new query has been made
+    if (!checkQueryIDCurrent(queryID)) { return; }
+    results = QueryParseUtils::parseEntries(query);
+
+    if (!checkQueryIDCurrent(queryID)) { return; }
+    notifyObserversIfQueryIdCurrent(results, /*emptyQuery=*/false, queryID);
+}
+
+void SQLSearch::searchPinyinThread(const QString &searchTerm,
+                                   const unsigned long long queryID)
+{
+    // Replace "v" and "ü" with "u:" since "ü" is stored as "u:" in the table
+    QString processedSearchTerm = searchTerm;
+    int location = processedSearchTerm.indexOf("v");
+    while (location != -1) {
+        processedSearchTerm.remove(location, 1);
+        processedSearchTerm.insert(location, "u:");
+        location = processedSearchTerm.indexOf("v", location);
+    }
+
+    location = processedSearchTerm.indexOf("ü");
+    while (location != -1) {
+        processedSearchTerm.remove(location, 1);
+        processedSearchTerm.insert(location, "u:");
+        location = processedSearchTerm.indexOf("ü", location);
+    }
+
+    bool searchExactMatch = searchTerm.at(0) == "\""
+                            && searchTerm.at(searchTerm.size() - 1) == "\""
+                            && searchTerm.length() >= 3;
+
+    std::vector<std::string> pinyinWords;
+    if (searchExactMatch) {
+        // When the search term is surrounded by quotes, do not process any
+        // further than checking for spaces
+        QString searchTermWithoutQuotes = searchTerm.mid(1,
+                                                         searchTerm.size() - 2);
+        Utils::split(searchTermWithoutQuotes.toStdString(), ' ', pinyinWords);
+    } else {
+        pinyinWords = ChineseUtils::segmentPinyin(searchTerm);
+    }
+
+    std::vector<Entry> results;
+
+    QSqlQuery query{_manager->getDatabase()};
+    query.prepare(
+        //// Get list of entry ids whose pinyin starts with the queried string
+        "WITH matching_entry_ids AS ( "
+        "  SELECT rowid FROM entries_fts WHERE entries_fts MATCH ? AND "
+        "    pinyin LIKE ? "
         "), "
         " "
         //// Get the list of all definitions for those entries
@@ -597,8 +769,8 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         "                'label', label, 'sentences', "
         "                json_group_array(json(sentence))) AS definition "
         "  FROM matching_definitions AS md "
-        "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON md.definition_id "
-        "    = mcsi.definition_id "
+        "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON "
+        "    md.definition_id = mcsi.definition_id "
         "  LEFT JOIN matching_sentences_with_translations AS mswt ON "
         "    mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
         "  GROUP BY md.definition_id "
@@ -625,171 +797,8 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         "  ORDER BY frequency DESC "
         ") "
         " "
-        "SELECT simplified, traditional, jyutping, pinyin, definitions from "
-        "matching_entries");
-
-    const char *matchJoinDelimiter = searchExactMatch ? "" : "*";
-    std::string matchTerm
-        = ChineseUtils::constructRomanisationQuery(jyutpingWords,
-                                                   matchJoinDelimiter,
-                                                   /*surroundWithQuotes=*/true);
-    const char *likeJoinDelimiter = searchExactMatch ? "" : "_";
-    std::string likeTerm
-        = ChineseUtils::constructRomanisationQuery(jyutpingWords,
-                                                   likeJoinDelimiter);
-
-    query.addBindValue("jyutping:" + QString{matchTerm.c_str()});
-    query.addBindValue(QString{likeTerm.c_str()}
-                       + QString{searchExactMatch ? "" : "%"});
-    query.exec();
-
-    // Do not parse results if new query has been made
-    if (!checkQueryIDCurrent(queryID)) { return; }
-    results = QueryParseUtils::parseEntries(query);
-
-    if (!checkQueryIDCurrent(queryID)) { return; }
-    notifyObserversIfQueryIdCurrent(results, /*emptyQuery=*/false, queryID);
-}
-
-void SQLSearch::searchPinyinThread(const QString &searchTerm,
-                                   const unsigned long long queryID)
-{
-    // Replace "v" and "ü" with "u:" since "ü" is stored as "u:" in the table
-    QString processedSearchTerm = searchTerm;
-    int location = processedSearchTerm.indexOf("v");
-    while (location != -1) {
-        processedSearchTerm.remove(location, 1);
-        processedSearchTerm.insert(location, "u:");
-        location = processedSearchTerm.indexOf("v", location);
-    }
-
-    location = processedSearchTerm.indexOf("ü");
-    while (location != -1) {
-        processedSearchTerm.remove(location, 1);
-        processedSearchTerm.insert(location, "u:");
-        location = processedSearchTerm.indexOf("ü", location);
-    }
-
-    bool searchExactMatch = searchTerm.at(0) == "\""
-                            && searchTerm.at(searchTerm.size() - 1) == "\""
-                            && searchTerm.length() >= 3;
-
-    std::vector<std::string> pinyinWords;
-    if (searchExactMatch) {
-        // When the search term is surrounded by quotes, do not process any
-        // further than checking for spaces
-        QString searchTermWithoutQuotes = searchTerm.mid(1,
-                                                         searchTerm.size() - 2);
-        Utils::split(searchTermWithoutQuotes.toStdString(), ' ', pinyinWords);
-    } else {
-        pinyinWords = ChineseUtils::segmentPinyin(searchTerm);
-    }
-
-    std::vector<Entry> results;
-
-    QSqlQuery query{_manager->getDatabase()};
-    query.prepare(
-        //// Get list of entry ids whose pinyin starts with the queried string
-        "WITH matching_entry_ids AS ( "
-        "  SELECT rowid FROM entries_fts WHERE entries_fts MATCH ? AND pinyin LIKE ?"
-        "), "
-        " "
-        //// Get the list of all definitions for those entries
-        //// This CTE is used multiple times; would be nice if could materialize it
-        "matching_definition_ids AS ( "
-        "  SELECT definition_id, definition FROM definitions WHERE fk_entry_id "
-        "    IN matching_entry_ids "
-        "), "
-        " "
-        //// Get corresponding sentence ids for each of those definitions
-        //// This CTE is used multiple times; would be nice if could materialize it
-        "matching_chinese_sentence_ids AS ( "
-        "  SELECT definition_id, fk_chinese_sentence_id "
-        "  FROM matching_definition_ids AS mdi "
-        "  JOIN definitions_chinese_sentences_links AS dcsl ON mdi.definition_id = dcsl.fk_definition_id "
-        "), "
-        " "
-        //// Get translations for each of the sentences
-        "matching_translations AS ( "
-        "  SELECT mcsi.fk_chinese_sentence_id, "
-        "    json_group_array(DISTINCT "
-        "      json_object('sentence', sentence, "
-        "                  'language', language, "
-        "                  'direct', direct "
-        "    )) AS translation "
-        "  FROM matching_chinese_sentence_ids AS mcsi "
-        "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = sl.fk_chinese_sentence_id "
-        "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = sl.fk_non_chinese_sentence_id "
-        "  GROUP BY mcsi.fk_chinese_sentence_id "
-        "), "
-        " "
-        //// Get sentence data for each of the sentence ids
-        "matching_sentences AS ( "
-        " SELECT chinese_sentence_id, traditional, simplified, pinyin, "
-        "   jyutping, language "
-        " FROM chinese_sentences AS cs "
-        " WHERE chinese_sentence_id IN ( "
-        "   SELECT fk_chinese_sentence_id FROM matching_chinese_sentence_ids "
-        " ) "
-        "),"
-        " "
-        //// Get translations for each of those sentences
-        "matching_sentences_with_translations AS ( "
-        "  SELECT chinese_sentence_id, "
-        "    json_object('traditional', traditional, "
-        "                'simplified', simplified, "
-        "                'pinyin', pinyin, "
-        "                'jyutping', jyutping, "
-        "                'language', language, "
-        "                'translations', json(translation)) AS sentence "
-        "  FROM matching_sentences AS ms "
-        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = mt.fk_chinese_sentence_id "
-        "), "
-        " "
-        //// Get definition data for each matching definition
-        "matching_definitions AS ( "
-        "  SELECT definition_id, fk_entry_id, fk_source_id, definition, "
-        "    label "
-        "  FROM definitions "
-        "  WHERE definitions.definition_id IN ( "
-        "    SELECT definition_id FROM matching_definition_ids"
-        "  ) "
-        "), "
-        " "
-        //// Create definition object with sentences for each definition
-        "matching_definitions_with_sentences AS ( "
-        "  SELECT fk_entry_id, fk_source_id, "
-        "    json_object('definition', definition, "
-        "                'label', label, 'sentences', "
-        "                json_group_array(json(sentence))) AS definition "
-        "  FROM matching_definitions AS md "
-        "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON md.definition_id = mcsi.definition_id "
-        "  LEFT JOIN matching_sentences_with_translations AS mswt ON mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
-        "  GROUP BY md.definition_id "
-        "), "
-        " "
-        //// Create definition groups for definitions of the same entry that come from the same source
-        "matching_definition_groups AS ( "
-        "  SELECT fk_entry_id, "
-        "    json_object('source', sourcename, "
-        "                'definitions', "
-        "                json_group_array(json(definition))) AS definitions "
-        "  FROM matching_definitions_with_sentences AS mdws "
-        "  LEFT JOIN sources ON sources.source_id = mdws.fk_source_id "
-        "  GROUP BY fk_entry_id, fk_source_id "
-        "), "
-        " "
-        //// Construct the final entry object
-        "matching_entries AS ( "
-        "  SELECT simplified, traditional, jyutping, pinyin, json_group_array(json(definitions)) AS definitions "
-        "  FROM matching_definition_groups AS mdg "
-        "  LEFT JOIN entries ON entries.entry_id = mdg.fk_entry_id "
-        "  GROUP BY entry_id "
-        "  ORDER BY frequency DESC "
-        ") "
-        " "
-        "SELECT simplified, traditional, jyutping, pinyin, definitions from matching_entries"
-    );
+        "SELECT simplified, traditional, jyutping, pinyin, definitions FROM "
+        "  matching_entries");
     const char *matchJoinDelimiter = searchExactMatch ? "" : "*";
     std::string matchTerm
         = ChineseUtils::constructRomanisationQuery(pinyinWords,
@@ -909,8 +918,8 @@ void SQLSearch::searchEnglishThread(const QString &searchTerm,
         "                'label', label, 'sentences', "
         "                json_group_array(json(sentence))) AS definition "
         "  FROM matching_definitions AS md "
-        "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON md.definition_id "
-        "    = mcsi.definition_id "
+        "  LEFT JOIN matching_chinese_sentence_ids AS mcsi ON "
+        "    md.definition_id = mcsi.definition_id "
         "  LEFT JOIN matching_sentences_with_translations AS mswt ON "
         "    mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
         "  GROUP BY md.definition_id "
@@ -937,8 +946,8 @@ void SQLSearch::searchEnglishThread(const QString &searchTerm,
         "  ORDER BY frequency DESC "
         ") "
         " "
-        "SELECT simplified, traditional, jyutping, pinyin, definitions from "
-        "matching_entries");
+        "SELECT simplified, traditional, jyutping, pinyin, definitions FROM "
+        "  matching_entries");
     if (searchExactMatch) {
         query.addBindValue("\"" + searchTermWithoutQuotes + "\"");
         query.addBindValue(searchTermWithoutQuotes);
@@ -993,90 +1002,97 @@ void SQLSearch::searchByUniqueThread(const QString &simplified,
         "matching_chinese_sentence_ids AS ( "
         "  SELECT definition_id, fk_chinese_sentence_id "
         "  FROM matching_definition_ids AS mdi "
-        "  JOIN definitions_chinese_sentences_links AS dcsl ON mdi.definition_id = dcsl.fk_definition_id "
+        "  JOIN definitions_chinese_sentences_links AS dcsl ON "
+        "    mdi.definition_id = dcsl.fk_definition_id "
         "), "
         " "
         //// Get translations for each of the sentences
-        " matching_translations AS ( "
-        "   SELECT mcsi.fk_chinese_sentence_id, "
-        "     json_group_array(DISTINCT "
-        "       json_object('sentence', sentence, "
-        "                   'language', language, "
-        "                   'direct', direct "
-        "     )) AS translation "
-        "   FROM matching_chinese_sentence_ids AS mcsi "
-        "   JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = sl.fk_chinese_sentence_id "
-        "   JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = sl.fk_non_chinese_sentence_id "
-        "   GROUP BY mcsi.fk_chinese_sentence_id "
+        "matching_translations AS ( "
+        "  SELECT mcsi.fk_chinese_sentence_id, "
+        "    json_group_array(DISTINCT "
+        "      json_object('sentence', sentence, "
+        "                  'language', language, "
+        "                  'direct', direct "
+        "    )) AS translation "
+        "  FROM matching_chinese_sentence_ids AS mcsi "
+        "  JOIN sentence_links AS sl ON mcsi.fk_chinese_sentence_id = "
+        "    sl.fk_chinese_sentence_id "
+        "  JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = "
+        "    sl.fk_non_chinese_sentence_id "
+        "  GROUP BY mcsi.fk_chinese_sentence_id "
         "), "
         " "
         //// Get sentence data for each of the sentence ids
-        " matching_sentences AS ( "
+        "matching_sentences AS ( "
         "  SELECT chinese_sentence_id, traditional, simplified, pinyin, "
         "    jyutping, language "
         "  FROM chinese_sentences AS cs "
         "  WHERE chinese_sentence_id IN ( "
-        "	 SELECT fk_chinese_sentence_id FROM matching_chinese_sentence_ids "
+        "    SELECT fk_chinese_sentence_id FROM matching_chinese_sentence_ids "
         "  ) "
         "),"
         " "
         //// Get translations for each of those sentences
-        " matching_sentences_with_translations AS ( "
-        "   SELECT chinese_sentence_id, "
-        "     json_object('traditional', traditional, "
-        "                 'simplified', simplified, "
-        "                 'pinyin', pinyin, "
-        "                 'jyutping', jyutping, "
-        "                 'language', language, "
-        "                 'translations', json(translation)) AS sentence "
-        "   FROM matching_sentences AS ms "
-        "   LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = mt.fk_chinese_sentence_id "
+        "matching_sentences_with_translations AS ( "
+        "  SELECT chinese_sentence_id, "
+        "    json_object('traditional', traditional, "
+        "                'simplified', simplified, "
+        "                'pinyin', pinyin, "
+        "                'jyutping', jyutping, "
+        "                'language', language, "
+        "                'translations', json(translation)) AS sentence "
+        "  FROM matching_sentences AS ms "
+        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = "
+        "    mt.fk_chinese_sentence_id "
         "), "
         " "
         //// Get definition data for each matching definition
-        " matching_definitions AS ( "
-        "   SELECT definition_id, fk_entry_id, fk_source_id, definition, "
-        "     label "
-        "   FROM definitions "
-        "   WHERE definitions.definition_id IN ( "
-        "     SELECT definition_id FROM matching_definition_ids"
-        "   ) "
+        "matching_definitions AS ( "
+        "  SELECT definition_id, fk_entry_id, fk_source_id, definition, "
+        "    label "
+        "  FROM definitions "
+        "  WHERE definitions.definition_id IN ( "
+        "    SELECT definition_id FROM matching_definition_ids"
+        "  ) "
         "), "
         " "
         //// Create definition object with sentences for each definition
-        " matching_definitions_with_sentences AS ( "
-        "   SELECT md.fk_entry_id, md.fk_source_id, "
-        "     json_object('definition', md.definition, "
-        "                 'label', label, 'sentences', "
-        "                 json_group_array(json(sentence))) AS definition "
-        "   FROM matching_definitions AS md "
-        "   LEFT JOIN matching_chinese_sentence_ids AS mcsi ON md.definition_id = mcsi.definition_id "
-        "   LEFT JOIN matching_sentences_with_translations AS mswt ON mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
-        "   GROUP BY md.definition_id "
+        "matching_definitions_with_sentences AS ( "
+        " SELECT md.fk_entry_id, md.fk_source_id, "
+        "   json_object('definition', md.definition, "
+        "               'label', label, 'sentences', "
+        "               json_group_array(json(sentence))) AS definition "
+        " FROM matching_definitions AS md "
+        " LEFT JOIN matching_chinese_sentence_ids AS mcsi ON "
+        "   md.definition_id = mcsi.definition_id "
+        " LEFT JOIN matching_sentences_with_translations AS mswt ON "
+        "   mcsi.fk_chinese_sentence_id = mswt.chinese_sentence_id "
+        " GROUP BY md.definition_id "
         "), "
         " "
         //// Create definition groups for definitions of the same entry that come from the same source
-        " matching_definition_groups AS ( "
-        "   SELECT fk_entry_id, "
-        "     json_object('source', sourcename, "
-        "                 'definitions', "
-        "                 json_group_array(json(definition))) AS definitions "
-        "   FROM matching_definitions_with_sentences AS mdws "
-        "   LEFT JOIN sources ON sources.source_id = mdws.fk_source_id "
-        "   GROUP BY fk_entry_id, fk_source_id "
+        "matching_definition_groups AS ( "
+        "  SELECT fk_entry_id, "
+        "    json_object('source', sourcename, "
+        "                'definitions', "
+        "                json_group_array(json(definition))) AS definitions "
+        "  FROM matching_definitions_with_sentences AS mdws "
+        "  LEFT JOIN sources ON sources.source_id = mdws.fk_source_id "
+        "  GROUP BY fk_entry_id, fk_source_id "
         "), "
         " "
         //// Construct the final entry object
         "matching_entries AS ( "
-        "  SELECT simplified, traditional, jyutping, pinyin, json_group_array(json(definitions)) AS definitions "
+        "  SELECT simplified, traditional, jyutping, pinyin, "
+        "    json_group_array(json(definitions)) AS definitions "
         "  FROM matching_definition_groups AS mdg "
         "  LEFT JOIN entries ON entries.entry_id = mdg.fk_entry_id "
         "  GROUP BY entry_id "
         "  ORDER BY frequency DESC "
         ") "
         " "
-        "SELECT simplified, traditional, jyutping, pinyin, definitions from matching_entries"
-    );
+        "SELECT simplified, traditional, jyutping, pinyin, definitions FROM "
+        "  matching_entries");
     query.addBindValue(simplified);
     query.addBindValue(traditional);
     query.addBindValue(jyutping);
@@ -1120,48 +1136,55 @@ void SQLSearch::searchTraditionalSentencesThread(const QString &searchTerm,
         "                'language', language, "
         "                'direct', direct)) AS translation "
         "  FROM matching_chinese_sentence_ids AS mcsi "
-        "  LEFT JOIN sentence_links AS sl ON mcsi.chinese_sentence_id = sl.fk_chinese_sentence_id "
-        "  LEFT JOIN nonchinese_sentences AS ncs ON ncs.non_chinese_sentence_id = sl.fk_non_chinese_sentence_id "
+        "  LEFT JOIN sentence_links AS sl ON mcsi.chinese_sentence_id = "
+        "    sl.fk_chinese_sentence_id "
+        "  LEFT JOIN nonchinese_sentences AS ncs ON "
+        "    ncs.non_chinese_sentence_id = sl.fk_non_chinese_sentence_id "
         "  LEFT JOIN sources AS s ON s.source_id = sl.fk_source_id"
         "  GROUP BY s.sourcename, mcsi.chinese_sentence_id"
         "), "
         ""
         //// Group translations by source
         "matching_translations AS ( "
-        "   SELECT chinese_sentence_id, "
-        "      json_group_array( "
-        "        json_object('source', source, "
-        "                    'translations', json(translation)) "
-        "      ) AS translations "
-        "   FROM translations_with_source AS tws "
-        "   GROUP BY chinese_sentence_id "
+        "  SELECT chinese_sentence_id, "
+        "     json_group_array( "
+        "       json_object('source', source, "
+        "                   'translations', json(translation)) "
+        "     ) AS translations "
+        "  FROM translations_with_source AS tws "
+        "  GROUP BY chinese_sentence_id "
         "), "
         " "
         //// Get sentence data for each of the sentence id
-        " matching_sentences AS ( "
-        "  SELECT chinese_sentence_id, traditional, simplified, pinyin, "
-        "    jyutping, language "
-        "  FROM chinese_sentences AS cs "
-        "  WHERE chinese_sentence_id IN ( "
-        "    SELECT chinese_sentence_id FROM matching_chinese_sentence_ids "
-        "  ) "
+        "matching_sentences AS ( "
+        " SELECT chinese_sentence_id, traditional, simplified, pinyin, "
+        "   jyutping, language "
+        " FROM chinese_sentences AS cs "
+        " WHERE chinese_sentence_id IN ( "
+        "   SELECT chinese_sentence_id FROM matching_chinese_sentence_ids "
+        " ) "
         "), "
         " "
         //// Match up the translations with their sentences, and get the linked
         //// definition's source name if it exists
-        " matching_sentences_with_translations AS ( "
-        "   SELECT max(sourcename) AS sourcename, traditional, simplified, pinyin, jyutping, language, translations "
-        "   FROM matching_sentences AS ms "
-        "   LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = mt.chinese_sentence_id "
-        "   LEFT JOIN definitions_chinese_sentences_links AS dcsl ON ms.chinese_sentence_id = dcsl.fk_chinese_sentence_id "
-        "   LEFT JOIN definitions AS d ON dcsl.fk_definition_id = d.definition_id "
-        "   LEFT JOIN sources AS s ON d.fk_source_id = s.source_id "
-        "   GROUP BY traditional, simplified, pinyin, jyutping, language, translations "
-        "   ORDER BY ms.chinese_sentence_id "
+        "matching_sentences_with_translations AS ( "
+        "  SELECT max(sourcename) AS sourcename, traditional, simplified, "
+        "    pinyin, jyutping, language, translations "
+        "  FROM matching_sentences AS ms "
+        "  LEFT JOIN matching_translations AS mt ON ms.chinese_sentence_id = "
+        "    mt.chinese_sentence_id "
+        "  LEFT JOIN definitions_chinese_sentences_links AS dcsl ON "
+        "    ms.chinese_sentence_id = dcsl.fk_chinese_sentence_id "
+        "  LEFT JOIN definitions AS d ON dcsl.fk_definition_id = "
+        "    d.definition_id "
+        "  LEFT JOIN sources AS s ON d.fk_source_id = s.source_id "
+        "  GROUP BY traditional, simplified, pinyin, jyutping, language, "
+        "    translations "
+        "  ORDER BY ms.chinese_sentence_id "
         ") "
         " "
-        "SELECT sourcename, traditional, simplified, pinyin, jyutping, language, translations from matching_sentences_with_translations "
-    );
+        "SELECT sourcename, traditional, simplified, pinyin, jyutping, "
+        "  language, translations FROM matching_sentences_with_translations ");
     query.addBindValue("%" + searchTerm + "%");
     query.exec();
 

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -1023,13 +1023,13 @@ std::vector<std::string> segmentJyutping(const QString &string,
                                                 "ng", "h", "gw", "kw", "w",
                                                 "z",  "c", "s",  "j",  "m"};
     std::unordered_set<std::string> finals
-        = {"aa",  "aai", "aau", "aam", "aan",  "aang", "aap", "aat", "aak",
-           "ai",  "au",  "am",  "an",  "ang",  "ap",   "at",  "ak",  "e",
-           "ei",  "eu",  "em",  "en",  "eng",  "ep",   "ek",  "i",   "iu",
-           "im",  "in",  "ing", "ip",  "it",   "ik",   "o",   "oi",  "ou",
-           "on",  "ong", "ot",  "ok",  "u",    "ui",   "un",  "ung", "ut",
-           "uk",  "oe",  "eoi", "eon", "oeng", "eot",  "oek", "yu",  "yun",
-           "yut", "m",   "ng"};
+        = {"a",   "aa",  "aai", "aau", "aam", "aan", "aang", "aap", "aat",
+           "aak", "ai",  "au",  "am",  "an",  "ang", "ap",   "at",  "ak",
+           "e",   "ei",  "eu",  "em",  "en",  "eng", "ep",   "ek",  "i",
+           "iu",  "im",  "in",  "ing", "ip",  "it",  "ik",   "o",   "oi",
+           "ou",  "on",  "ong", "ot",  "ok",  "u",   "ui",   "un",  "ung",
+           "ut",  "uk",  "oe",  "oet", "eoi", "eon", "oeng", "eot", "oek",
+           "yu",  "yun", "yut", "m",   "ng"};
 
     // Keep track of indices for current segmented word; [start_index, end_index)
     // Greedily try to expand end_index by checking for valid sequences


### PR DESCRIPTION
# Description

When surrounding a query with quotes (""), only entries that match that query exactly are returned. See screenshots for a "before-and-after".

Closes #62.

<img width="800" alt="Screen Shot 2022-12-28 at 11 19 52 PM" src="https://user-images.githubusercontent.com/14353716/209902981-0d5f9f31-39e7-4a56-826b-ca382130de85.png">
<img width="800" alt="Screen Shot 2022-12-28 at 11 19 59 PM" src="https://user-images.githubusercontent.com/14353716/209902987-a2086b4c-bd0e-49da-b562-9336f78f0be8.png">

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
This has been built on Windows 10, elementary OS 5.1 Hera, and macOS 12.3.1 Monterey. Functionality worked as expected.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python code, none currently for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
