### PR TITLE
#90: Modify search result list to show "-" when there are no pronunciation is available

### DIFF
--- a/src/jyut-dict/components/entrysearchresult/resultlistdelegate.cpp
+++ b/src/jyut-dict/components/entrysearchresult/resultlistdelegate.cpp
@@ -233,6 +233,9 @@ void ResultListDelegate::paint(QPainter *painter,
                                                   .c_str(),
                                               Qt::ElideRight,
                                               r.width());
+        if (phonetic.isEmpty()) {
+            phonetic = "-";
+        }
         painter->drawText(r, 0, phonetic, &boundingRect);
         r = r.adjusted(0, bodyFontSize + contentSpacingMargin / 2, 0, 0);
 

--- a/src/jyut-dict/logic/entry/entry.cpp
+++ b/src/jyut-dict/logic/entry/entry.cpp
@@ -345,7 +345,7 @@ std::string Entry::getPhonetic(EntryPhoneticOptions options,
             std::string cantonese = getCantonesePhonetic(cantoneseOptions);
             std::string mandarin = getMandarinPhonetic(mandarinOptions);
             if (cantonese.empty()) {
-                return "(" + mandarin + ")";
+                return mandarin.empty() ? "" : "(" + mandarin + ")";
             } else if (mandarin.empty()) {
                 return cantonese;
             } else {
@@ -356,7 +356,7 @@ std::string Entry::getPhonetic(EntryPhoneticOptions options,
             std::string cantonese = getCantonesePhonetic(cantoneseOptions);
             std::string mandarin = getMandarinPhonetic(mandarinOptions);
             if (mandarin.empty()) {
-                return "(" + cantonese + ")";
+                return cantonese.empty() ? "" : "(" + cantonese + ")";
             } else if (cantonese.empty()) {
                 return mandarin;
             } else {


### PR DESCRIPTION
# Description

Instead of showing "()" when there are no pronunciations available, show "-" in the search results list.

Closes #90.

Before:
<img width="800" alt="Screen Shot 2023-02-03 at 12 23 12 AM" src="https://user-images.githubusercontent.com/14353716/216519203-b8cb820d-389b-48d6-a287-e4ce2e45d470.png">

After:
<img width="800" alt="Screen Shot 2023-02-03 at 12 24 14 AM" src="https://user-images.githubusercontent.com/14353716/216519865-bbc51dd0-0b8b-4178-9546-44d122780ad2.png">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Built using Qt 5.15.2 on macOS Monterey.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
