### PR TITLE
#88: Replace HanziConv with OpenCC

### DIFF
--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -1,5 +1,5 @@
 from dragonmapper import transcriptions
-from hanziconv import HanziConv
+import opencc
 import pinyin_jyutping_sentence
 from wordfreq import zipf_frequency
 
@@ -39,6 +39,8 @@ EXAMPLE_TYPE = re.compile(
 VARIANTS = re.compile(r"((?:./)+.)")
 ABRIDGED_DATED_VARIANT = re.compile(r"@{.*?}")
 
+converter = opencc.OpenCC("s2hk.json")
+
 
 class Type(Enum):
     NONE = 0
@@ -67,7 +69,7 @@ def insert_example(c, definition_id, starting_example_id, example):
     examples_inserted = 0
 
     simp = example[0].content
-    trad = HanziConv.toTraditional(simp) if simp else ""
+    trad = converter.convert(simp) if simp else ""
     jyut = ""
     pin = example[0].pron
     lang = example[0].lang
@@ -340,7 +342,9 @@ def parse_example_pinyin(content, entry_pinyin):
     content = parse_pinyin(content)
     # Re-add stripped punctuation
     content = (
-        content + stripped_punctuation if stripped_punctuation in string.punctuation else content
+        content + stripped_punctuation
+        if stripped_punctuation in string.punctuation
+        else content
     )
 
     return content
@@ -470,8 +474,12 @@ def parse_file(filename, words):
 
                 # First, parse all the lines that relate to the entirety of the entry
                 # These lines do not have a number preceding them.
-                entry_lines = list(filter(lambda x: not (x[0].isdigit()), current_entry_lines))
-                parsed_entry_lines = list(map(parse_line, entry_lines, [current_entry] * len(entry_lines)))
+                entry_lines = list(
+                    filter(lambda x: not (x[0].isdigit()), current_entry_lines)
+                )
+                parsed_entry_lines = list(
+                    map(parse_line, entry_lines, [current_entry] * len(entry_lines))
+                )
 
                 for parsed_type, parsed in parsed_entry_lines:
                     if parsed_type == Type.PINYIN:
@@ -480,9 +488,11 @@ def parse_file(filename, words):
                         current_entry.add_traditional(parsed[0][0])
                         current_entry.add_simplified(parsed[0][1])
                         current_entry.add_freq(zipf_frequency(parsed[0][0], "zh"))
-                        current_entry.add_jyutping(pinyin_jyutping_sentence.jyutping(
-                            parsed[0][0], tone_numbers=True, spaces=True
-                        ))
+                        current_entry.add_jyutping(
+                            pinyin_jyutping_sentence.jyutping(
+                                parsed[0][0], tone_numbers=True, spaces=True
+                            )
+                        )
                         variants = parsed[1:]
                     elif parsed_type == Type.POS:
                         entry_pos = parsed
@@ -500,13 +510,19 @@ def parse_file(filename, words):
                             continue
 
                         # Add the psx label to the definition if there is one
-                        definition = entry_posx + " " + definition if entry_posx else definition
+                        definition = (
+                            entry_posx + " " + definition if entry_posx else definition
+                        )
                         label = entry_pos if entry_pos else ""
 
-                        current_definition = objects.Definition(definition=definition, label=label)
+                        current_definition = objects.Definition(
+                            definition=definition, label=label
+                        )
                         current_entry.append_to_defs(current_definition)
 
-                parsed_entry_lines = list(map(parse_line, entry_lines, [current_entry] * len(entry_lines)))
+                parsed_entry_lines = list(
+                    map(parse_line, entry_lines, [current_entry] * len(entry_lines))
+                )
 
                 for parsed_type, parsed in parsed_entry_lines:
                     if parsed_type == Type.EXAMPLE_HANZI:
@@ -521,40 +537,83 @@ def parse_file(filename, words):
 
                 if entry_ex_pin or entry_ex_hz or entry_ex_tr:
                     current_definition.examples.append([])
-                    current_definition.examples[-1].append(objects.Example(lang="cmn", pron=entry_ex_pin, content=entry_ex_hz))
-                    current_definition.examples[-1].append(objects.Example(lang="eng", content=entry_ex_tr))
-
+                    current_definition.examples[-1].append(
+                        objects.Example(
+                            lang="cmn", pron=entry_ex_pin, content=entry_ex_hz
+                        )
+                    )
+                    current_definition.examples[-1].append(
+                        objects.Example(lang="eng", content=entry_ex_tr)
+                    )
 
                 # Then, parse each of the numbered lines
-                numbered_lines = list(filter(lambda x: x[0].isdigit(), current_entry_lines))
-                parsed_numbered_lines = list(map(parse_line, numbered_lines, [current_entry] * len(numbered_lines)))
-                parsed_numbered_lines = list(filter(lambda x: x[0] == Type.SMUSHED, parsed_numbered_lines))
+                numbered_lines = list(
+                    filter(lambda x: x[0].isdigit(), current_entry_lines)
+                )
+                parsed_numbered_lines = list(
+                    map(
+                        parse_line,
+                        numbered_lines,
+                        [current_entry] * len(numbered_lines),
+                    )
+                )
+                parsed_numbered_lines = list(
+                    filter(lambda x: x[0] == Type.SMUSHED, parsed_numbered_lines)
+                )
                 parsed_numbered_lines = list(map(lambda x: x[1], parsed_numbered_lines))
 
                 for pos_index in range(1, 8):
                     # In the ABC dictionary, there is a maximum of seven parts of speech (1-indexed)
-                    pos_index_lines = list(filter(lambda x: x["pos_index"] == pos_index, parsed_numbered_lines))
+                    pos_index_lines = list(
+                        filter(
+                            lambda x: x["pos_index"] == pos_index, parsed_numbered_lines
+                        )
+                    )
 
                     # First, let's isolate lines that apply to all lines in this pos_index:
                     # do this by finding lines where the pos_index is some number, def_index == None, and ex_index == None
                     # e.g. "1ps   n." => applies to "11df   greeting", as well as "12df   salutation"
-                    applies_to_all_in_this_pos_index = list(filter(lambda x: x["def_index"] == None and x["ex_index"] == None, pos_index_lines))
+                    applies_to_all_in_this_pos_index = list(
+                        filter(
+                            lambda x: x["def_index"] == None and x["ex_index"] == None,
+                            pos_index_lines,
+                        )
+                    )
 
                     # Parse the part of speech that applies to all lines in this index
-                    pos_index_pos_line = list(filter(lambda x: x["parsed"] and x["parsed"][0] == Type.POS, applies_to_all_in_this_pos_index))
-                    pos_index_pos_line = list(map(lambda x: x["parsed"], pos_index_pos_line))
+                    pos_index_pos_line = list(
+                        filter(
+                            lambda x: x["parsed"] and x["parsed"][0] == Type.POS,
+                            applies_to_all_in_this_pos_index,
+                        )
+                    )
+                    pos_index_pos_line = list(
+                        map(lambda x: x["parsed"], pos_index_pos_line)
+                    )
 
                     pos_index_pos = ""
                     if len(pos_index_pos_line) > 1:
-                        logging.error(f"Found more than one part of speech for index {pos_index} in entry {current_entry.traditional}")
+                        logging.error(
+                            f"Found more than one part of speech for index {pos_index} in entry {current_entry.traditional}"
+                        )
                         logging.error(pos_index_pos_line)
                     elif len(pos_index_pos_line) == 1:
                         pos_index_pos = pos_index_pos_line[0][1]
 
                     # Parse the definitions that apply to all lines in this index
-                    pos_index_def_lines = list(filter(lambda x: x["parsed"] and x["parsed"][0] in (Type.POSX, Type.DEFINITION), applies_to_all_in_this_pos_index))
-                    pos_index_def_lines = list(filter(lambda x: x["parsed"][1][0] == "en", pos_index_def_lines))
-                    pos_index_def_lines = list(map(lambda x: x["parsed"], pos_index_def_lines))
+                    pos_index_def_lines = list(
+                        filter(
+                            lambda x: x["parsed"]
+                            and x["parsed"][0] in (Type.POSX, Type.DEFINITION),
+                            applies_to_all_in_this_pos_index,
+                        )
+                    )
+                    pos_index_def_lines = list(
+                        filter(lambda x: x["parsed"][1][0] == "en", pos_index_def_lines)
+                    )
+                    pos_index_def_lines = list(
+                        map(lambda x: x["parsed"], pos_index_def_lines)
+                    )
 
                     posx = definition = ""
                     definition_list = []
@@ -568,15 +627,32 @@ def parse_file(filename, words):
 
                     definition = " ".join(definition_list)
 
-                    label = (entry_pos if entry_pos else "") + (pos_index_pos if pos_index_pos else "")
+                    label = (entry_pos if entry_pos else "") + (
+                        pos_index_pos if pos_index_pos else ""
+                    )
 
                     if definition:
-                        current_definition = objects.Definition(definition=definition, label=label)
+                        current_definition = objects.Definition(
+                            definition=definition, label=label
+                        )
                         current_entry.append_to_defs(current_definition)
 
                     # Then, parse the examples
-                    pos_index_ex_lines = list(filter(lambda x: x["parsed"] and x["parsed"][0] in (Type.EXAMPLE_HANZI, Type.EXAMPLE_PINYIN, Type.EXAMPLE_TRANSLATION), applies_to_all_in_this_pos_index))
-                    pos_index_ex_lines = list(map(lambda x: x["parsed"], pos_index_ex_lines))
+                    pos_index_ex_lines = list(
+                        filter(
+                            lambda x: x["parsed"]
+                            and x["parsed"][0]
+                            in (
+                                Type.EXAMPLE_HANZI,
+                                Type.EXAMPLE_PINYIN,
+                                Type.EXAMPLE_TRANSLATION,
+                            ),
+                            applies_to_all_in_this_pos_index,
+                        )
+                    )
+                    pos_index_ex_lines = list(
+                        map(lambda x: x["parsed"], pos_index_ex_lines)
+                    )
 
                     ex_pin = ex_hz = ex_tr = ""
                     for content_type, content in pos_index_ex_lines:
@@ -592,19 +668,41 @@ def parse_file(filename, words):
 
                     if ex_pin or ex_hz or ex_tr:
                         current_definition.examples.append([])
-                        current_definition.examples[-1].append(objects.Example(lang="cmn", pron=ex_pin, content=ex_hz))
-                        current_definition.examples[-1].append(objects.Example(lang="eng", content=ex_tr))
+                        current_definition.examples[-1].append(
+                            objects.Example(lang="cmn", pron=ex_pin, content=ex_hz)
+                        )
+                        current_definition.examples[-1].append(
+                            objects.Example(lang="eng", content=ex_tr)
+                        )
 
                     for def_index in range(1, 10):
                         # Then, parse all the lines that apply to a smaller scope
                         # For each pos_index, there can be many definitions, but limit ourselves to 9 for now
-                        def_index_lines = list(filter(lambda x: x["def_index"] == def_index, pos_index_lines))
-                        applies_to_all_in_this_def_index_lines = list(filter(lambda x: x["ex_index"] == None, def_index_lines))
+                        def_index_lines = list(
+                            filter(
+                                lambda x: x["def_index"] == def_index, pos_index_lines
+                            )
+                        )
+                        applies_to_all_in_this_def_index_lines = list(
+                            filter(lambda x: x["ex_index"] == None, def_index_lines)
+                        )
 
                         # Parse the definitions that apply to all lines in this index
-                        def_index_def_lines = list(filter(lambda x: x["parsed"] and x["parsed"][0] in (Type.POSX, Type.DEFINITION), applies_to_all_in_this_def_index_lines))
-                        def_index_def_lines = list(filter(lambda x: x["parsed"][1][0] == "en", def_index_def_lines))
-                        def_index_def_lines = list(map(lambda x: x["parsed"], def_index_def_lines))
+                        def_index_def_lines = list(
+                            filter(
+                                lambda x: x["parsed"]
+                                and x["parsed"][0] in (Type.POSX, Type.DEFINITION),
+                                applies_to_all_in_this_def_index_lines,
+                            )
+                        )
+                        def_index_def_lines = list(
+                            filter(
+                                lambda x: x["parsed"][1][0] == "en", def_index_def_lines
+                            )
+                        )
+                        def_index_def_lines = list(
+                            map(lambda x: x["parsed"], def_index_def_lines)
+                        )
 
                         posx = definition = ""
                         definition_list = []
@@ -618,15 +716,32 @@ def parse_file(filename, words):
 
                         definition = " ".join(definition_list)
 
-                        label = (entry_pos if entry_pos else "") + (pos_index_pos if pos_index_pos else "")
+                        label = (entry_pos if entry_pos else "") + (
+                            pos_index_pos if pos_index_pos else ""
+                        )
 
                         if definition:
-                            current_definition = objects.Definition(definition=definition, label=label)
+                            current_definition = objects.Definition(
+                                definition=definition, label=label
+                            )
                             current_entry.append_to_defs(current_definition)
 
                         # Then, parse the examples
-                        def_index_ex_lines = list(filter(lambda x: x["parsed"] and x["parsed"][0] in (Type.EXAMPLE_HANZI, Type.EXAMPLE_PINYIN, Type.EXAMPLE_TRANSLATION), applies_to_all_in_this_def_index_lines))
-                        def_index_ex_lines = list(map(lambda x: x["parsed"], def_index_ex_lines))
+                        def_index_ex_lines = list(
+                            filter(
+                                lambda x: x["parsed"]
+                                and x["parsed"][0]
+                                in (
+                                    Type.EXAMPLE_HANZI,
+                                    Type.EXAMPLE_PINYIN,
+                                    Type.EXAMPLE_TRANSLATION,
+                                ),
+                                applies_to_all_in_this_def_index_lines,
+                            )
+                        )
+                        def_index_ex_lines = list(
+                            map(lambda x: x["parsed"], def_index_ex_lines)
+                        )
 
                         ex_pin = ex_hz = ex_tr = ""
                         for content_type, content in def_index_ex_lines:
@@ -642,16 +757,36 @@ def parse_file(filename, words):
 
                         if ex_pin or ex_hz or ex_tr:
                             current_definition.examples.append([])
-                            current_definition.examples[-1].append(objects.Example(lang="cmn", pron=ex_pin, content=ex_hz))
-                            current_definition.examples[-1].append(objects.Example(lang="eng", content=ex_tr))
-
+                            current_definition.examples[-1].append(
+                                objects.Example(lang="cmn", pron=ex_pin, content=ex_hz)
+                            )
+                            current_definition.examples[-1].append(
+                                objects.Example(lang="eng", content=ex_tr)
+                            )
 
                         for ex_index in range(1, 10):
                             # For each definition, there can be up to 10 examples
-                            ex_index_lines = list(filter(lambda x: x["ex_index"] == ex_index, def_index_lines))
+                            ex_index_lines = list(
+                                filter(
+                                    lambda x: x["ex_index"] == ex_index, def_index_lines
+                                )
+                            )
 
-                            ex_index_ex_lines = list(filter(lambda x: x["parsed"] and x["parsed"][0] in (Type.EXAMPLE_HANZI, Type.EXAMPLE_PINYIN, Type.EXAMPLE_TRANSLATION), ex_index_lines))
-                            ex_index_ex_lines = list(map(lambda x: x["parsed"], ex_index_ex_lines))
+                            ex_index_ex_lines = list(
+                                filter(
+                                    lambda x: x["parsed"]
+                                    and x["parsed"][0]
+                                    in (
+                                        Type.EXAMPLE_HANZI,
+                                        Type.EXAMPLE_PINYIN,
+                                        Type.EXAMPLE_TRANSLATION,
+                                    ),
+                                    ex_index_lines,
+                                )
+                            )
+                            ex_index_ex_lines = list(
+                                map(lambda x: x["parsed"], ex_index_ex_lines)
+                            )
 
                             ex_pin = ex_hz = ex_tr = ""
                             for content_type, content in ex_index_ex_lines:
@@ -667,8 +802,14 @@ def parse_file(filename, words):
 
                             if ex_pin or ex_hz or ex_tr:
                                 current_definition.examples.append([])
-                                current_definition.examples[-1].append(objects.Example(lang="cmn", pron=ex_pin, content=ex_hz))
-                                current_definition.examples[-1].append(objects.Example(lang="eng", content=ex_tr))
+                                current_definition.examples[-1].append(
+                                    objects.Example(
+                                        lang="cmn", pron=ex_pin, content=ex_hz
+                                    )
+                                )
+                                current_definition.examples[-1].append(
+                                    objects.Example(lang="eng", content=ex_tr)
+                                )
 
                 words[current_entry.traditional].append(current_entry)
 
@@ -677,9 +818,11 @@ def parse_file(filename, words):
                     variant_entry = copy.deepcopy(current_entry)
                     variant_entry.add_simplified(simplified)
                     variant_entry.add_traditional(traditional)
-                    variant_entry.add_jyutping(pinyin_jyutping_sentence.jyutping(
-                        traditional, tone_numbers=True, spaces=True
-                    ))
+                    variant_entry.add_jyutping(
+                        pinyin_jyutping_sentence.jyutping(
+                            traditional, tone_numbers=True, spaces=True
+                        )
+                    )
                     variant_entry.add_freq(zipf_frequency(traditional, "zh"))
                     words[variant_entry.traditional].append(variant_entry)
 

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -206,7 +206,7 @@ def parse_pinyin(content):
     # But we don't support that, so remove it
     # Pinyin also sometimes has superscript numbers preceding them that we need to remove
     # I assume it's to distinguish between words with the same Pinyin? Unsure
-    content = content.translate(str.maketrans("ạẹịọụ'-", "aeiou  ", "̠*¹²³⁴⁵⁶⁷⁸⁹"))
+    content = content.translate(str.maketrans("ạẹịọụ'-", "aeiou  ", "̠*¹²³⁴⁵⁶⁷⁸⁹⁰"))
     # ABC also indicates erhua with (r) in Pinyin. This causes difficulties with
     # entry coalescing, so remove it.
     content = content.replace("(r)", "")

--- a/src/dictionaries/abc_/requirements.txt
+++ b/src/dictionaries/abc_/requirements.txt
@@ -1,5 +1,5 @@
 dragonmapper==0.2.6
-hanziconv==0.3.2
+opencc==1.1.6
 jieba==0.42.1
 pinyin_jyutping_sentence==1.0
 wordfreq==2.5.1

--- a/src/dictionaries/cantodict/requirements.txt
+++ b/src/dictionaries/cantodict/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.10.0
-hanziconv==0.3.2
 jieba==0.42.1
 msgpack==1.0.2
+opencc==1.1.6
 pypinyin==0.43.0
 pypinyin-dict==0.1.0
 wordfreq==2.5.1

--- a/src/dictionaries/cross_straits/requirements.txt
+++ b/src/dictionaries/cross_straits/requirements.txt
@@ -1,7 +1,7 @@
 dragonmapper==0.2.6
-hanziconv==0.3.2
 jieba==0.42.1
 msgpack==1.0.2
+opencc==1.1.6
 pinyin_jyutping_sentence==1.0
 pypinyin==0.43.0
 pypinyin-dict==0.1.0

--- a/src/dictionaries/cuhk/parse.py
+++ b/src/dictionaries/cuhk/parse.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
-from hanziconv import HanziConv
 from hkscs_unicode_converter import converter
+import opencc
 from pypinyin import lazy_pinyin, Style
 from pypinyin_dict.phrase_pinyin_data import cc_cedict
 from wordfreq import zipf_frequency
@@ -35,6 +35,8 @@ MEANING_REGEX = re.compile(
 REMARK_REGEX = re.compile("MainContent_repeaterRecord_lblRemark_*")
 
 JYUTPING_MAP = {"7": "1", "8": "3", "9": "6"}
+
+cc_converter = opencc.OpenCC("hk2s.json")
 
 
 def write(db_name, source, entries):
@@ -116,7 +118,7 @@ def parse_word_file(file_name, words):
             trad = re.sub(
                 PRIVATE_USE_AREA_REGEX, PRIVATE_USE_AREA_REPLACEMENT_STRING, trad
             )
-        simp = HanziConv.toSimplified(trad)
+        simp = cc_converter.convert(trad)
 
         word = os.path.splitext(os.path.basename(file_name))[0]
         word = converter.convert_string(word)
@@ -150,7 +152,7 @@ def parse_word_file(file_name, words):
 
         # Automatically generate pinyin
         pin = (
-            " ".join(lazy_pinyin(trad, style=Style.TONE3, neutral_tone_with_five=True))
+            " ".join(lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True))
             .lower()
             .replace("v", "u:")
         )

--- a/src/dictionaries/cuhk/requirements.txt
+++ b/src/dictionaries/cuhk/requirements.txt
@@ -1,8 +1,8 @@
 beautifulsoup4==4.10.0
-hanziconv==0.3.2
 hkscs_unicode_converter==1.1.0
 jieba==0.42.1
 msgpack==1.0.2
+opencc==1.1.6
 pypinyin==0.43.0
 pypinyin-dict==0.1.0
 wordfreq==2.5.1

--- a/src/dictionaries/database/objects.py
+++ b/src/dictionaries/database/objects.py
@@ -16,6 +16,7 @@ SourceTuple = namedtuple(
     ],
 )
 
+
 # Option 1 for representing an entry: this class gives a basic structure for an object with
 # traditional, simplified, pinyin, jyutping, and definitions, with pinyin/jyutping/definitions
 # able to be set later via add_pinyin/add_jyutping/add_defs functions.

--- a/src/dictionaries/hsk3/parse.py
+++ b/src/dictionaries/hsk3/parse.py
@@ -1,4 +1,4 @@
-from hanziconv import HanziConv
+import opencc
 import pinyin_jyutping_sentence
 from pypinyin import lazy_pinyin, Style
 from pypinyin_dict.phrase_pinyin_data import cc_cedict
@@ -17,6 +17,8 @@ lists = (
     "汉字表",
     "手写字表",
 )
+
+converter = opencc.OpenCC("s2hk.json")
 
 
 def write(db_name, source, entries):
@@ -109,7 +111,7 @@ def parse_file(filename, entries):
                 simp = split[1]
                 label = ""
 
-            trad = HanziConv.toTraditional(simp)
+            trad = converter.convert(simp)
             pin = " ".join(
                 lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True)
             ).lower()

--- a/src/dictionaries/hsk3/requirements.txt
+++ b/src/dictionaries/hsk3/requirements.txt
@@ -1,6 +1,6 @@
-hanziconv==0.3.2
 jieba==0.42.1
 msgpack==1.0.2
+opencc==1.1.6
 pinyin_jyutping_sentence==1.0
 pypinyin==0.43.0
 pypinyin-dict==0.1.0

--- a/src/dictionaries/kaifangcidian/parse.py
+++ b/src/dictionaries/kaifangcidian/parse.py
@@ -122,7 +122,7 @@ def parse_file(filename_traditional, filename_simplified_jyutping, entries):
         jyut = " ".join(simplified[index + trad_len : index + trad_len + jyut_len])
 
         pin = (
-            " ".join(lazy_pinyin(trad, style=Style.TONE3, neutral_tone_with_five=True))
+            " ".join(lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True))
             .lower()
             .replace("v", "u:")
         )
@@ -138,7 +138,7 @@ def parse_file(filename_traditional, filename_simplified_jyutping, entries):
             defs_traditional = traditional[row][2].split("，")
             defs_simplified = simplified[index + trad_len + jyut_len].split("，")
             definitions = []
-            for (def_traditional, def_simplified) in zip(
+            for def_traditional, def_simplified in zip(
                 defs_traditional, defs_simplified
             ):
                 if def_traditional != def_simplified:

--- a/src/dictionaries/moedict/parse.py
+++ b/src/dictionaries/moedict/parse.py
@@ -1,5 +1,5 @@
-from hanziconv import HanziConv
 import jieba
+import opencc
 import pinyin_jyutping_sentence
 from pypinyin import lazy_pinyin, Style
 from pypinyin_dict.phrase_pinyin_data import cc_cedict
@@ -16,6 +16,7 @@ import re
 import sqlite3
 import sys
 import traceback
+import unicodedata
 
 # Useful test words:
 #   - 重: multiple heteronyms, labels for definitions
@@ -29,6 +30,10 @@ import traceback
 #   - 削: contains 讀音 and 語音
 #   - 剖: contains （又音）
 #   - 乾兒: transcription for 兒 is super annoying
+#   - 倘來之物: has {[90ba]} in the pronunciation
+#   - 不到頭: has {[97ef]} before a comma
+#   - 救應: has {[9afc]} after a period
+#   - 三十年河東，三十年河西: has multiple punctuation marks one after the other
 
 PINYIN_COLLOQUIAL_PRONUNCIATION_REGEX_PATTERN = re.compile(r"（語音）")
 PINYIN_LITERARY_PRONUNCIATION_REGEX_PATTERN = re.compile(r"（讀音）")
@@ -42,12 +47,19 @@ VARIANT_PRONUNCIATION_REGEX_PATTERN = re.compile(r"\s\(變\).*")
 COLLOQUIAL_PRONUNCIATION_REGEX_PATTERN = re.compile(r"\s（語音）.*")
 STRANGE_ENTRY_REGEX_PATTERN = re.compile(r".*（.*\)")
 
+PUNCTUATION_TABLE = {}
+for i in range(sys.maxunicode):
+    if unicodedata.category(chr(i)).startswith("P"):
+        PUNCTUATION_TABLE[i] = " " + chr(i) + " "
+
+converter = opencc.OpenCC("tw2s.json")
+
 
 def insert_example(c, definition_id, starting_example_id, example):
     examples_inserted = 0
 
     trad = example.content
-    simp = HanziConv.toSimplified(trad)
+    simp = converter.convert(trad)
     jyut = ""
     pin = example.pron
     lang = example.lang
@@ -174,7 +186,7 @@ def parse_file(filename, words):
 
             # These do not change no matter the heteronym
             trad = item["title"]
-            simp = HanziConv.toSimplified(trad)
+            simp = converter.convert(trad)
             jyut = pinyin_jyutping_sentence.jyutping(
                 trad, tone_numbers=True, spaces=True
             )
@@ -252,20 +264,32 @@ def parse_file(filename, words):
                                     "", example_text
                                 )
 
-                                # Joining and splitting separates series of full-width punctuation marks
-                                # into separate items,  which is necessary so that lazy_pinyin() returns
-                                # separate items for each full-width punctuation mark in the list it returns
+                                # Translating using the PUNCTUATION_TABLE adds spaces to series of full-width
+                                # punctuation marks, which is necessary so that the split() in
+                                # change_pinyin_to_match_phrase() creates a list of Pinyin where each entry in that
+                                # list corresponds 1:1 to each Unicode glyph.
                                 #
-                                # e.g. "《儒林外史．第四六回》：「成老爹道..." turns into
-                                # "《 儒 林 外 史 ． 第 四 六 回 》 ： 「 成 老 爹 道", which turns into
-                                # ['《', '儒', '林', '外', '史', '．', '第', '四', '六', '回', '》', '：', '「', '成', '老', '爹', '道']
-                                # (Notice how "》：「"" is now split up into three different items)
-                                example_pinyin = lazy_pinyin(
-                                    " ".join(example_text).split(),
+                                # e.g. "《元．秦{[90ba]}夫《東堂老．第三折》：「忠..." passes through lazy_pinyin(), so it turns into:
+                                # ['yuan2', '．', 'qin2', '{[90ba]}', 'fu1', '《', 'dong1', 'tang2', 'lao3', '．', 'di4', 'san1', 'zhe2', '》：「', 'zhong1']
+                                # Then we add spaces between the punctuation marks and the {[90ba]} to get:
+                                # "yuan2  ．  qin2  {   [  9 0 b a  ]   }  fu1  《  dong1 tang2 lao3  ．  di4 san1 zhe2  》  ：  「  zhong1 xiao4 shi4 li4 shen1 zhi1 ben3  ，  zhe4 qian2 cai2 shi4 tang3 lai2 zhi1 wu4  。  」"
+                                # Finally, change_pinyin_to_match_phrase() calls split() on that string, and it sees:
+                                # ['yuan2', '．', 'qin2', '{', '[', '9', '0', 'b', 'a', ']', '}', 'fu1', '《', 'dong1', 'tang2', 'lao3', '．', 'di4', 'san1', 'zhe2', '》', '：', '「', 'zhong1']
+                                example_pinyin_list = lazy_pinyin(
+                                    converter.convert(example_text),
                                     style=Style.TONE3,
                                     neutral_tone_with_five=True,
                                 )
+                                example_pinyin = []
+                                for item in example_pinyin_list:
+                                    if "{[" in item and "]}" in item:
+                                        example_pinyin += " ".join(item).split()
+                                    else:
+                                        example_pinyin.append(item)
                                 example_pinyin = " ".join(example_pinyin).lower()
+                                example_pinyin = example_pinyin.translate(
+                                    PUNCTUATION_TABLE
+                                )
                                 example_pinyin = example_pinyin.strip().replace(
                                     "v", "u:"
                                 )
@@ -319,12 +343,19 @@ def parse_file(filename, words):
                         for quote in definition["quote"]:
                             quote_text = re.sub(WHITESPACE_REGEX_PATTERN, "", quote)
 
-                            quote_pinyin = lazy_pinyin(
-                                " ".join(quote_text).split(),
+                            quote_pinyin_list = lazy_pinyin(
+                                converter.convert(quote_text),
                                 style=Style.TONE3,
                                 neutral_tone_with_five=True,
                             )
+                            quote_pinyin = []
+                            for item in quote_pinyin_list:
+                                if "{[" in item and "]}" in item:
+                                    quote_pinyin += " ".join(item).split()
+                                else:
+                                    quote_pinyin.append(item)
                             quote_pinyin = " ".join(quote_pinyin).lower()
+                            quote_pinyin = quote_pinyin.translate(PUNCTUATION_TABLE)
                             quote_pinyin = quote_pinyin.strip().replace("v", "u:")
 
                             phrase_pinyin = pin

--- a/src/dictionaries/moedict/requirements.txt
+++ b/src/dictionaries/moedict/requirements.txt
@@ -1,6 +1,6 @@
-hanziconv==0.3.2
 jieba==0.42.1
 msgpack==1.0.2
+opencc==1.1.6
 pinyin_jyutping_sentence==1.0
 pypinyin==0.43.0
 pypinyin-dict==0.1.0

--- a/src/dictionaries/tatoeba/parse.py
+++ b/src/dictionaries/tatoeba/parse.py
@@ -1,5 +1,5 @@
 import hanzidentifier
-from hanziconv import HanziConv
+import opencc
 from pypinyin import lazy_pinyin, Style
 from pypinyin_dict.phrase_pinyin_data import cc_cedict
 import pinyin_jyutping_sentence
@@ -9,6 +9,9 @@ from database import database, objects
 import collections
 import sqlite3
 import sys
+
+simplified_to_traditional_converter = opencc.OpenCC("s2hk.json")
+traditional_to_simplified_converter = opencc.OpenCC("t2s.json")
 
 
 def write(chinese_sentences, nonchinese_sentences, links, db_name):
@@ -99,16 +102,16 @@ def parse_sentence_file(
 
             if lang == source:
                 if hanzidentifier.is_simplified(sentence):
-                    trad = HanziConv.toTraditional(sentence)
+                    trad = simplified_to_traditional_converter.convert(sentence)
                     simp = sentence
                 else:
                     trad = sentence
-                    simp = HanziConv.toSimplified(sentence)
+                    simp = traditional_to_simplified_converter.convert(sentence)
                 pin = ""
                 if enable_pinyin:
                     pin = " ".join(
                         lazy_pinyin(
-                            trad, style=Style.TONE3, neutral_tone_with_five=True
+                            simp, style=Style.TONE3, neutral_tone_with_five=True
                         )
                     ).lower()
                     pin = pin.strip().replace("v", "u:")

--- a/src/dictionaries/tatoeba/requirements.txt
+++ b/src/dictionaries/tatoeba/requirements.txt
@@ -1,5 +1,5 @@
 hanzidentifier==1.0.2
-hanziconv==0.3.2
+opencc==1.1.6
 pypinyin==0.43.0
 pypinyin-dict==0.1.0
 pinyin_jyutping_sentence==1.0

--- a/src/dictionaries/two_shores_three_places/parse.py
+++ b/src/dictionaries/two_shores_three_places/parse.py
@@ -1,6 +1,6 @@
-from hanziconv import HanziConv
 from dragonmapper import transcriptions
 import jieba
+import opencc
 import pinyin_jyutping_sentence
 from pypinyin import lazy_pinyin, Style
 from pypinyin_dict.phrase_pinyin_data import cc_cedict
@@ -13,6 +13,8 @@ import csv
 import logging
 import sqlite3
 import sys
+
+converter = opencc.OpenCC("tw2s.json")
 
 
 def read_csv(filename):
@@ -120,7 +122,7 @@ def parse_same_meaning_file(filename, words):
         for location in terms:
             for term in terms[location]:
                 trad = term
-                simp = HanziConv.toSimplified(trad)
+                simp = converter.convert(trad)
                 if term == line[4] and line[2]:
                     # Use the provided pinyin, which always corresponds at least to the first Taiwan term
                     pin = transcriptions.zhuyin_to_pinyin(
@@ -128,7 +130,7 @@ def parse_same_meaning_file(filename, words):
                     )
                 else:
                     pin = lazy_pinyin(
-                        trad,
+                        simp,
                         style=Style.TONE3,
                         neutral_tone_with_five=True,
                     )
@@ -161,9 +163,9 @@ def parse_same_word_file(filename, words):
             continue
 
         trad = line[0]
-        simp = HanziConv.toSimplified(trad)
+        simp = converter.convert(trad)
         pin = lazy_pinyin(
-            trad,
+            simp,
             style=Style.TONE3,
             neutral_tone_with_five=True,
         )

--- a/src/dictionaries/two_shores_three_places/requirements.txt
+++ b/src/dictionaries/two_shores_three_places/requirements.txt
@@ -1,7 +1,7 @@
 dragonmapper==0.2.6
-hanziconv==0.3.2
 jieba==0.42.1
 msgpack==1.0.2
+opencc==1.1.6
 pinyin_jyutping_sentence==1.0
 pypinyin==0.43.0
 pypinyin-dict==0.1.0

--- a/src/dictionaries/words_hk/parse.py
+++ b/src/dictionaries/words_hk/parse.py
@@ -1,5 +1,5 @@
-from hanziconv import HanziConv
 import jieba
+import opencc
 from pypinyin import lazy_pinyin, Style
 from pypinyin_dict.phrase_pinyin_data import cc_cedict
 from wordfreq import zipf_frequency
@@ -43,6 +43,8 @@ NEAR_SYNONYM_REGEX = re.compile(r"\(sim:(.*?)\)")
 ANTONYM_REGEX = re.compile(r"\(ant:(.*?)\)")
 LINK_REGEX = re.compile(r"#(.*?)\s")
 
+converter = opencc.OpenCC("hk2s.json")
+
 
 def read_csv(filename):
     with open(filename) as csvfile:
@@ -58,7 +60,7 @@ def insert_example(c, definition_id, starting_example_id, example):
     examples_inserted = 0
 
     trad = example[0].content
-    simp = HanziConv.toSimplified(trad)
+    simp = converter.convert(trad)
     jyut = example[0].pron
     pin = ""
     lang = example[0].lang
@@ -195,9 +197,9 @@ def process_entry(line):
 
     for variant in variants:
         trad = variant.split(":")[0]
-        simp = HanziConv.toSimplified(trad)
+        simp = converter.convert(trad)
         pin = (
-            " ".join(lazy_pinyin(trad, style=Style.TONE3, neutral_tone_with_five=True))
+            " ".join(lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True))
             .lower()
             .replace("v", "u:")
         )

--- a/src/dictionaries/words_hk/requirements.txt
+++ b/src/dictionaries/words_hk/requirements.txt
@@ -1,6 +1,6 @@
-hanziconv==0.3.2
 jieba==0.42.1
 msgpack==1.0.2
+opencc==1.1.6
 pypinyin==0.43.0
 pypinyin-dict==0.1.0
 wordfreq==2.5.1


### PR DESCRIPTION
# Description

OpenCC handles conversion from simplified->traditional for phrases better than HanziConv. For example, 了 is almost always converted to 瞭 using HanziConv (which is incorrect, as 了 should only be converted to 瞭 in specific cases like 瞭解, 明瞭, etc.)

This commit switches simplified->traditional conversion and vice-versa to OpenCC.

Closes #88.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Generated all dictionaries using Python 3.11.1 on macOS.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
