### PR TITLE
#109: Adjust interface whenever settings are changed, instead of on repaint

### DIFF
--- a/src/jyut-dict/components/definitioncard/definitioncardwidget.cpp
+++ b/src/jyut-dict/components/definitioncard/definitioncardwidget.cpp
@@ -51,6 +51,7 @@ void DefinitionCardWidget::changeEvent(QEvent *event)
 void DefinitionCardWidget::setEntry(const DefinitionsSet &definitionsSet)
 {
     _source = definitionsSet.getSourceShortString();
+
     _definitionHeaderWidget->setSectionTitle(
         QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                     Strings::DEFINITIONS_ALL_CAPS)

--- a/src/jyut-dict/components/definitioncard/definitioncontentwidget.cpp
+++ b/src/jyut-dict/components/definitioncard/definitioncontentwidget.cpp
@@ -143,17 +143,15 @@ void DefinitionContentWidget::setEntry(const std::vector<Definition::Definition>
                                   MandarinOptions::PRETTY_PINYIN))
                       .value<MandarinOptions>();
 
-            QString cantonese = QString{definitions[i]
-                                            .sentences[j]
-                                            .getCantonesePhonetic(
-                                                cantoneseOptions)
-                                            .c_str()}
-                                    .trimmed();
-            QString mandarin = QString{definitions[i]
-                                           .sentences[j]
-                                           .getMandarinPhonetic(mandarinOptions)
-                                           .c_str()}
-                                   .trimmed();
+            SourceSentence sentence = definitions[i].sentences[j];
+            sentence.generatePhonetic(cantoneseOptions, mandarinOptions);
+
+            QString cantonese
+                = QString{sentence.getCantonesePhonetic(cantoneseOptions).c_str()}
+                      .trimmed();
+            QString mandarin
+                = QString{sentence.getMandarinPhonetic(mandarinOptions).c_str()}
+                      .trimmed();
 
             switch (Settings::getSettings()
                         ->value("Preview/phoneticOptions",

--- a/src/jyut-dict/components/entrysearchresult/resultlistdelegate.cpp
+++ b/src/jyut-dict/components/entrysearchresult/resultlistdelegate.cpp
@@ -284,47 +284,20 @@ QSize ResultListDelegate::sizeHint(const QStyleOptionViewItem &option,
             }
         }
         case Settings::InterfaceSize::NORMAL: {
-            switch (Settings::getCurrentLocale().language()) {
-            case QLocale::French: {
-                return QSize(100, 150);
-            }
-            case QLocale::Chinese: {
-                return QSize(100, 150);
-            }
-            case QLocale::Cantonese: {
-                return QSize(100, 150);
-            }
-            default: {
-                return QSize(100, 130);
-            }
-            }
+            return QSize(100, 150);
         }
         case Settings::InterfaceSize::LARGE: {
             switch (Settings::getCurrentLocale().language()) {
-            case QLocale::Chinese: {
-                return QSize(100, 170);
-            }
             case QLocale::French: {
                 return QSize(100, 190);
             }
             default: {
-                return QSize(100, 165);
+                return QSize(100, 170);
             }
             }
         }
         case Settings::InterfaceSize::LARGER: {
-            switch (Settings::getCurrentLocale().language()) {
-            case QLocale::Chinese: {
-                return QSize(100, 215);
-            }
-            case QLocale::Cantonese:
-            case QLocale::French: {
-                return QSize(100, 215);
-            }
-            default: {
-                return QSize(100, 190);
-            }
-            }
+            return QSize(100, 215);
         }
         }
 #elif defined(Q_OS_LINUX)

--- a/src/jyut-dict/components/entryview/entrycontentwidget.cpp
+++ b/src/jyut-dict/components/entryview/entrycontentwidget.cpp
@@ -88,6 +88,9 @@ EntryContentWidget::EntryContentWidget(
 
 void EntryContentWidget::setEntry(const Entry &entry)
 {
+    _entry = entry;
+    _entryIsValid = true;
+
     _definitionSection->setEntry(entry);
     _sentenceSection->setEntry(entry);
     _relatedSection->setEntry(entry);
@@ -128,6 +131,13 @@ void EntryContentWidget::showRelatedSection(void)
 
 void EntryContentWidget::updateStyleRequested(void)
 {
+    if (_entryIsValid) {
+        // For some reason, setting the entry here makes the application not
+        // flash when updating the style. Setting it in the individual definition
+        // cards does.
+        _definitionSection->setEntry(_entry);
+    }
+
     _definitionSection->updateStyleRequested();
     _sentenceSection->updateStyleRequested();
     _relatedSection->updateStyleRequested();

--- a/src/jyut-dict/components/entryview/entrycontentwidget.cpp
+++ b/src/jyut-dict/components/entryview/entrycontentwidget.cpp
@@ -132,10 +132,12 @@ void EntryContentWidget::showRelatedSection(void)
 void EntryContentWidget::updateStyleRequested(void)
 {
     if (_entryIsValid) {
+        bool relatedSectionIsVisible = _relatedSection->isVisible();
         // For some reason, setting the entry here makes the application not
         // flash when updating the style. Setting it in the individual definition
         // cards does.
         _definitionSection->setEntry(_entry);
+        _relatedSection->setVisible(relatedSectionIsVisible);
     }
 
     _definitionSection->updateStyleRequested();

--- a/src/jyut-dict/components/entryview/entrycontentwidget.h
+++ b/src/jyut-dict/components/entryview/entrycontentwidget.h
@@ -25,6 +25,9 @@ public:
     void setEntry(const Entry &entry);
 
 private:
+    Entry _entry;
+    bool _entryIsValid = false;
+
     QVBoxLayout *_entryContentLayout;
     DefinitionCardSection *_definitionSection;
     EntryViewSentenceCardSection *_sentenceSection;

--- a/src/jyut-dict/components/entryview/entryscrollareawidget.cpp
+++ b/src/jyut-dict/components/entryview/entryscrollareawidget.cpp
@@ -143,6 +143,11 @@ void EntryScrollAreaWidget::setStyle(bool use_dark)
 
 void EntryScrollAreaWidget::updateStyleRequested(void)
 {
+    if (_entryIsValid) {
+        _entry.refreshColours();
+        _entryHeaderWidget->setEntry(_entry);
+    }
+
     QEvent event{QEvent::PaletteChange};
     QCoreApplication::sendEvent(_entryHeaderWidget, &event);
     QCoreApplication::sendEvent(_entryActionWidget, &event);

--- a/src/jyut-dict/components/entryview/entryscrollareawidget.cpp
+++ b/src/jyut-dict/components/entryview/entryscrollareawidget.cpp
@@ -2,6 +2,7 @@
 
 #include "components/entryview/entryscrollarea.h"
 #include "components/magnifywindow/magnifyscrollarea.h"
+#include "logic/settings/settingsutils.h"
 #ifdef Q_OS_MAC
 #include "logic/utils/utils_mac.h"
 #elif defined (Q_OS_LINUX)
@@ -21,6 +22,8 @@ EntryScrollAreaWidget::EntryScrollAreaWidget(
     , _manager{manager}
 {
     setObjectName("EntryScrollAreaWidget");
+
+    _settings = Settings::getSettings(this);
 
     // Entire Scroll Area
     _scrollAreaLayout = new QGridLayout{this};
@@ -144,7 +147,23 @@ void EntryScrollAreaWidget::setStyle(bool use_dark)
 void EntryScrollAreaWidget::updateStyleRequested(void)
 {
     if (_entryIsValid) {
-        _entry.refreshColours();
+        _entry.refreshColours(
+            _settings
+                ->value("entryColourPhoneticType",
+                        QVariant::fromValue(EntryColourPhoneticType::CANTONESE))
+                .value<EntryColourPhoneticType>());
+
+        CantoneseOptions cantoneseOptions
+            = _settings
+                  ->value("Entry/cantonesePronunciationOptions",
+                          QVariant::fromValue(CantoneseOptions::RAW_JYUTPING))
+                  .value<CantoneseOptions>();
+        MandarinOptions mandarinOptions
+            = _settings
+                  ->value("Entry/mandarinPronunciationOptions",
+                          QVariant::fromValue(MandarinOptions::PRETTY_PINYIN))
+                  .value<MandarinOptions>();
+        _entry.generatePhonetic(cantoneseOptions, mandarinOptions);
         _entryHeaderWidget->setEntry(_entry);
     }
 

--- a/src/jyut-dict/components/entryview/entryscrollareawidget.h
+++ b/src/jyut-dict/components/entryview/entryscrollareawidget.h
@@ -8,6 +8,7 @@
 
 #include <QEvent>
 #include <QGridLayout>
+#include <QSettings>
 #include <QWidget>
 
 // The DefinitionScrollAreaWidget is the widget that contains other widgets
@@ -32,6 +33,7 @@ private:
 
     std::shared_ptr<SQLUserDataUtils> _sqlUserUtils;
     std::shared_ptr<SQLDatabaseManager> _manager;
+    std::unique_ptr<QSettings> _settings;
     Entry _entry;
     bool _entryIsValid = false;
 

--- a/src/jyut-dict/components/favouritewindow/favouritesplitter.cpp
+++ b/src/jyut-dict/components/favouritewindow/favouritesplitter.cpp
@@ -80,6 +80,11 @@ void FavouriteSplitter::setupUI()
             _entryScrollArea,
             &EntryScrollArea::stallSentenceUIUpdate);
 
+    connect(_entryScrollArea,
+            &EntryScrollArea::searchQuery,
+            this,
+            &FavouriteSplitter::searchQueryRequested);
+
     setHandleWidth(1);
     setCollapsible(0, false);
     setCollapsible(1, false);
@@ -129,6 +134,12 @@ void FavouriteSplitter::updateStyleRequested(void)
     foreach (auto &area, scrollAreas) {
         area->updateStyleRequested();
     }
+}
+
+void FavouriteSplitter::searchQueryRequested(const QString &query,
+                                             const SearchParameters &parameters)
+{
+    emit searchQuery(query, parameters);
 }
 
 void FavouriteSplitter::prepareEntry(Entry &entry)

--- a/src/jyut-dict/components/favouritewindow/favouritesplitter.h
+++ b/src/jyut-dict/components/favouritewindow/favouritesplitter.h
@@ -52,8 +52,14 @@ private:
     EntryScrollArea *_entryScrollArea;
     QListView *_resultListView;
 
+signals:
+    void searchQuery(const QString &query, const SearchParameters &parameters);
+
 public slots:
     void updateStyleRequested();
+
+    void searchQueryRequested(const QString &query,
+                              const SearchParameters &parameters);
 
 private slots:
     void prepareEntry(Entry &entry);

--- a/src/jyut-dict/components/magnifywindow/magnifyscrollarea.h
+++ b/src/jyut-dict/components/magnifywindow/magnifyscrollarea.h
@@ -23,6 +23,10 @@ public:
 private:
     void resizeEvent(QResizeEvent *event) override;
 
+    std::unique_ptr<QSettings> _settings;
+    Entry _entry;
+    bool _entryIsValid = false;
+
     MagnifyScrollAreaWidget *_scrollAreaWidget;
 
 public slots:

--- a/src/jyut-dict/components/magnifywindow/magnifyscrollareawidget.cpp
+++ b/src/jyut-dict/components/magnifywindow/magnifyscrollareawidget.cpp
@@ -95,6 +95,8 @@ void MagnifyScrollAreaWidget::setEntry(const Entry &entry)
             _simplifiedLabel->setVisible(false);
             break;
         }
+        _simplifiedLabelLabel->setVisible(true);
+        _simplifiedLabel->setVisible(true);
         _widgetLayout->addWidget(_simplifiedLabelLabel, Qt::AlignHCenter);
         _widgetLayout->addWidget(_simplifiedLabel);
         break;
@@ -107,6 +109,8 @@ void MagnifyScrollAreaWidget::setEntry(const Entry &entry)
             _traditionalLabel->setVisible(false);
             break;
         }
+        _traditionalLabelLabel->setVisible(true);
+        _traditionalLabel->setVisible(true);
         _widgetLayout->addWidget(_traditionalLabelLabel, Qt::AlignHCenter);
         _widgetLayout->addWidget(_traditionalLabel);
         break;
@@ -119,6 +123,8 @@ void MagnifyScrollAreaWidget::setEntry(const Entry &entry)
             _traditionalLabel->setVisible(false);
             break;
         }
+        _traditionalLabelLabel->setVisible(true);
+        _traditionalLabel->setVisible(true);
         _widgetLayout->addWidget(_traditionalLabelLabel, Qt::AlignHCenter);
         _widgetLayout->addWidget(_traditionalLabel);
         break;
@@ -128,6 +134,8 @@ void MagnifyScrollAreaWidget::setEntry(const Entry &entry)
             _simplifiedLabel->setVisible(false);
             break;
         }
+        _simplifiedLabelLabel->setVisible(true);
+        _simplifiedLabel->setVisible(true);
         _widgetLayout->addWidget(_simplifiedLabelLabel, Qt::AlignHCenter);
         _widgetLayout->addWidget(_simplifiedLabel);
         break;

--- a/src/jyut-dict/components/magnifywindow/magnifyscrollareawidget.h
+++ b/src/jyut-dict/components/magnifywindow/magnifyscrollareawidget.h
@@ -26,7 +26,6 @@ private:
     void setStyle(bool use_dark);
 
     bool _paletteRecentlyChanged = false;
-
     std::unique_ptr<QSettings> _settings;
 
     QVBoxLayout *_scrollAreaLayout;

--- a/src/jyut-dict/components/mainwindow/searchlineedit.cpp
+++ b/src/jyut-dict/components/mainwindow/searchlineedit.cpp
@@ -204,17 +204,19 @@ void SearchLineEdit::setStyle(bool use_dark)
             _searchLineEdit->setIcon(search_inverted);
             _clearLineEdit->setIcon(clear_inverted);
     } else {
-            setStyleSheet(
-                QString{"QLineEdit { "
-                        "   background-color: #ffffff; "
-                        "   border-radius: 3px; "
-                        "   border: 1px solid palette(alternate-base); "
-                        "   font-size: %1px; "
-                        "   icon-size: %1px; "
-                        "   padding-top: 4px; "
-                        "   padding-bottom: 4px; "
-                        "} "}
-                    .arg(std::to_string(h6FontSize).c_str()));
+            setStyleSheet(QString{"QLineEdit { "
+                                  "   background-color: #ffffff; "
+                                  "   border-radius: 3px; "
+                                  "   font-size: %1px; "
+                                  "   icon-size: %1px; "
+                                  "   padding-top: 4px; "
+                                  "   padding-bottom: 4px; "
+                                  "} "
+                                  ""
+                                  "QLineEdit:focus { "
+                                  "   border-radius: 2px; "
+                                  "} "}
+                              .arg(std::to_string(h6FontSize).c_str()));
             _searchLineEdit->setIcon(search);
             _clearLineEdit->setIcon(clear);
     }

--- a/src/jyut-dict/components/sentencecard/sentencecardwidget.cpp
+++ b/src/jyut-dict/components/sentencecard/sentencecardwidget.cpp
@@ -55,13 +55,16 @@ void SentenceCardWidget::displaySentences(const std::vector<SourceSentence> &sen
         return;
     }
 
+    _sourceSentences = sentences;
+    _sourceSentencesIsValid = true;
+
     _source = sentences.at(0).getSentenceSets().at(0).getSourceShortString();
     _sentenceHeaderWidget->setCardTitle(
         QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                     Strings::SENTENCES_ALL_CAPS)
             .toStdString()
         + " (" + _source + ")");
-    _sentenceContentWidget->setSourceSentenceVector(sentences);
+    _sentenceContentWidget->setSourceSentenceVector(_sourceSentences);
 
     setStyle(Utils::isDarkMode());
 }
@@ -117,6 +120,10 @@ void SentenceCardWidget::setStyle(bool use_dark)
 
 void SentenceCardWidget::updateStyleRequested(void)
 {
+    if (_sourceSentencesIsValid) {
+        _sentenceContentWidget->setSourceSentenceVector(_sourceSentences);
+    }
+
     QEvent event{QEvent::PaletteChange};
     QCoreApplication::sendEvent(_sentenceHeaderWidget, &event);
     QCoreApplication::sendEvent(_sentenceContentWidget, &event);

--- a/src/jyut-dict/components/sentencecard/sentencecardwidget.h
+++ b/src/jyut-dict/components/sentencecard/sentencecardwidget.h
@@ -31,6 +31,7 @@ private:
     bool _paletteRecentlyChanged = false;
 
     std::vector<SourceSentence> _sourceSentences;
+    bool _sourceSentencesIsValid = false;
     std::string _source;
 
     QVBoxLayout *_sentenceCardLayout;

--- a/src/jyut-dict/components/sentencecard/sentencecontentwidget.cpp
+++ b/src/jyut-dict/components/sentencecard/sentencecontentwidget.cpp
@@ -85,6 +85,8 @@ void SentenceContentWidget::setSentenceSet(const SentenceSet &set)
 void SentenceContentWidget::setSourceSentenceVector(
     const std::vector<SourceSentence> &sourceSentences)
 {
+    cleanupLabels();
+
     if (sourceSentences.empty()) {
         return;
     }

--- a/src/jyut-dict/components/sentenceview/sentencescrollareawidget.cpp
+++ b/src/jyut-dict/components/sentenceview/sentencescrollareawidget.cpp
@@ -1,5 +1,6 @@
 #include "sentencescrollareawidget.h"
 
+#include "logic/settings/settingsutils.h"
 #ifdef Q_OS_MAC
 #include "logic/utils/utils_mac.h"
 #elif defined (Q_OS_LINUX)
@@ -15,6 +16,8 @@ SentenceScrollAreaWidget::SentenceScrollAreaWidget(QWidget *parent)
     : QWidget(parent)
 {
     setObjectName("SentenceScrollAreaWidget");
+
+    _settings = Settings::getSettings(this);
 
     // Entire Scroll Area
     _scrollAreaLayout = new QVBoxLayout{this};
@@ -66,6 +69,17 @@ void SentenceScrollAreaWidget::setStyle(bool use_dark)
 void SentenceScrollAreaWidget::updateStyleRequested(void)
 {
     if (_sentenceIsValid) {
+        CantoneseOptions cantoneseOptions
+            = _settings
+                  ->value("Entry/cantonesePronunciationOptions",
+                          QVariant::fromValue(CantoneseOptions::RAW_JYUTPING))
+                  .value<CantoneseOptions>();
+        MandarinOptions mandarinOptions
+            = _settings
+                  ->value("Entry/mandarinPronunciationOptions",
+                          QVariant::fromValue(MandarinOptions::PRETTY_PINYIN))
+                  .value<MandarinOptions>();
+        _sentence.generatePhonetic(cantoneseOptions, mandarinOptions);
         _sentenceViewHeaderWidget->setSourceSentence(_sentence);
     }
     QEvent event{QEvent::PaletteChange};

--- a/src/jyut-dict/components/sentenceview/sentencescrollareawidget.cpp
+++ b/src/jyut-dict/components/sentenceview/sentencescrollareawidget.cpp
@@ -47,8 +47,11 @@ void SentenceScrollAreaWidget::changeEvent(QEvent *event)
 
 void SentenceScrollAreaWidget::setSourceSentence(const SourceSentence &sentence)
 {
-    _sentenceViewHeaderWidget->setSourceSentence(sentence);
-    _sentenceViewContentWidget->setSourceSentence(sentence);
+    _sentence = sentence;
+    _sentenceIsValid = true;
+
+    _sentenceViewHeaderWidget->setSourceSentence(_sentence);
+    _sentenceViewContentWidget->setSourceSentence(_sentence);
 }
 
 void SentenceScrollAreaWidget::setStyle(bool use_dark)
@@ -62,6 +65,9 @@ void SentenceScrollAreaWidget::setStyle(bool use_dark)
 
 void SentenceScrollAreaWidget::updateStyleRequested(void)
 {
+    if (_sentenceIsValid) {
+        _sentenceViewHeaderWidget->setSourceSentence(_sentence);
+    }
     QEvent event{QEvent::PaletteChange};
     QCoreApplication::sendEvent(_sentenceViewHeaderWidget, &event);
     _sentenceViewContentWidget->updateStyleRequested();

--- a/src/jyut-dict/components/sentenceview/sentencescrollareawidget.h
+++ b/src/jyut-dict/components/sentenceview/sentencescrollareawidget.h
@@ -26,6 +26,9 @@ private:
 
     bool _paletteRecentlyChanged = false;
 
+    SourceSentence _sentence;
+    bool _sentenceIsValid = false;
+
     QVBoxLayout *_scrollAreaLayout;
 
     SentenceViewHeaderWidget *_sentenceViewHeaderWidget;

--- a/src/jyut-dict/components/sentenceview/sentencescrollareawidget.h
+++ b/src/jyut-dict/components/sentenceview/sentencescrollareawidget.h
@@ -6,6 +6,7 @@
 #include "logic/sentence/sourcesentence.h"
 
 #include <QEvent>
+#include <QSettings>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -26,6 +27,7 @@ private:
 
     bool _paletteRecentlyChanged = false;
 
+    std::unique_ptr<QSettings> _settings;
     SourceSentence _sentence;
     bool _sentenceIsValid = false;
 

--- a/src/jyut-dict/components/settings/settingstab.cpp
+++ b/src/jyut-dict/components/settings/settingstab.cpp
@@ -1,7 +1,6 @@
 #include "settingstab.h"
 
 #include "logic/entry/entryphoneticoptions.h"
-#include "logic/settings/settings.h"
 #include "logic/settings/settingsutils.h"
 #ifdef Q_OS_MAC
 #include "logic/utils/utils_mac.h"
@@ -286,6 +285,8 @@ void SettingsTab::initializePreviewPhonetic(QWidget &previewPhoneticWidget)
                 _settings->setValue("Preview/phoneticOptions",
                                     _previewPhoneticCombobox->itemData(index));
                 _settings->sync();
+
+                emit updateStyle();
             });
 }
 
@@ -301,6 +302,8 @@ void SettingsTab::initializeSearchResultsCantonesePronunciation(
                             QVariant::fromValue<CantoneseOptions>(
                                 CantoneseOptions::RAW_JYUTPING));
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_previewYale, &QRadioButton::clicked, this, [&]() {
@@ -308,6 +311,8 @@ void SettingsTab::initializeSearchResultsCantonesePronunciation(
                             QVariant::fromValue<CantoneseOptions>(
                                 CantoneseOptions::PRETTY_YALE));
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_previewCantoneseIPA, &QRadioButton::clicked, this, [&]() {
@@ -315,6 +320,8 @@ void SettingsTab::initializeSearchResultsCantonesePronunciation(
                             QVariant::fromValue<CantoneseOptions>(
                                 CantoneseOptions::CANTONESE_IPA));
         _settings->sync();
+
+        emit updateStyle();
     });
 
     setSearchResultsCantonesePronunciationDefault(cantonesePronunciationWidget);
@@ -333,6 +340,8 @@ void SettingsTab::initializeSearchResultsMandarinPronunciation(
                             QVariant::fromValue<MandarinOptions>(
                                 MandarinOptions::PRETTY_PINYIN));
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_previewNumberedPinyin, &QRadioButton::clicked, this, [&]() {
@@ -340,6 +349,8 @@ void SettingsTab::initializeSearchResultsMandarinPronunciation(
                             QVariant::fromValue<MandarinOptions>(
                                 MandarinOptions::NUMBERED_PINYIN));
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_previewZhuyin, &QRadioButton::clicked, this, [&]() {
@@ -347,6 +358,8 @@ void SettingsTab::initializeSearchResultsMandarinPronunciation(
                             QVariant::fromValue<MandarinOptions>(
                                 MandarinOptions::ZHUYIN));
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_previewMandarinIPA, &QRadioButton::clicked, this, [&]() {
@@ -354,6 +367,8 @@ void SettingsTab::initializeSearchResultsMandarinPronunciation(
                             QVariant::fromValue<MandarinOptions>(
                                 MandarinOptions::MANDARIN_IPA));
         _settings->sync();
+
+        emit updateStyle();
     });
 
     setSearchResultsMandarinPronunciationDefault(mandarinPronunciationWidget);
@@ -384,6 +399,8 @@ void SettingsTab::initializeEntryCantonesePronunciation(
                                     & ~(CantoneseOptions::RAW_JYUTPING)));
         }
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_entryYale, &QCheckBox::stateChanged, this, [&]() {
@@ -404,6 +421,8 @@ void SettingsTab::initializeEntryCantonesePronunciation(
                                     & ~(CantoneseOptions::PRETTY_YALE)));
         }
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_entryCantoneseIPA, &QCheckBox::stateChanged, this, [&]() {
@@ -424,6 +443,8 @@ void SettingsTab::initializeEntryCantonesePronunciation(
                                     & ~(CantoneseOptions::CANTONESE_IPA)));
         }
         _settings->sync();
+
+        emit updateStyle();
     });
 
     setEntryCantonesePronunciationDefault(cantonesePronunciationWidget);
@@ -455,6 +476,8 @@ void SettingsTab::initializeEntryMandarinPronunciation(
                                     & ~(MandarinOptions::PRETTY_PINYIN)));
         }
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_entryNumberedPinyin, &QCheckBox::stateChanged, this, [&]() {
@@ -475,6 +498,8 @@ void SettingsTab::initializeEntryMandarinPronunciation(
                                     & ~(MandarinOptions::NUMBERED_PINYIN)));
         }
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_entryZhuyin, &QCheckBox::stateChanged, this, [&]() {
@@ -495,6 +520,8 @@ void SettingsTab::initializeEntryMandarinPronunciation(
                                     & ~(MandarinOptions::ZHUYIN)));
         }
         _settings->sync();
+
+        emit updateStyle();
     });
 
     connect(_entryMandarinIPA, &QCheckBox::stateChanged, this, [&]() {
@@ -514,6 +541,8 @@ void SettingsTab::initializeEntryMandarinPronunciation(
                                     options & ~(MandarinOptions::MANDARIN_IPA)));
         }
         _settings->sync();
+
+        emit updateStyle();
     });
 
     setEntryMandarinPronunciationDefault(mandarinPronunciationWidget);

--- a/src/jyut-dict/components/settings/settingstab.h
+++ b/src/jyut-dict/components/settings/settingstab.h
@@ -51,6 +51,8 @@ private:
 
     bool _paletteRecentlyChanged = false;
 
+    std::unique_ptr<QSettings> _settings;
+
     QLabel *_previewTitleLabel;
     QWidget *_previewPhoneticWidget;
     QHBoxLayout *_previewPhoneticLayout;
@@ -82,7 +84,8 @@ private:
 
     QFormLayout *_tabLayout;
 
-    std::unique_ptr<QSettings> _settings;
+signals:
+    void updateStyle(void);
 
 public slots:
     void resetSettings(void);

--- a/src/jyut-dict/components/settings/texttab.cpp
+++ b/src/jyut-dict/components/settings/texttab.cpp
@@ -237,6 +237,8 @@ void TextTab::initializeCharacterComboBox(QComboBox &characterCombobox)
                 _settings->setValue("characterOptions",
                                     characterCombobox.itemData(index));
                 _settings->sync();
+
+                emit updateStyle();
             });
 }
 
@@ -296,6 +298,8 @@ void TextTab::initializeColourComboBox(QComboBox &colourCombobox)
                 _settings->setValue("entryColourPhoneticType",
                                     colourCombobox.itemData(index));
                 _settings->sync();
+
+                emit updateStyle();
             });
 }
 
@@ -342,6 +346,8 @@ void TextTab::initializeJyutpingColourWidget(QWidget &jyutpingColourWidget)
                 Settings::jyutpingToneColours[index].c_str()));
 
             saveJyutpingColours();
+
+            emit updateStyle();
         });
 
         // Then add tone label underneath it
@@ -401,6 +407,8 @@ void TextTab::initializePinyinColourWidget(QWidget &pinyinColourWidget)
                 Settings::pinyinToneColours[index].c_str()));
 
             savePinyinColours();
+
+            emit updateStyle();
         });
 
         QLabel *label = new QLabel{&pinyinColourWidget};

--- a/src/jyut-dict/logic/entry/entry.cpp
+++ b/src/jyut-dict/logic/entry/entry.cpp
@@ -427,16 +427,16 @@ std::vector<int> Entry::getJyutpingNumbers() const
     std::vector<int> jyutpingNumbers;
 
     if (_jyutping.empty()) {
-        return getPinyinNumbers();
+        return jyutpingNumbers;
     }
 
     size_t pos = _jyutping.find_first_of("0123456");
-    while(pos != std::string::npos) {
+    while (pos != std::string::npos) {
         jyutpingNumbers.push_back(_jyutping.at(pos) - '0');
         pos = _jyutping.find_first_of("0123456", pos + 1);
     }
 
-return jyutpingNumbers;
+    return jyutpingNumbers;
 }
 
 std::string Entry::getPinyin(void) const
@@ -464,8 +464,12 @@ std::vector<int> Entry::getPinyinNumbers() const
 {
     std::vector<int> pinyinNumbers;
 
+    if (_pinyin.empty()) {
+        return pinyinNumbers;
+    }
+
     size_t pos = _pinyin.find_first_of("012345");
-    while(pos != std::string::npos) {
+    while (pos != std::string::npos) {
         pinyinNumbers.push_back(_pinyin.at(pos) - '0');
         pos = _pinyin.find_first_of("012345", pos + 1);
     }

--- a/src/jyut-dict/windows/mainwindow.cpp
+++ b/src/jyut-dict/windows/mainwindow.cpp
@@ -1214,6 +1214,11 @@ void MainWindow::openFavouritesWindow(void)
         ->move(x() + (width() - _favouritesWindow->size().width()) / 2,
                y() + (height() - _favouritesWindow->size().height()) / 2);
     _favouritesWindow->setFocus();
+
+    connect(_favouritesWindow,
+            &FavouriteSplitter::searchQuery,
+            _mainToolBar,
+            &MainToolBar::searchQueryRequested);
 }
 
 void MainWindow::checkForUpdate(bool showProgress)

--- a/src/jyut-dict/windows/settingswindow.cpp
+++ b/src/jyut-dict/windows/settingswindow.cpp
@@ -114,6 +114,11 @@ void SettingsWindow::setupUI()
 
     setCentralWidget(_contentStackedWidget);
 
+    connect(generalTab,
+            &SettingsTab::updateStyle,
+            this,
+            &SettingsWindow::updateStyleRequested);
+
     connect(textTab,
             &TextTab::updateStyle,
             this,


### PR DESCRIPTION
# Description

This commit makes settings reflect immediately in the UI, instead of on a manual repaint (such as selecting a new entry). The settings that this commit applies to include:
- Pronunciation language settings
- Romanization types for Cantonese and Mandarin
- Simplified/Traditional character preference
- Tone colouring

Closes #109.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Built using Qt 5.15.2 on macOS 12.3.1, Pop!_OS 22.04, Windows 11. Manually verified settings were applied correctly.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
