### PR TITLE
#104: Mark filepaths to be ignored by Github Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+docs/* -linguist-documentation
+
+src/jyut-dict/platform/linux/deb/debian/jyutdict.cron.d.ex -linguist-detectable
+src/jyut-dict/platform/linux/deb/debian/jyutdict.doc-base.EX -linguist-detectable
+src/jyut-dict/platform/linux/deb/debian/manpage.xml.ex -linguist-detectable
+src/jyut-dict/platform/linux/deb/debian/menu.ex -linguist-detectable
+src/jyut-dict/platform/linux/deb/debian/watch.ex -linguist-detectable


### PR DESCRIPTION
# Description

Some filepaths aren't actually code (like many of the .ex files that Linguist detects as Elixir or Euphoria). This commits prevents those files from being detected by Linguist.

Closes #103.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran Github Linguist locally using ruby 3.0.2p107 on Pop!_OS 22.04. Confirmed that files were banished.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
