### PR TITLE
#23: Add ability to search using Unix glob characters

### DIFF
--- a/src/jyut-dict/components/entryview/entryviewsentencecardsection.cpp
+++ b/src/jyut-dict/components/entryview/entryviewsentencecardsection.cpp
@@ -175,7 +175,9 @@ void EntryViewSentenceCardSection::setEntry(const Entry &entry)
     _showLoadingIconTimer->start();
 
     // Actually start searching for sentences
-    _search->searchTraditionalSentences(entry.getTraditional().c_str());
+    _search->searchTraditionalSentences(QString{entry.getTraditional().c_str()}
+                                            .replace("%", "\\%")
+                                            .replace("_", "\\_"));
     _title = entry
                  .getCharactersNoSecondary(
                      Settings::getSettings()

--- a/src/jyut-dict/logic/search/sqlsearch.cpp
+++ b/src/jyut-dict/logic/search/sqlsearch.cpp
@@ -1129,7 +1129,7 @@ void SQLSearch::searchTraditionalSentencesThread(const QString &searchTerm,
         "WITH matching_chinese_sentence_ids AS ( "
         "  SELECT chinese_sentence_id "
         "  FROM chinese_sentences "
-        "  WHERE traditional LIKE ? "
+        "  WHERE traditional LIKE ? ESCAPE '\\'"
         "), "
         " "
         //// Get translations for each of the sentence

--- a/src/jyut-dict/logic/search/sqlsearch.cpp
+++ b/src/jyut-dict/logic/search/sqlsearch.cpp
@@ -190,10 +190,8 @@ void SQLSearch::runThread(void (SQLSearch::*threadFunction)(const QString &searc
 // NOTE: If you are modifying these functions, you may also want to modify
 // the search functions in SQLUserDataUtils.cpp as well!
 
-// For SearchSimplified and SearchTraditional, we use LIKE instead of MATCH
-// even though the database is FTS5-compatible.
-// This is because FTS searches using the space as a separator, and
-// Chinese words and phrases are not separated by spaces.
+// For searching simplified and traditional, we use GLOB, so that wildcard
+// characters like * and ? can be used.
 void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
                                        const unsigned long long queryID)
 {
@@ -204,9 +202,14 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
                              || (searchTerm.startsWith("”")
                                  && searchTerm.endsWith("“")))
                             && searchTerm.length() >= 3;
+    bool dontAppendWildcard = searchTerm.at(searchTerm.size() - 1) == "$";
+
     QString searchTermWithoutQuotes;
+    QString searchTermWithoutEndPositionMarker;
     if (searchExactMatch) {
         searchTermWithoutQuotes = searchTerm.mid(1, searchTerm.size() - 2);
+    } else if (dontAppendWildcard) {
+        searchTermWithoutEndPositionMarker = searchTerm.chopped(1);
     }
 
     std::vector<Entry> results;
@@ -215,7 +218,7 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
     query.prepare(
         //// Get list of entry ids whose simplified form matches the query
         "WITH matching_entry_ids AS ( "
-        "  SELECT rowid FROM entries WHERE simplified LIKE ?"
+        "  SELECT rowid FROM entries WHERE simplified GLOB ?"
         "), "
         " "
         //// Get the list of all definitions for those entries
@@ -323,10 +326,11 @@ void SQLSearch::searchSimplifiedThread(const QString &searchTerm,
         "SELECT simplified, traditional, jyutping, pinyin, definitions FROM "
         "  matching_entries");
     if (searchExactMatch) {
-        // Don't need to add wildcard character if searching exact!
         query.addBindValue(searchTermWithoutQuotes);
+    } else if (dontAppendWildcard) {
+        query.addBindValue(searchTermWithoutEndPositionMarker);
     } else {
-        query.addBindValue(searchTerm + "%");
+        query.addBindValue(searchTerm + "*");
     }
     query.exec();
 
@@ -350,9 +354,14 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
                              || (searchTerm.startsWith("“")
                                  && searchTerm.endsWith("”")))
                             && searchTerm.length() >= 3;
+    bool dontAppendWildcard = searchTerm.at(searchTerm.size() - 1) == "$";
+
     QString searchTermWithoutQuotes;
+    QString searchTermWithoutEndPositionMarker;
     if (searchExactMatch) {
         searchTermWithoutQuotes = searchTerm.mid(1, searchTerm.size() - 2);
+    } else if (dontAppendWildcard) {
+        searchTermWithoutEndPositionMarker = searchTerm.chopped(1);
     }
 
     std::vector<Entry> results;
@@ -361,7 +370,7 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
     query.prepare(
         //// Get list of entry ids whose traditional form matches the query
         "WITH matching_entry_ids AS ( "
-        "  SELECT rowid FROM entries WHERE traditional LIKE ?"
+        "  SELECT rowid FROM entries WHERE traditional GLOB ?"
         "), "
         " "
         //// Get the list of all definitions for those entries
@@ -470,8 +479,10 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
         "  matching_entries");
     if (searchExactMatch) {
         query.addBindValue(searchTermWithoutQuotes);
+    } else if (dontAppendWildcard) {
+        query.addBindValue(searchTermWithoutEndPositionMarker);
     } else {
-        query.addBindValue(searchTerm + "%");
+        query.addBindValue(searchTerm + "*");
     }
     query.exec();
 
@@ -485,13 +496,8 @@ void SQLSearch::searchTraditionalThread(const QString &searchTerm,
     notifyObserversIfQueryIdCurrent(results, /*emptyQuery=*/false, queryID);
 }
 
-// For searching jyutping and pinyin, we use MATCH and then LIKE, in order
-// to take advantage of the quick full-text-search matching, before then
-// filtering the results to only those that begin with the query
-// using a LIKE wildcard.
-//
-// This approach is approximately ten times faster than simply using the LIKE
-// operator and the % wildcard.
+// For searching Jyutping and Pinyin, we use GLOB, so that wildcard characters
+// like * and ? can be used.
 //
 // !NOTE! Using QSQLQuery's positional placeholder method automatically
 // surrounds the bound value with single quotes, i.e. "'". There is no need
@@ -506,13 +512,18 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
     bool searchExactMatch = searchTerm.at(0) == "\""
                             && searchTerm.at(searchTerm.size() - 1) == "\""
                             && searchTerm.length() >= 3;
+    bool dontAppendWildcard = searchTerm.at(searchTerm.size() - 1) == "$";
+
     std::vector<std::string> jyutpingWords;
     if (searchExactMatch) {
         QString searchTermWithoutQuotes = searchTerm.mid(1,
                                                          searchTerm.size() - 2);
         Utils::split(searchTermWithoutQuotes.toStdString(), ' ', jyutpingWords);
     } else {
-        jyutpingWords = ChineseUtils::segmentJyutping(searchTerm);
+        jyutpingWords
+            = ChineseUtils::segmentJyutping(searchTerm,
+                                            /* removeSpecialCharacters */ true,
+                                            /* removeGlobCharacters */ false);
     }
 
     std::vector<Entry> results;
@@ -521,8 +532,7 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
     query.prepare(
         //// Get list of entry ids whose jyutping starts with the queried string
         "WITH matching_entry_ids AS ( "
-        "  SELECT rowid FROM entries_fts WHERE entries_fts MATCH ? AND "
-        "    jyutping LIKE ?"
+        "  SELECT rowid FROM entries WHERE jyutping GLOB ?"
         "), "
         " "
         //// Get the list of all definitions for those entries
@@ -630,21 +640,15 @@ void SQLSearch::searchJyutpingThread(const QString &searchTerm,
         "SELECT simplified, traditional, jyutping, pinyin, definitions FROM "
         "  matching_entries");
 
-    // Don't add wildcard characters to either the MATCH term or the LIKE term
-    // if searching for exact match
-    const char *matchJoinDelimiter = searchExactMatch ? "" : "*";
-    std::string matchTerm
+    // Don't add wildcard characters to GLOB term if searching for exact match
+    const char *globJoinDelimiter = searchExactMatch ? "" : "?";
+    std::string globTerm
         = ChineseUtils::constructRomanisationQuery(jyutpingWords,
-                                                   matchJoinDelimiter,
-                                                   /*surroundWithQuotes=*/true);
-    const char *likeJoinDelimiter = searchExactMatch ? "" : "_";
-    std::string likeTerm
-        = ChineseUtils::constructRomanisationQuery(jyutpingWords,
-                                                   likeJoinDelimiter);
+                                                   globJoinDelimiter);
 
-    query.addBindValue("jyutping:" + QString{matchTerm.c_str()});
-    query.addBindValue(QString{likeTerm.c_str()}
-                       + QString{searchExactMatch ? "" : "%"});
+    query.addBindValue(
+        QString{globTerm.c_str()}
+        + QString{(searchExactMatch || dontAppendWildcard) ? "" : "*"});
     query.exec();
 
     // Do not parse results if new query has been made
@@ -679,6 +683,7 @@ void SQLSearch::searchPinyinThread(const QString &searchTerm,
                                                       - 1)
                                    == "\""
                             && processedSearchTerm.length() >= 3;
+    bool dontAppendWildcard = searchTerm.at(searchTerm.size() - 1) == "$";
 
     std::vector<std::string> pinyinWords;
     if (searchExactMatch) {
@@ -686,7 +691,10 @@ void SQLSearch::searchPinyinThread(const QString &searchTerm,
             = processedSearchTerm.mid(1, processedSearchTerm.size() - 2);
         Utils::split(searchTermWithoutQuotes.toStdString(), ' ', pinyinWords);
     } else {
-        pinyinWords = ChineseUtils::segmentPinyin(processedSearchTerm);
+        pinyinWords
+            = ChineseUtils::segmentPinyin(processedSearchTerm,
+                                          /* removeSpecialCharacters */ true,
+                                          /* removeGlobCharacters */ false);
     }
 
     std::vector<Entry> results;
@@ -695,8 +703,7 @@ void SQLSearch::searchPinyinThread(const QString &searchTerm,
     query.prepare(
         //// Get list of entry ids whose pinyin starts with the queried string
         "WITH matching_entry_ids AS ( "
-        "  SELECT rowid FROM entries_fts WHERE entries_fts MATCH ? AND "
-        "    pinyin LIKE ? "
+        "  SELECT rowid FROM entries WHERE pinyin GLOB ?"
         "), "
         " "
         //// Get the list of all definitions for those entries
@@ -802,19 +809,16 @@ void SQLSearch::searchPinyinThread(const QString &searchTerm,
         " "
         "SELECT simplified, traditional, jyutping, pinyin, definitions FROM "
         "  matching_entries");
-    const char *matchJoinDelimiter = searchExactMatch ? "" : "*";
-    std::string matchTerm
+
+    // Don't add wildcard characters to GLOB term if searching for exact match
+    const char *globJoinDelimiter = searchExactMatch ? "" : "?";
+    std::string globTerm
         = ChineseUtils::constructRomanisationQuery(pinyinWords,
-                                                   matchJoinDelimiter,
-                                                   /*surroundWithQuotes=*/true);
-    const char *likeJoinDelimiter = searchExactMatch ? "" : "_";
-    std::string likeTerm
-        = ChineseUtils::constructRomanisationQuery(pinyinWords,
-                                                   likeJoinDelimiter,
-                                                   /*surroundWithQuotes=*/false);
-    query.addBindValue("pinyin:" + QString{matchTerm.c_str()});
-    query.addBindValue(QString{likeTerm.c_str()}
-                       + QString{searchExactMatch ? "" : "%"});
+                                                   globJoinDelimiter);
+
+    query.addBindValue(
+        QString{globTerm.c_str()}
+        + QString{(searchExactMatch || dontAppendWildcard) ? "" : "*"});
     query.exec();
 
     // Do not parse results if new query has been made

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -1360,10 +1360,12 @@ std::vector<std::string> segmentPinyin(const QString &string,
                 words.push_back(stringToExamine.toStdString());
             } else if (!removeGlobCharacters && isGlobCharacter) {
                 // Since whitespace matters for glob characters, consume the
-                // next or previous whitespace if it exists.
+                // next or previous whitespace if it exists (and was not
+                // already consumed by another glob character).
                 int new_end_index = end_index;
                 int length = 1;
-                if ((end_index >= 1) && (string.at(end_index - 1) == " ")) {
+                if ((end_index >= 1) && (string.at(end_index - 1) == " ")
+                    && words.back().back() != ' ') {
                     // Add preceding whitespace to this word
                     new_end_index--;
                     length++;
@@ -1499,10 +1501,12 @@ std::vector<std::string> segmentJyutping(const QString &string,
                 words.push_back(stringToExamine.toStdString());
             } else if (!removeGlobCharacters && isGlobCharacter) {
                 // Since whitespace matters for glob characters, consume the
-                // next or previous whitespace if it exists.
+                // next or previous whitespace if it exists (and was not
+                // already consumed by another glob character).
                 int new_end_index = end_index;
                 int length = 1;
-                if ((end_index >= 1) && (string.at(end_index - 1) == " ")) {
+                if ((end_index >= 1) && (string.at(end_index - 1) == " ")
+                    && words.back().back() != ' ') {
                     // Add preceding whitespace to this word
                     new_end_index--;
                     length++;

--- a/src/jyut-dict/logic/utils/utils.cpp
+++ b/src/jyut-dict/logic/utils/utils.cpp
@@ -1,5 +1,6 @@
 #include "utils.h"
 
+#include <regex>
 #include <sstream>
 #include <string>
 
@@ -36,5 +37,12 @@ namespace Utils {
             previous = current + delimiter.length();
         }
         result.push_back(string.substr(previous));
+    }
+
+    void trim(const std::string &string, std::string &result)
+    {
+        result = std::regex_replace(string,
+                                    std::regex("^\\s+|\\s+$|(\\s)\\s+"),
+                                    "$1");
     }
 }

--- a/src/jyut-dict/logic/utils/utils.h
+++ b/src/jyut-dict/logic/utils/utils.h
@@ -91,6 +91,8 @@ namespace Utils {
     void split(const std::string &string,
                const std::string delimiter,
                std::vector<std::string> &result);
+
+    void trim(const std::string &string, std::string &result);
 }
 
 #endif // UTILS_H


### PR DESCRIPTION
# Description

This commit adds the ability to search in Simplified, Traditional, Jyutping, and Pinyin using Unix glob characters + a character to specify "end of phrase". This includes "*" for zero or more characters, "?" for a single character, and "$" to specify the end of a phrase (as inspired by regex).

This commit is a prerequisite for #23.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Jyut Dictionary has been built on macOS 12.3.1 Monterey, Windows 11, and Pop!_OS 22.04 using Qt 5.15.2.

Various tests include:
- ChineseUtils::constructRomanisationQuery:
  - Testing that space is preserved after a wildcard character: `* in` is converted to `* in?` when searching using Jyutping
  - Testing that no spaces are inserted after a wildcard character if it was not in the query: `*in` is converted to `*in?` when searching using Jyutping
  - Testing that no spaces are inserted before a wildcard character if it was not in the query: `i*` is converted to `i*` when searching using Jyutping
  - Testing that space is preserved before a wildcard character: `i *` is converted to `i? *` when searching using Jyutping
  - Testing that the single-character wildcard is correctly inserted after a syllable when syllable is followed by space and more wildcard characters: `i ???` is converted to `i? ???` when searching using Jyutping
  - Testing that wildcard characters separated by a space don't have extra spaces inserted between them: `* ?at6` is converted to `* ?at6` when searching using Jyutping
- When searching with the "end of phrase" character, the "end of phrase" character is not passed to the actual query. 

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
