### PR TITLE
#92: Add parsing script for CFDICT.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ CMakeLists.txt.user*
 **/cantodict/developer/*
 **/cedict/archive_*
 **/cedict/developer/*
+**/cfdict-xml/archive_*
+**/cfdict-xml/data/*
+**/cfdict-xml/developer/*
 **/cross_straits/archive_*
 **/cross_straits/data/*
 **/cross_straits/developer/*

--- a/src/dictionaries/cfdict-xml/README.md
+++ b/src/dictionaries/cfdict-xml/README.md
@@ -1,0 +1,12 @@
+#### Usage:
+- To install required packages: `pip install -r requirements.txt`
+- Data files for Cantonese Readings from Pleco are located in the `cedict/data` subdirectory – I recommend using `FULLREADINGS.txt`, as it contains Cantonese pronunciations from both `READINGS.txt` and `CC-CANTO.txt`.
+- Specific usage instructions for each script are provided by the scripts themselves.
+- **Run the script from the `dictionaries` folder, e.g. `python3 -m cfdict-xml.parse <database filename> <CFDICT.xml file> <Cantonese readings file> <source name> <source short name> <source version> <source description> <source legal> <source link> <source update url> <source contents>`.**
+
+#### Scripts:
+- `parse.py`
+  - This script generates a SQLite database file from the entries/definitions contained in a CEDICT-compatible XML format and readings from a Cantonese readings file created by `generate_readings.py`.
+  - The purpose of this script is to generate a database file for CFDICT where there is only one XML file containing entries and definitions, and no Cantonese readings are provided.
+  - **This script has been tested only with CFDICT. If you need to parse CEDICT, CC-CANTO, or HanDeDict, see instructions in the `cedict` directory.**
+  - A copy of CFDICT.xml may be downloaded from this site: https://chine.in/mandarin/dictionnaire/CFDICT/

--- a/src/dictionaries/cfdict-xml/parse.py
+++ b/src/dictionaries/cfdict-xml/parse.py
@@ -1,0 +1,175 @@
+from wordfreq import zipf_frequency
+
+from database import database, objects
+
+import logging
+import sqlite3
+import sys
+import xml.etree.ElementTree as ET
+
+def write(db_name, source, entries):
+    db = sqlite3.connect(db_name)
+    c = db.cursor()
+
+    # Set version of database
+    database.write_database_version(c)
+
+    # Delete old tables and indices, then create new one
+    database.drop_tables(c)
+    database.create_tables(c)
+
+    # Add sources to table
+    database.insert_source(
+        c,
+        source.name,
+        source.shortname,
+        source.version,
+        source.description,
+        source.legal,
+        source.link,
+        source.update_url,
+        source.other,
+        None,
+    )
+
+    for key in entries:
+        for entry in entries[key]:
+            entry_id = database.get_entry_id(
+                c,
+                entry.traditional,
+                entry.simplified,
+                entry.pinyin,
+                entry.jyutping if entry.jyutping != "" else entry.fuzzy_jyutping,
+                entry.freq,
+            )
+
+            if entry_id == -1:
+                entry_id = database.insert_entry(
+                    c,
+                    entry.traditional,
+                    entry.simplified,
+                    entry.pinyin,
+                    entry.jyutping if entry.jyutping != "" else entry.fuzzy_jyutping,
+                    entry.freq,
+                )
+                if entry_id == -1:
+                    logging.error(f"Could not insert word {entry.traditional}, uh oh!")
+                    continue
+
+            for definition in entry.definitions:
+                definition_id = database.insert_definition(
+                    c, definition, "", entry_id, 1, None
+                )
+                if definition_id == -1:
+                    logging.error(
+                        f"Could not insert definition {definition} for word {entry.traditional}, uh oh!"
+                    )
+                    continue
+
+    database.generate_indices(c)
+
+    db.commit()
+    db.close()
+
+
+def parse_file(filename, entries):
+    tree = ET.parse(filename)
+    root = tree.getroot()
+    for word in root:
+        definitions = []
+        for attrib in word:
+            match attrib.tag:
+                case "trad":
+                    trad = attrib.text
+                case "simp":
+                    simp = attrib.text
+                case "py":
+                    pin = attrib.text.lower()
+                case "trans":
+                    for translation in attrib:
+                        definitions.append(translation.text)
+                case "id" | "upd":
+                    pass
+                case other:
+                    print(f"another attrib found, tag: {attrib.tag}")
+        entry = objects.Entry(trad=trad, simp=simp, pin=pin, defs=definitions)
+        if trad in entries:
+            entries[trad].append(entry)
+        else:
+            entries[trad] = [entry]
+
+
+def parse_cc_cedict_canto_readings(filename, entries):
+    with open(filename, "r", encoding="utf8") as f:
+        for line in f:
+            if len(line) == 0 or line[0] == "#":
+                continue
+
+            split = line.split()
+            trad = split[0]
+            simp = split[1]
+            pin = "".join(
+                line[line.index("[") + 1 : line.index("]")].lower().split()
+            ).replace("v", "u:")
+            jyut = line[line.index("{") + 1 : line.index("}")].lower()
+            if trad not in entries:
+                continue
+
+            for entry in entries[trad]:
+                # If it's an exact match, then set jyutping
+                if entry.simplified == simp and "".join(entry.pinyin.split()) == pin:
+                    entry.add_jyutping(jyut)
+                # Otherwise, add as fuzzy
+                else:
+                    entry.add_fuzzy_jyutping(jyut)
+
+
+def assign_frequencies(entries):
+    for key in entries:
+        for entry in entries[key]:
+            freq = zipf_frequency(entry.traditional, "zh")
+            entry.add_freq(freq)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 12:
+        print(
+            (
+                "Usage: python3 script.py <database filename> "
+                "<CFDICT.xml file> <Cantonese readings file> "
+                "<source name> <source short name> "
+                "<source version> <source description> <source legal> "
+                "<source link> <source update url> <source contents>"
+            )
+        )
+        print(
+            (
+                "e.g. python3 script.py dict.db CFDICT.xml READINGS.txt "
+                'CFDICT-2016 CF2016 2016-01-17 "En 2010, David Houstin, '
+                'fondateur de CHINE INFORMATIONS, a commencé à partager '
+                'librement une partie de la base de données son dictionnaire '
+                'français-chinois en ligne." '
+                '"Cette création est mise à disposition sous un contrat '
+                'Creative Commons Paternité - Partage des Conditions Initiales '
+                'à l\'Identique." '
+                '"http://www.mdbg.net/chindict/chindict.php?page=cc-cedict" '
+                '"https://chine.in/mandarin/dictionnaire/CFDICT/" "" "words"'
+            )
+        )
+        sys.exit(1)
+
+    entries = {}
+    source = objects.SourceTuple(
+        sys.argv[4],
+        sys.argv[5],
+        sys.argv[6],
+        sys.argv[7],
+        sys.argv[8],
+        sys.argv[9],
+        sys.argv[10],
+        sys.argv[11],
+    )
+    parse_file(sys.argv[2], entries)
+    parse_cc_cedict_canto_readings(sys.argv[3], entries)
+    assign_frequencies(entries)
+    write(sys.argv[1], source, entries)

--- a/src/dictionaries/cfdict-xml/parse.py
+++ b/src/dictionaries/cfdict-xml/parse.py
@@ -7,6 +7,7 @@ import sqlite3
 import sys
 import xml.etree.ElementTree as ET
 
+
 def write(db_name, source, entries):
     db = sqlite3.connect(db_name)
     c = db.cursor()
@@ -146,12 +147,12 @@ if __name__ == "__main__":
             (
                 "e.g. python3 script.py dict.db CFDICT.xml READINGS.txt "
                 'CFDICT-2016 CF2016 2016-01-17 "En 2010, David Houstin, '
-                'fondateur de CHINE INFORMATIONS, a commencé à partager '
-                'librement une partie de la base de données son dictionnaire '
+                "fondateur de CHINE INFORMATIONS, a commencé à partager "
+                "librement une partie de la base de données son dictionnaire "
                 'français-chinois en ligne." '
                 '"Cette création est mise à disposition sous un contrat '
-                'Creative Commons Paternité - Partage des Conditions Initiales '
-                'à l\'Identique." '
+                "Creative Commons Paternité - Partage des Conditions Initiales "
+                "à l'Identique.\" "
                 '"http://www.mdbg.net/chindict/chindict.php?page=cc-cedict" '
                 '"https://chine.in/mandarin/dictionnaire/CFDICT/" "" "words"'
             )

--- a/src/dictionaries/cfdict-xml/requirements.txt
+++ b/src/dictionaries/cfdict-xml/requirements.txt
@@ -1,0 +1,2 @@
+jieba==0.42.1
+wordfreq==2.5.1


### PR DESCRIPTION
# Description

This commit adds a script to parse CFDICT's XML format. A version of the pre-2017 CFDICT is available online in the XML format.

Closes #92.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
Built and run using Python 3.11.1 on macOS. Generated database without any problems.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
