### PR TITLE
Resolve #58: Make 64-bit installer default to 64-bit Program Files folder on Windows

### DIFF
--- a/src/jyut-dict/platform/windows/README.md
+++ b/src/jyut-dict/platform/windows/README.md
@@ -4,7 +4,7 @@ To build for Windows:
 - Copy the executable, dict.db, and user.db to `installer/packages/com.aaronhktan.cantonesedictionary/data`.
 - Run WinDeployQt on the executable. Make sure to run WinDeployQt with the command prompt installed in the Start Menu or run QtEnv2.bat, so that appropriate paths are added to the system path.
 - Download and install the appropriate OpenSSL 1.1.1 file (32-bit and 64-bit). Copy libssl-1_1.dll, libcrypto-1_1.dll, capi.dll, and dasync.dll to the data folder.
-- Run binarycreator.exe (from Qt Installer Framework Tools), passing `--offline-only -c <path-to-config/config.xml> -p <path-to-packages> <name-of-executable>`.
+- Run binarycreator.exe (from Qt Installer Framework Tools), passing `--offline-only -c <path-to-config/config.xml> -p <path-to-packages> <name-of-executable>`. Note that there are different `config.xml` files for 32-bit and 64-bit installers!
 
 Defender SmartScreen notes:
 - Submit the installer .exe and the portable .exe to Microsoft's malware analysis: https://www.microsoft.com/en-us/wdsi/filesubmission.

--- a/src/jyut-dict/platform/windows/installer/config/config.xml
+++ b/src/jyut-dict/platform/windows/installer/config/config.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Installer>
-    <Name>Jyut Dictionary</Name>
-    <Version>2022-02-07</Version>
-    <Title>Jyut Dictionary</Title>
-    <Publisher>Aaron Tan</Publisher>
-    <StartMenuDir>Jyut Dictionary</StartMenuDir>
-    <TargetDir>@ApplicationsDir@/Jyut Dictionary</TargetDir>
-</Installer>

--- a/src/jyut-dict/platform/windows/installer/config/config_32.xml
+++ b/src/jyut-dict/platform/windows/installer/config/config_32.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Installer>
+    <Name>Jyut Dictionary</Name>
+    <Version>2022-02-07</Version>
+    <Title>Jyut Dictionary</Title>
+    <Publisher>Aaron Tan</Publisher>
+    <StartMenuDir>Jyut Dictionary</StartMenuDir>
+    <TargetDir>@ApplicationsDir@/Jyut Dictionary</TargetDir>
+</Installer>

--- a/src/jyut-dict/platform/windows/installer/config/config_64.xml
+++ b/src/jyut-dict/platform/windows/installer/config/config_64.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Installer>
+    <Name>Jyut Dictionary</Name>
+    <Version>2022-02-07</Version>
+    <Title>Jyut Dictionary</Title>
+    <Publisher>Aaron Tan</Publisher>
+    <StartMenuDir>Jyut Dictionary</StartMenuDir>
+    <TargetDir>@ApplicationsDirX64@/Jyut Dictionary</TargetDir>
+</Installer>


### PR DESCRIPTION
# Description

The installer should default to 64-bit program files folder instead of 32-bit program folder when using the 64-bit installer on Windows. This commit separates the 32-bit and 64-bit install configs such that this is now possible.

Closes #58.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have built the installer using Qt Installer Frramework 3.2.2, Qt 5.15.2, using the 1.22.0207 release of Jyut Dictionary.

![32_bit_installer](https://user-images.githubusercontent.com/14353716/210201445-f76a5d2a-d934-4611-9802-50592e24e4ac.png)
![64_bit_installer](https://user-images.githubusercontent.com/14353716/210201449-1cfefc27-9208-480f-8d19-7c556fea6e74.png)

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
