### PR TITLE
Address parsing issues

### DIFF
--- a/src/dictionaries/aby/parse.py
+++ b/src/dictionaries/aby/parse.py
@@ -120,7 +120,8 @@ def insert_words(c, words):
     #   - 3000000000-3999999999: MoEDict
     #   - 4000000000-4999999999: Cross-Straits Dictionary
     #   - 5000000000-5999999999: ABC Chinese-English Dictionary
-    example_id = 5000000000
+    #   - 6000000000-6999999999: ABC Cantonese-English Dictionary
+    example_id = 6000000000
 
     for key in words:
         for entry in words[key]:

--- a/src/dictionaries/cantodict/parse.py
+++ b/src/dictionaries/cantodict/parse.py
@@ -320,7 +320,7 @@ def parse_word_file(file_name, words):
         jyut = jyut_element.get_text() if jyut_element else ""
         jyut = LITERARY_CANTONESE_READING_REGEX_PATTERN.sub("", jyut)
         jyut = LITERARY_CANTONESE_READING_REGEX_PATTERN_VARIANT.sub("\g<2>", jyut)
-        jyut = jyut.replace("  ", " ") # Remove double-spaces
+        jyut = jyut.replace("  ", " ")  # Remove double-spaces
         jyut = jyut.strip()
 
         pin_element = soup.find("span", class_="cardpinyin")
@@ -335,7 +335,7 @@ def parse_word_file(file_name, words):
         pin = pin.strip().replace("v", "u:")
         # Remove the zero-width spaces that sometimes show up
         pin = pin.replace("​", "")
-        pin = pin.replace("  ", " ") # Remove double-spaces
+        pin = pin.replace("  ", " ")  # Remove double-spaces
 
         # CantoDict may have multiple pronunciations for an entry
         # Check for multiple pronunciations in Jyutping

--- a/src/dictionaries/cantodict/parse.py
+++ b/src/dictionaries/cantodict/parse.py
@@ -319,6 +319,7 @@ def parse_word_file(file_name, words):
         jyut = jyut_element.get_text() if jyut_element else ""
         jyut = LITERARY_CANTONESE_READING_REGEX_PATTERN.sub("", jyut)
         jyut = LITERARY_CANTONESE_READING_REGEX_PATTERN_VARIANT.sub("\g<2>", jyut)
+        jyut = jyut.replace("  ", " ") # Remove double-spaces
         jyut = jyut.strip()
 
         pin_element = soup.find("span", class_="cardpinyin")
@@ -333,6 +334,7 @@ def parse_word_file(file_name, words):
         pin = pin.strip().replace("v", "u:")
         # Remove the zero-width spaces that sometimes show up
         pin = pin.replace("​", "")
+        pin = pin.replace("  ", " ") # Remove double-spaces
 
         # CantoDict may have multiple pronunciations for an entry
         # Check for multiple pronunciations in Jyutping

--- a/src/dictionaries/cantodict/parse.py
+++ b/src/dictionaries/cantodict/parse.py
@@ -32,6 +32,7 @@ import sys
 #   - 卡拉OK has latin script in the entry
 #   - AA制 starts with latin script
 #   - 蛇 gwe has an extra space at the end of the entry name
+#   - 节哀顺变 has double spaces in its Jyutping
 #   - 犄角 has zero-width spaces in its Pinyin
 #   - 購 has multiple pronunciations in Jyutping
 #   - 垃圾 has Taiwan/PRC differences in pronunciation (Taiwan first)

--- a/src/dictionaries/cross_straits/parse.py
+++ b/src/dictionaries/cross_straits/parse.py
@@ -246,6 +246,9 @@ def parse_file(filename, words):
                     # Remove dashes in pinyin
                     pins = list(map(lambda x: x.replace("-", " "), pins))
 
+                    # Remove apostrophes in pinyin
+                    pins = list(map(lambda x: x.replace("'", " "), pins))
+
                     # Remove commas in pinyin
                     pins = list(map(lambda x: x.replace(",", ""), pins))
 

--- a/src/dictionaries/cross_straits/parse.py
+++ b/src/dictionaries/cross_straits/parse.py
@@ -23,6 +23,7 @@ import unicodedata
 #   - 歛: multiple heteronyms, labels for definitions
 #   - 穀: some duplicate definitions (姓。) and has labels for literary use (〈書〉)
 #   - 横征暴敛: Pinyin has dashes in it (bad!)
+#   - 节哀顺变: has apostrophes in the Pinyin
 #   - 空橋: contains 陸⃝ in the definition
 #   - 空擋: contains 臺⃝ in the definition
 #   - 空濛: has a literary definition


### PR DESCRIPTION
# Description

This commit fixes three issues in source parsing:
- Cantodict has some Jyutping with double space (such as 節哀順變), that cause it to be incorrectly classified as a separate entry.
- ABC Cantonese-English dictionary has the wrong sentence IDs, so it clobbers some of ABC Chinese-English dictionary sentence IDs.
- CSLD (Cross Straits Language Database) has some pinyin that use a single apostrophe (') to indicate syllable breaks, like 節哀順變. These should be removed from the Pinyin.

Closes #102.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Built CSLD, Cantodict, and ABC Cantonese-English dictionary using Python 3.11 on macOS 12.3.1. Manually verified that bugs were fixed.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
