### PR TITLE
#85: Select item in dictionary list upon mouse release

### DIFF
--- a/src/jyut-dict/components/dictionarylist/dictionarylistmodel.h
+++ b/src/jyut-dict/components/dictionarylist/dictionarylistmodel.h
@@ -35,10 +35,6 @@ public:
 
 private:
     std::vector<DictionaryMetadata> _dictionaries;
-
-signals:
-
-public slots:
 };
 
 #endif // DICTIONARYLISTMODEL_H

--- a/src/jyut-dict/components/dictionarylist/dictionarylistview.cpp
+++ b/src/jyut-dict/components/dictionarylist/dictionarylistview.cpp
@@ -46,6 +46,7 @@ void DictionaryListView::paintWithApplicationState()
     viewport()->update();
 }
 
+#ifdef Q_OS_MAC
 void DictionaryListView::mousePressEvent(QMouseEvent *event)
 {
     // Don't change item selection on mouse press.
@@ -54,3 +55,4 @@ void DictionaryListView::mousePressEvent(QMouseEvent *event)
     // they didn't select.
     (void) (event);
 }
+#endif

--- a/src/jyut-dict/components/dictionarylist/dictionarylistview.cpp
+++ b/src/jyut-dict/components/dictionarylist/dictionarylistview.cpp
@@ -45,3 +45,12 @@ void DictionaryListView::paintWithApplicationState()
 {
     viewport()->update();
 }
+
+void DictionaryListView::mousePressEvent(QMouseEvent *event)
+{
+    // Don't change item selection on mouse press.
+    // The window size changes before the user releases the mouse, which causes
+    // the item selection to change, and bounces the user to another item that
+    // they didn't select.
+    (void) (event);
+}

--- a/src/jyut-dict/components/dictionarylist/dictionarylistview.h
+++ b/src/jyut-dict/components/dictionarylist/dictionarylistview.h
@@ -26,6 +26,9 @@ private:
 
     QAbstractListModel *_model;
     QStyledItemDelegate *_delegate;
+
+protected:
+    virtual void mousePressEvent(QMouseEvent *event) override;
 };
 
 #endif // DICTIONARYLISTVIEW_H

--- a/src/jyut-dict/components/dictionarylist/dictionarylistview.h
+++ b/src/jyut-dict/components/dictionarylist/dictionarylistview.h
@@ -27,8 +27,10 @@ private:
     QAbstractListModel *_model;
     QStyledItemDelegate *_delegate;
 
+#ifdef Q_OS_MAC
 protected:
     virtual void mousePressEvent(QMouseEvent *event) override;
+#endif
 };
 
 #endif // DICTIONARYLISTVIEW_H

--- a/src/jyut-dict/components/settings/dictionarytab.cpp
+++ b/src/jyut-dict/components/settings/dictionarytab.cpp
@@ -2,7 +2,6 @@
 
 #include "components/dictionarylist/dictionarylistview.h"
 #include "logic/dictionary/dictionarysource.h"
-#include "logic/utils/utils.h"
 #include "logic/settings/settingsutils.h"
 #ifdef Q_OS_MAC
 #include "logic/utils/utils_mac.h"
@@ -44,12 +43,6 @@ void DictionaryTab::changeEvent(QEvent *event)
 
 void DictionaryTab::setupUI()
 {
-#ifdef Q_OS_WIN
-    if (QLocale::system().language() & QLocale::Chinese ||
-        QLocale::system().language() & QLocale::Cantonese) {
-        setStyleSheet("QLabel { font-size: 12px; }");
-    }
-#endif
     _tabLayout = new QGridLayout{this};
     _tabLayout->setAlignment(Qt::AlignTop);
 
@@ -144,19 +137,13 @@ void DictionaryTab::translateUI()
 void DictionaryTab::setStyle(bool use_dark) {
     (void) (use_dark);
 #ifdef Q_OS_MAC
-    setStyleSheet(
-        "QPushButton[isHan=\"true\"] { font-size: 12px; height: 16px; }");
     _list->setStyleSheet("QListView {"
                          "   border: 1px solid palette(window); "
                          "} ");
 #else
     setAttribute(Qt::WA_StyledBackground);
     setObjectName("DictionaryTab");
-    setStyleSheet("QPushButton[isHan=\"true\"] { "
-                  "   font-size: 12px; height: 20px; "
-                  "}"
-                  ""
-                  "QWidget#DictionaryTab {"
+    setStyleSheet("QWidget#DictionaryTab {"
                   "   background-color: palette(base);"
                   "} ");
     _list->setStyleSheet("QListView {"

--- a/src/jyut-dict/components/settings/dictionarytab.cpp
+++ b/src/jyut-dict/components/settings/dictionarytab.cpp
@@ -8,6 +8,7 @@
 #elif defined (Q_OS_LINUX)
 #include "logic/utils/utils_linux.h"
 #elif defined(Q_OS_WIN)
+#include "logic/strings/strings.h"
 #include "logic/utils/utils_windows.h"
 #endif
 

--- a/src/jyut-dict/components/settings/dictionarytab.h
+++ b/src/jyut-dict/components/settings/dictionarytab.h
@@ -70,9 +70,6 @@ private:
 
     std::shared_ptr<SQLDatabaseManager> _manager;
     std::unique_ptr<SQLDatabaseUtils> _utils;
-signals:
-
-public slots:
 };
 
 #endif // DICTIONARYTAB_H


### PR DESCRIPTION
# Description

- As described in #85, items in the dictionary list are selected upon mouse down and mouse release. However, this causes the dictionary window to resize (1) upon mouse down, and (2) again on mouse release. The resizing occurring at (1) causes the item underneath the mouse to shift as the dictionary list resizes, so the item selected at moment (2) is not what the user clicked on.
- By restricting item selection to mouse release, items are selected only once, and the window adjusts its size only after a selection is made and the mouse is released.

Closes #85.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested on macOS 12.3.1 Ventura, Windows 10 build 1803, and elementary OS 5.1 Hera, building with Qt 5.15.2.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
