### PR TITLE
Fix crashing when searching in Jyutping mode

### DIFF
--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -1261,6 +1261,10 @@ std::string constructRomanisationQuery(const std::vector<std::string> &words,
                                        const char *delimiter,
                                        const bool surroundWithQuotes)
 {
+    if (words.empty()) {
+        return "";
+    }
+
     const char *quotes = surroundWithQuotes ? "\"" : "";
     std::ostringstream string;
     for (size_t i = 0; i < words.size() - 1; i++) {


### PR DESCRIPTION
# Description

- Fixed crashing when searching single quote '"' in Jyutping mode.

Closes #81.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested by running on macOS.

<img width="912" alt="Screen Shot 2023-01-15 at 2 57 09 AM" src="https://user-images.githubusercontent.com/14353716/212529294-d315d3bf-25d5-4dab-aef6-a1143521f5ad.png">

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
