### PR TITLE
#114: Add parsing script for 廣州話正音字典

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,12 +102,12 @@ CMakeLists.txt.user*
 **/cuhk/archive_*
 **/cuhk/data/*
 **/cuhk/developer/*
+**/gzzj/archive_*
+**/gzzj/data/*
+**/gzzj/developer/*
 **/hsk3/archive_*
 **/hsk3/data/*
 **/hsk3/developer/*
-**/jyutnet/archive_*
-**/jyutnet/data/*
-**/jyutnet/developer/*
 **/kaifangcidian/archive_*
 **/kaifangcidian/data/*
 **/kaifangcidian/developer/*

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ CMakeLists.txt.user*
 **/hsk3/archive_*
 **/hsk3/data/*
 **/hsk3/developer/*
+**/jyutnet/archive_*
+**/jyutnet/data/*
+**/jyutnet/developer/*
 **/kaifangcidian/archive_*
 **/kaifangcidian/data/*
 **/kaifangcidian/developer/*

--- a/README.md
+++ b/README.md
@@ -41,16 +41,20 @@ The project contains two subdirectories under `src`: `dictionaries`, and `jyut-d
 
 ### dictionaries
 
-This folder contains several Python3 scripts that convert the various online Cantonese/Written Chinese dictionaries into the dictionary format used by Jyut Dictionary. Some sources include:
-- CC-CEDICT and CC-CEDICT-compatible dictionaries, such as:
+This folder contains several Python3 scripts that convert the various online Cantonese/Written Chinese dictionaries into the dictionary format used by Jyut Dictionary. However, for copyright reasons, data for these sources may not be included in this repository. Selected sources include:
+- CC-CEDICT and CC-CEDICT-compatible dictionaries (in .u8 and .xml format), such as:
   - **[CC-CEDICT](https://cc-cedict.org/editor/editor.php?handler=Download)**
   - **[CC-CANTO](https://cantonese.org/download.html)**
   - **[CFDICT](https://chine.in/mandarin/dictionnaire/)**
   - **[HanDeDict](https://handedict.zydeo.net/de)**
+- **[ABC Chinese-English Dictionary](https://wenlin.com/abc)**
+- **[ABC Cantonese-English Dictionary](https://wenlin.co/wow/Project:Jyut)**
 - **[CUHK 現代標準漢語與粵語對照資料庫](https://apps.itsc.cuhk.edu.hk/hanyu/Page/Cover.aspx)**
 - **[CantoDict](https://www.cantonese.sheik.co.uk/)**
 - **[Cross-Straits Language Database (兩岸詞典)](http://www.chinese-linguipedia.org/)**
   - **[兩岸三地生活差異詞語彙編](https://github.com/g0v/moedict-data-csld/blob/master/%E5%85%A9%E5%B2%B8%E4%B8%89%E5%9C%B0%E7%94%9F%E6%B4%BB%E5%B7%AE%E7%95%B0%E8%A9%9E%E8%AA%9E%E5%BD%99%E7%B7%A8-%E5%90%8C%E5%90%8D%E7%95%B0%E5%AF%A6.csv)**
+- **[廣州話正音字典](https://github.com/jyutnet/cantonese-books-data/tree/master/2004_%E5%BB%A3%E5%B7%9E%E8%A9%B1%E6%AD%A3%E9%9F%B3%E5%AD%97%E5%85%B8)
+- **[HSK 3.0 (汉语水平考试 3.0)](https://github.com/elkmovie/hsk30)
 - **[Kaifangcidian 粵語詞典 - 開放詞典](https://www.kaifangcidian.com/han/yue)**
 - **[MoEDict (重編國語辭典修訂本)](http://dict.revised.moe.edu.tw/cbdic/)**
 - **[Tatoeba](https://tatoeba.org/eng/downloads)**

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ This folder contains several Python3 scripts that convert the various online Can
 - **[CantoDict](https://www.cantonese.sheik.co.uk/)**
 - **[Cross-Straits Language Database (兩岸詞典)](http://www.chinese-linguipedia.org/)**
   - **[兩岸三地生活差異詞語彙編](https://github.com/g0v/moedict-data-csld/blob/master/%E5%85%A9%E5%B2%B8%E4%B8%89%E5%9C%B0%E7%94%9F%E6%B4%BB%E5%B7%AE%E7%95%B0%E8%A9%9E%E8%AA%9E%E5%BD%99%E7%B7%A8-%E5%90%8C%E5%90%8D%E7%95%B0%E5%AF%A6.csv)**
-- **[廣州話正音字典](https://github.com/jyutnet/cantonese-books-data/tree/master/2004_%E5%BB%A3%E5%B7%9E%E8%A9%B1%E6%AD%A3%E9%9F%B3%E5%AD%97%E5%85%B8)
-- **[HSK 3.0 (汉语水平考试 3.0)](https://github.com/elkmovie/hsk30)
+- **[廣州話正音字典](https://github.com/jyutnet/cantonese-books-data/tree/master/2004_%E5%BB%A3%E5%B7%9E%E8%A9%B1%E6%AD%A3%E9%9F%B3%E5%AD%97%E5%85%B8)**
+- **[HSK 3.0 (汉语水平考试 3.0)](https://github.com/elkmovie/hsk30)**
 - **[Kaifangcidian 粵語詞典 - 開放詞典](https://www.kaifangcidian.com/han/yue)**
 - **[MoEDict (重編國語辭典修訂本)](http://dict.revised.moe.edu.tw/cbdic/)**
 - **[Tatoeba](https://tatoeba.org/eng/downloads)**

--- a/src/dictionaries/abc_/README.md
+++ b/src/dictionaries/abc_/README.md
@@ -1,8 +1,9 @@
 #### Usage:
 - To install required packages: `pip install -r requirements.txt`
-- Specific usage instructions for each script are provided by the scripts themselves.
+- Specific usage instructions for the script are provided by the script itself.
 - **Run the scripts from the `dictionaries` folder, e.g. `python3 -m abc_.parse <database filename> <cidian.u8 file> <source name> <source short name> <source version> <source description> <source legal> <source link> <source update url> <source other>`.**
 
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database from the `cidian.u8` file provided by Wenlin's Developer Program. See [Wenlin's webpage](https://wenlin.com/developers) for more details.
+  - Run `python3 -m abc_.parse help` to view instructions.

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -833,7 +833,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 11:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m abc_.parse <database filename> "
                 "<cidian.u8 file> "
                 "<source name> <source short name> "
                 "<source version> <source description> <source legal> "

--- a/src/dictionaries/abc_/parse.py
+++ b/src/dictionaries/abc_/parse.py
@@ -25,6 +25,7 @@ import unicodedata
 # - 回@@/迴 (1005378131): contains "@@" in entry headword
 # - 纪委 (1006643399): contains "-" in Pinyin
 # - 就 (1006571134): contains example with weird Pinyin ("yī̠diǎnr")
+# - 女媧: has ü in Pinyin
 
 IGNORED_LINES = ("cidian.wenlindb\n", ".-arc\n", ".-publish\n")
 IGNORED_TYPES = (
@@ -236,6 +237,9 @@ def parse_pinyin(content):
     # And remove the space in front of punctuatation
     for punctuation in string.punctuation:
         content = content.replace(" " + punctuation, punctuation)
+
+    # Convert ü to u:
+    content = content.replace("ü", "u:")
 
     return content
 

--- a/src/dictionaries/aby/README.md
+++ b/src/dictionaries/aby/README.md
@@ -1,8 +1,9 @@
 #### Usage:
 - To install required packages: `pip install -r requirements.txt`
-- Specific usage instructions for each script are provided by the scripts themselves.
+- Specific usage instructions for the script are provided by the script itself.
 - **Run the scripts from the `dictionaries` folder, e.g. `python3 -m aby.parse <database filename> <jyut.u8 file> <source name> <source short name> <source version> <source description> <source legal> <source link> <source update url> <source other>`.**
 
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database from the `jyut.u8` file provided by Wenlin's Developer Program. See [Wenlin's webpage](https://wenlin.com/developers) for more details.
+  - Run `python3 -m aby.parse help` to view instructions.

--- a/src/dictionaries/aby/parse.py
+++ b/src/dictionaries/aby/parse.py
@@ -759,8 +759,8 @@ if __name__ == "__main__":
     if len(sys.argv) != 11:
         print(
             (
-                "Usage: python3 script.py <database filename> "
-                "<cidian.u8 file> "
+                "Usage: python3 -m aby.parse <database filename> "
+                "<jyut.u8 file> "
                 "<source name> <source short name> "
                 "<source version> <source description> <source legal> "
                 "<source link> <source update url> <source other>"

--- a/src/dictionaries/cantodict/README.md
+++ b/src/dictionaries/cantodict/README.md
@@ -12,9 +12,13 @@
 #### Scripts:
 - `setup_data.py`
   - This script downloads the list of characters, words, and sentence URLs that will be scraped.
+  - Run `python3 -m cantodict.setup_data help` to view instructions.
 - `scrape.py`
   - This script downloads every webpage for each URL in the files created by `setup_data.py`.
-- `parse.py`
-  - This script generates a SQLite database from the webpages downloaded by `scrape.py`.
+  - Run `python3 -m cantodict.scrape help` to view instructions.
 - `fixup.py`
   - This script attempts to re-download compound word webpages whose text failed to parse (usually compound words starting with roman characters, e.g. AA制)
+  - Run `python3 -m cantodict.fixup help` to view instructions.
+- `parse.py`
+  - This script generates a SQLite database from the webpages downloaded by `scrape.py`.
+  - Run `python3 -m cantodict.parse help` to view instructions.

--- a/src/dictionaries/cantodict/fixup.py
+++ b/src/dictionaries/cantodict/fixup.py
@@ -22,7 +22,8 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 -m cantodict.fixup ./cantodict/logging.log ./cantodict/scraped_words/"
+                "e.g. python3 -m cantodict.fixup cantodict/logging.log "
+                "cantodict/data/scraped_words/"
             )
         )
         sys.exit(1)

--- a/src/dictionaries/cantodict/parse.py
+++ b/src/dictionaries/cantodict/parse.py
@@ -627,12 +627,12 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 -m cantodict.parse cantodict.db ./cantodict/scraped_words/ "
-                "./cantodict/scraped_sentences/ CantoDict CD 2021-07-18 "
+                "e.g. python3 -m cantodict.parse cantodict/developer/cantodict.db cantodict/data/scraped_words/ "
+                "cantodict/data/scraped_sentences/ CantoDict CD 2021-07-18 "
                 '"CantoDict is a collaborative Chinese Dictionary project started in November 2003. '
                 'Entries are added and mistakes corrected by a team of kind volunteers from around the world." '
                 '"https://www.cantonese.sheik.co.uk/copyright.htm" "https://www.cantonese.sheik.co.uk/" "" "" '
-                "./cantodict/logging.log"
+                "cantodict/logging.log"
             )
         )
         sys.exit(1)

--- a/src/dictionaries/cantodict/scrape.py
+++ b/src/dictionaries/cantodict/scrape.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         print(
             (
                 "e.g. python3 -m cantodict.scrape "
-                "word_urls.txt ./cantodict/scraped_words/ "
+                "word_urls.txt cantodict/data/scraped_words/ "
                 "0 55000"
             )
         )

--- a/src/dictionaries/cedict/README.md
+++ b/src/dictionaries/cedict/README.md
@@ -8,12 +8,15 @@
 - `generate-readings.py`
   - This script outputs a file that contains Cantonese pronunciations for every term in CC-CANTO *and* the Cantonese readings file provided by Pleco.
   - The purpose of the outputted Cantonese pronunciation file is to provide Cantonese readings for other dictionaries, such as CFDICT or HanDeDict, that do not come with Cantonese pronunciations.
+  - Run `python3 -m cedict.generate-readings help` to view instructions.
 - `parse-individual.py`
   - This script generates a SQLite database file from the entries/definitions contained in a CEDICT-compatible format and readings from a Cantonese readings file created by `generate_readings.py`.
   - The purpose of this script is to generate a database file for CFDict, HanDeDict, etc. where there is only one file containing entries and definitions, and no Cantonese readings are provided.
+  - Run `python3 -m cedict.parse-individual help` to view instructions.
 - `parse-set.py`
   - This script generates a SQLite database file from:
     - the entries/definitions contained in CEDICT (or a CEDICT-compatible format)
     - the entries/definitions contained in CC-CANTO (or a CC-CANTO-compatible format)
     - the readings provided by Pleco (or a Pleco-readings-compatible format)
   - The purpose of this script is to generate a database file where there is one file that contains Mandarin entries/definitions (e.g. CEDICT), another file that contains Cantonese entries/definitions (e.g. CC-CANTO), and another file that contains Cantonese pronunciations for Mandarin words (e.g. the Pleco readings file).
+  - Run `python3 -m cedict.parse-set help` to view instructions.

--- a/src/dictionaries/cedict/generate-readings.py
+++ b/src/dictionaries/cedict/generate-readings.py
@@ -94,9 +94,12 @@ def parse_cc_cedict_canto_readings(filename, entries):
 if __name__ == "__main__":
     if len(sys.argv) != 4:
         print(
-            "Usage: python3 script.py <output filename> <CC_CANTO file> <Cantonese Readings file>"
+            "Usage: python3 -m cedict.generate-readings <output filename> <CC_CANTO file> <Cantonese Readings file>"
         )
-        print("e.g. python3 script.py FULLREADINGS.txt CC-CANTO.txt READINGS.txt")
+        print(
+            "e.g. python3 -m cedict.generate-readings cedict/data/FULLREADINGS.txt "
+            "cedict/data/CC-CANTO.txt cedict/dataREADINGS.txt"
+        )
         sys.exit(1)
 
     entries = {}

--- a/src/dictionaries/cedict/parse-individual.py
+++ b/src/dictionaries/cedict/parse-individual.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 12:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m cedict.parse-individual <database filename> "
                 "<CC_CEDICT file> <Cantonese readings file> "
                 "<source name> <source short name> "
                 "<source version> <source description> <source legal> "
@@ -136,7 +136,8 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 script.py dict.db CEDICT.txt READINGS.txt "
+                "e.g. python3 -m cedict.parse-individual cedict/developer/dict.db "
+                "cedict/data/CEDICT.txt cedict/data/READINGS.txt "
                 'CC-CEDICT CC 2018-07-09 "CC-CEDICT is a dictionary." '
                 '"This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License." '
                 '"http://www.mdbg.net/chindict/chindict.php?page=cc-cedict" "" ""'

--- a/src/dictionaries/cedict/parse-set.py
+++ b/src/dictionaries/cedict/parse-set.py
@@ -211,11 +211,14 @@ if __name__ == "__main__":
     if len(sys.argv) != 5:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m cedict.parse-set <database filename> "
                 "<CC_CEDICT file> <CC_CANTO file> <Cantonese Readings file>"
             )
         )
-        print("e.g. python3 script.py eng.db CC-CEDICT.txt CC-CANTO.txt READINGS.txt")
+        print(
+            "e.g. python3 -m cedict.parse-set cedict/developer/eng.db "
+            "cedict/data/CC-CEDICT.txt cedict/data/CC-CANTO.txt cedict/data/READINGS.txt"
+        )
         sys.exit(1)
 
     entries = {}

--- a/src/dictionaries/cfdict-xml/parse.py
+++ b/src/dictionaries/cfdict-xml/parse.py
@@ -145,7 +145,8 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 script.py dict.db CFDICT.xml READINGS.txt "
+                "e.g. python3 -m cfdict-xml.parse cfdict-xml/developer/dict.db "
+                "cfdict-xml/data/CFDICT.xml cfdict-xml/data/READINGS.txt "
                 'CFDICT-2016 CF2016 2016-01-17 "En 2010, David Houstin, '
                 "fondateur de CHINE INFORMATIONS, a commencé à partager "
                 "librement une partie de la base de données son dictionnaire "

--- a/src/dictionaries/cross_straits/parse.py
+++ b/src/dictionaries/cross_straits/parse.py
@@ -23,6 +23,7 @@ import unicodedata
 #   - 歛: multiple heteronyms, labels for definitions
 #   - 穀: some duplicate definitions (姓。) and has labels for literary use (〈書〉)
 #   - 横征暴敛: Pinyin has dashes in it (bad!)
+#   - 女媧氏: has ü in Pinyin
 #   - 节哀顺变: has apostrophes in the Pinyin
 #   - 空橋: contains 陸⃝ in the definition
 #   - 空擋: contains 臺⃝ in the definition
@@ -318,6 +319,7 @@ def parse_file(filename, words):
                             )
                             for x in pins
                         ]
+                        pins = [x.replace("ü", "u:") for x in pins]
 
                         for x in pins:
                             if x.count(" ") >= len(trad):
@@ -335,6 +337,7 @@ def parse_file(filename, words):
                                 transcriptions.zhuyin_to_pinyin(x, accented=False)
                                 for x in pins
                             ]
+                            pins = [x.replace("ü", "u:") for x in pins]
                         except Exception as e:
                             logging.error(
                                 f"Unable to split up Pinyin for word {trad}: {e}, skipping word..."

--- a/src/dictionaries/cross_straits/parse.py
+++ b/src/dictionaries/cross_straits/parse.py
@@ -563,8 +563,8 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 script.py cross_straits.db ./dict-clsd.json "
-                '"Cross-Straits Language Database" CSLD 2021-08-06 '
+                "e.g. python3 -m cross_straits.parse cross_straits/developer/cross_straits.db "
+                'cross_straits/data/dict-clsd.json "Cross-Straits Language Database" CSLD 2021-08-06 '
                 '"兩岸差異用詞主要依據《中華語文大辭典》所收兩岸差異語詞加以分類表列，以一般性常用語詞為主，'
                 '如生活、文化、社會等各領域的用語，也包含學術專業語詞，如物理、化學、生物等各學科的用語。" '
                 '"《兩岸詞典》由中華文化總會以 CC BY-NC-ND 4.0 之条款下提供。" '

--- a/src/dictionaries/cuhk/parse.py
+++ b/src/dictionaries/cuhk/parse.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 11:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m cuhk.parse <database filename> "
                 "<entries HTML folder> "
                 "<source name> <source short name> "
                 "<source version> <source description> <source legal> "
@@ -193,9 +193,11 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 script.py cuhk.db scraped_words/ 現代標準漢語與粵語對照資料庫 CUHK 2021-10-03 "
+                "e.g. python3 -m cuhk.parse cuhk/developer/cuhk.db cuhk/data/scraped/ "
+                "現代標準漢語與粵語對照資料庫 CUHK 2021-10-03 "
                 '"香港通行廣州話（以下簡稱粵語），本地逾九成師生之母語為粵語。" '
-                '"(c) 2014保留版權 香港中文大學 中國語言及文學系" "https://apps.itsc.cuhk.edu.hk/hanyu/Page/Cover.aspx" "" "words"'
+                '"(c) 2014保留版權 香港中文大學 中國語言及文學系" '
+                '"https://apps.itsc.cuhk.edu.hk/hanyu/Page/Cover.aspx" "" "words"'
             )
         )
         sys.exit(1)

--- a/src/dictionaries/database/objects.py
+++ b/src/dictionaries/database/objects.py
@@ -158,8 +158,13 @@ class Example:
         return hash((self.lang, self.pron, self.content))
 
     def __eq__(self, other):
-        if not isinstance(other, type(self)): return NotImplemented
-        return self.lang == other.lang and self.pron == other.pron and self.content == other.content
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return (
+            self.lang == other.lang
+            and self.pron == other.pron
+            and self.content == other.content
+        )
 
 
 @dataclass
@@ -172,5 +177,6 @@ class Definition:
         return hash((self.definition, self.label))
 
     def __eq__(self, other):
-        if not isinstance(other, type(self)): return NotImplemented
+        if not isinstance(other, type(self)):
+            return NotImplemented
         return self.definition == other.definition and self.label == other.label

--- a/src/dictionaries/gzzj/README.md
+++ b/src/dictionaries/gzzj/README.md
@@ -1,8 +1,9 @@
 #### Usage:
 - To install required packages: `pip install -r requirements.txt`
-- Specific usage instructions for the script is provided by the script itself.
+- Specific usage instructions for the script are provided by the script itself.
 - Run the scripts from the `dictionaries` folder, e.g. `python3 -m gzzj.parse <database filename> <B01_讀音資料.txt>`.
 
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database file for all entries provided by the B01_讀音資料.txt file downloaded from https://github.com/jyutnet/cantonese-books-data/tree/master/2004_%E5%BB%A3%E5%B7%9E%E8%A9%B1%E6%AD%A3%E9%9F%B3%E5%AD%97%E5%85%B8.
+  - Run `python3 -m gzzj.parse help` to view instructions.

--- a/src/dictionaries/gzzj/README.md
+++ b/src/dictionaries/gzzj/README.md
@@ -1,0 +1,8 @@
+#### Usage:
+- To install required packages: `pip install -r requirements.txt`
+- Specific usage instructions for the script is provided by the script itself.
+- Run the scripts from the `dictionaries` folder, e.g. `python3 -m gzzj.parse <database filename> <B01_讀音資料.txt>`.
+
+#### Scripts:
+- `parse.py`
+  - This script generates a SQLite database file for all entries provided by the B01_讀音資料.txt file downloaded from https://github.com/jyutnet/cantonese-books-data/tree/master/2004_%E5%BB%A3%E5%B7%9E%E8%A9%B1%E6%AD%A3%E9%9F%B3%E5%AD%97%E5%85%B8.

--- a/src/dictionaries/gzzj/parse.py
+++ b/src/dictionaries/gzzj/parse.py
@@ -1,0 +1,192 @@
+import opencc
+from pypinyin import lazy_pinyin, Style
+from pypinyin_dict.phrase_pinyin_data import cc_cedict
+from wordfreq import zipf_frequency
+
+from database import database, objects
+
+from collections import defaultdict
+import copy
+import csv
+import logging
+import sqlite3
+import sys
+
+converter = opencc.OpenCC("hk2s.json")
+
+NUMERICAL_VALUES = str.maketrans("①②③④⑤⑥⑦⑧⑨⑩", "\n\n\n\n\n\n\n\n\n\n", "㈠㈡㈢㈣")
+
+
+def insert_words(c, words):
+    for char in words:
+        for entry in words[char]:
+            entry_id = database.get_entry_id(
+                c,
+                entry.traditional,
+                entry.simplified,
+                entry.pinyin,
+                entry.jyutping,
+                entry.freq,
+            )
+
+            already_in_db = (entry_id == -1)
+
+            if entry_id == -1:
+                entry_id = database.insert_entry(
+                    c,
+                    entry.traditional,
+                    entry.simplified,
+                    entry.pinyin,
+                    entry.jyutping,
+                    entry.freq,
+                )
+                if entry_id == -1:
+                    logging.error(f"Could not insert word {entry.traditional}, uh oh!")
+                    continue
+
+            if not already_in_db and len(words[char]) > 1:
+                other_pronunciations = set()
+                for other_entry in words[char]:
+                    if other_entry.jyutping == entry.jyutping:
+                        continue
+                    other_pronunciations.add(
+                        other_entry.traditional + " " + other_entry.jyutping
+                    )
+                entry.append_to_defs(
+                    objects.DefinitionTuple(
+                        "，".join(list(other_pronunciations)), "參看", []
+                    )
+                )
+
+            for definition in entry.definitions:
+                definition_id = database.insert_definition(
+                    c, definition.definition, definition.label, entry_id, 1, None
+                )
+                if definition_id == -1:
+                    logging.error(
+                        f"Could not insert definition {definition} for word {entry.traditional} "
+                        "- check if the definition is a duplicate!"
+                    )
+                    continue
+
+
+def write(db_name, source, words):
+    db = sqlite3.connect(db_name)
+    c = db.cursor()
+
+    database.write_database_version(c)
+
+    database.drop_tables(c)
+    database.create_tables(c)
+
+    database.insert_source(
+        c,
+        source.name,
+        source.shortname,
+        source.version,
+        source.description,
+        source.legal,
+        source.link,
+        source.update_url,
+        source.other,
+        None,
+    )
+
+    insert_words(c, words)
+
+    database.generate_indices(c)
+
+    db.commit()
+    db.close()
+
+
+def parse_file(filename, words):
+    with open(filename) as csvfile:
+        reader = csv.DictReader(csvfile, delimiter="\t")
+        for row in reader:
+            traditional_variants = row["字頭"].split("|")
+            trad = traditional_variants[0]
+            simp = converter.convert(trad)
+
+            pin = lazy_pinyin(
+                simp,
+                style=Style.TONE3,
+                neutral_tone_with_five=True,
+            )
+            pin = " ".join(pin).lower()
+            pin = pin.strip().replace("v", "u:")
+            jyut = row["粵拼讀音"]
+
+            freq = zipf_frequency(trad, "zh")
+
+            defs = []
+            if row["釋義"]:
+                explanation = row["釋義"]
+                explanation = explanation.translate(NUMERICAL_VALUES)
+                definitions = explanation.split()
+                for definition in definitions:
+                    defs.append(objects.DefinitionTuple(definition, "釋義", []))
+            if row["(輔助檢索用異體)"]:
+                defs.append(objects.DefinitionTuple(row["(輔助檢索用異體)"], "異體", []))
+
+            entry = objects.Entry(trad, simp, pin, jyut, freq=freq, defs=defs)
+            words[trad].add(entry)
+
+            for variant in traditional_variants[1:]:
+                trad = variant
+                simp = converter.convert(trad)
+                pin = lazy_pinyin(
+                    simp,
+                    style=Style.TONE3,
+                    neutral_tone_with_five=True,
+                )
+                pin = " ".join(pin).lower()
+                pin = pin.strip().replace("v", "u:")
+                freq = zipf_frequency(trad, "zh")
+                entry = objects.Entry(variant, simp, pin, jyut, freq=freq, defs=copy.deepcopy(defs))
+                words[trad].add(entry)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 11:
+        print(
+            (
+                "Usage: python3 -m jyutnet.parse <database filename> "
+                "<B01_讀音資料.csv> "
+                "<source name> <source short name> "
+                "<source version> <source description> <source legal> "
+                "<source link> <source update url> <source other>"
+            )
+        )
+        print(
+            (
+                "e.g. python3 -m gzzj.parse ./gzzj/developer/gzzj.db "
+                "./gzzj/data/B01_讀音資料.txt "
+                "廣州話正音字典 GZZJ 2023-03-13 "
+                '"1988 年，香港教育署語文教育學院中文系成立「常用字廣州話讀音研究委員會」，委員會由香港各大專院校學者組成，'
+                "為坊間辭書不一致的讀音進行審音工作，其成果見於 1990 年的《常用字廣州話讀音表》。\n\n"
+                "而在 1990 年，廣東語言學界成立「廣州話審音委員會」，開展了繼《常用字廣州話讀音表》後，第二次規模較大的粵語審音工作。"
+                "委員會成員包括粵、港、澳三地二十多名學者；成果則見於 2001 年出版的《廣州話正音字典》。"
+                "二書都是權威性的工具書，其注音皆有參考價值。\n\n"
+                '本數碼檔案根據 2004 年第二版的《廣州話正音字典》編成。" '
+                '"詹伯慧主編，2004/7 第二版，2007/2 第三次印刷" '
+                '"https://github.com/jyutnet/cantonese-books-data/tree/master/2004_%E5%BB%A3%E5%B7%9E%E8%A9%B1%E6%AD%A3%E9%9F%B3%E5%AD%97%E5%85%B8" "" "words"'
+            )
+        )
+        sys.exit(1)
+
+    cc_cedict.load()
+
+    words = defaultdict(set)
+    source = objects.SourceTuple(
+        sys.argv[3],
+        sys.argv[4],
+        sys.argv[5],
+        sys.argv[6],
+        sys.argv[7],
+        sys.argv[8],
+        sys.argv[9],
+        sys.argv[10],
+    )
+    parse_file(sys.argv[2], words)
+    write(sys.argv[1], source, words)

--- a/src/dictionaries/gzzj/parse.py
+++ b/src/dictionaries/gzzj/parse.py
@@ -107,7 +107,7 @@ def parse_file(filename, words):
         for row in reader:
             traditional_variants = row["字頭"].split("|")
             trad = traditional_variants[0]
-            trad = unicodedata.normalize('NFKD', trad)
+            trad = unicodedata.normalize("NFKD", trad)
             simp = converter.convert(trad)
 
             pin = lazy_pinyin(
@@ -139,7 +139,7 @@ def parse_file(filename, words):
 
             for variant in traditional_variants[1:]:
                 trad = variant
-                trad = unicodedata.normalize('NFKD', trad)
+                trad = unicodedata.normalize("NFKD", trad)
                 simp = converter.convert(trad)
                 pin = lazy_pinyin(
                     simp,

--- a/src/dictionaries/gzzj/parse.py
+++ b/src/dictionaries/gzzj/parse.py
@@ -29,7 +29,7 @@ def insert_words(c, words):
                 entry.freq,
             )
 
-            already_in_db = (entry_id == -1)
+            already_in_db = entry_id == -1
 
             if entry_id == -1:
                 entry_id = database.insert_entry(
@@ -143,7 +143,9 @@ def parse_file(filename, words):
                 pin = " ".join(pin).lower()
                 pin = pin.strip().replace("v", "u:")
                 freq = zipf_frequency(trad, "zh")
-                entry = objects.Entry(variant, simp, pin, jyut, freq=freq, defs=copy.deepcopy(defs))
+                entry = objects.Entry(
+                    variant, simp, pin, jyut, freq=freq, defs=copy.deepcopy(defs)
+                )
                 words[trad].add(entry)
 
 
@@ -151,7 +153,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 11:
         print(
             (
-                "Usage: python3 -m jyutnet.parse <database filename> "
+                "Usage: python3 -m gzzj.parse <database filename> "
                 "<B01_讀音資料.csv> "
                 "<source name> <source short name> "
                 "<source version> <source description> <source legal> "

--- a/src/dictionaries/gzzj/requirements.txt
+++ b/src/dictionaries/gzzj/requirements.txt
@@ -1,0 +1,6 @@
+jieba==0.42.1
+msgpack==1.0.2
+opencc==1.1.6
+pypinyin==0.43.0
+pypinyin-dict==0.1.0
+wordfreq==2.5.1

--- a/src/dictionaries/hsk3/README.md
+++ b/src/dictionaries/hsk3/README.md
@@ -6,3 +6,4 @@
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database from the wordlist.txt and charlist.txt files downloaded from `https://github.com/elkmovie/hsk30`.
+  - Run `python3 -m hsk3.parse help` to view instructions.

--- a/src/dictionaries/hsk3/parse.py
+++ b/src/dictionaries/hsk3/parse.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 12:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m hsk3.parse <database filename> "
                 "<HSK3 wordlist.txt filepath> <HSK3 charlist.txt filepath>"
                 "<source name> <source short name> "
                 "<source version> <source description> <source legal> "
@@ -143,7 +143,8 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 script.py hks3.db ./wordlist.txt ./charlist.txt HSK3.0 HSK3 2021-07-01 "
+                "e.g. python3 -m hsk3.parse hsk3/developer/hks3.db hsk3/data/wordlist.txt "
+                "hsk3/data/charlist.txt HSK3.0 HSK3 2021-07-01 "
                 '"本规范规定了中文作为第二语言的学习 者在生活、学习、'
                 "工作等领域运用中文完成交际的语言水平等级。本规范适用于国际中文教育的学习、"
                 '教学、测试与评估，并为其提供参考。" '

--- a/src/dictionaries/kaifangcidian/README.md
+++ b/src/dictionaries/kaifangcidian/README.md
@@ -1,9 +1,10 @@
 #### Usage:
 - To install required packages: `pip install -r requirements.txt`
-- Specific usage instructions for each script are provided by the scripts themselves.
+- Specific usage instructions for the script are provided by the script itself.
 - Run the scripts from the `dictionaries` folder, e.g. `python3 -m kaifangcidian.parse <database filename>`.
 
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database file for all the words contained in the traditional and simplified source files from Kaifangcidian.
   - The purpose of this script is to generate a database file from the Traditional + Yale romanisation file (cidian_zhyue-ft-kfcd-ylshu-2019623.txt) and Simplified + Jyutping romanisation file (cidian_zhyue-jt-kfcd-yp-2019623.txt), so that all entries have a simplified + traditional script version, as well as simplified + traditional definitions in Mandarin.
+  - Run `python3 -m kaifangcidian.parse help` to view instructions.

--- a/src/dictionaries/kaifangcidian/parse.py
+++ b/src/dictionaries/kaifangcidian/parse.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 12:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m kaifangcidian.parse <database filename> "
                 "<Kaifangcidian traditional + Yale file> "
                 "<Kaifangcidian simplified + Jyutping file> "
                 "<source name> <source short name> "
@@ -181,8 +181,9 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 script.py kfcd.db cidian_zhyue-ft-kfcd-ylshu-2019623.txt "
-                "cidian_zhyue-jt-kfcd-yp-2019623.txt Kaifangcidian KFCD 2019-06-23 "
+                "e.g. python3 -m kaifangcidian.parse kaifangcidian/developer/kfcd.db "
+                "kaifangcidian/data/cidian_zhyue-ft-kfcd-ylshu-2019623.txt "
+                "kaifangcidian/data/cidian_zhyue-jt-kfcd-yp-2019623.txt Kaifangcidian KFCD 2019-06-23 "
                 '"Kaifangcidian is a dictionary" '
                 '"本词典以创作共用“署名 3.0”许可协议授权发布（详见 http://creativecommons.org/licenses/by/3.0/）" '
                 '"http://www.kaifangcidian.com/han/yue" "" ""'

--- a/src/dictionaries/moedict/README.md
+++ b/src/dictionaries/moedict/README.md
@@ -1,8 +1,9 @@
 #### Usage:
 - To install required packages: `pip install -r requirements.txt`
-- Specific usage instructions for each script are provided by the scripts themselves.
+- Specific usage instructions for the script are provided by the script itself.
 - Run the scripts from the `dictionaries` folder, e.g. `python3 -m moedict.parse <database filename> <dict-revised.json>`.
 
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database file for all entries provided by the dict-revised.json file downloaded from https://github.com/g0v/moedict-data.
+  - Run `python3 -m moedict.parse help` to view instructions.

--- a/src/dictionaries/moedict/parse.py
+++ b/src/dictionaries/moedict/parse.py
@@ -403,7 +403,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 11:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m moedict.parse <database filename> "
                 "<dict-revised.json filepath> "
                 "<source name> <source short name> "
                 "<source version> <source description> <source legal> "
@@ -412,7 +412,7 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 script.py moedict.db ./dict-revised.json "
+                "e.g. python3 -m moedict.parse moedict/developer/moedict.db moedict/data/dict-revised.json "
                 '"Ministry of Education Dictionary (MoEDict)" MOE 2021-08-06 '
                 '"本典為一部歷史語言辭典，記錄中古至現代各類詞語，並大量引用古典文獻書證，字 音部分則兼收現代及傳統音讀。" '
                 '"中華民國教育部《重編國語辭典修訂本》資料採「創用CC-姓名標示- 禁止改作 3.0 臺灣授權條款」釋出'

--- a/src/dictionaries/tatoeba/README.md
+++ b/src/dictionaries/tatoeba/README.md
@@ -1,9 +1,10 @@
 #### Usage:
 - To install required packages: `pip install -r requirements.txt`
-- Specific usage instructions for each script are provided by the scripts themselves.
+- Specific usage instructions for the script are provided by the script itself.
 - Run the scripts from the `dictionaries` folder, e.g. `python3 -m tatoeba.parse <database filename> <Tatoeba sentences file> <Tatoeba links file>`.
 
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database file for all sentences and translations between a language pair specified by their ISO-639-3 language codes (e.g. `eng` for English, `fra` for French, `cmn` for Mandarin, `yue` for Cantonese).
   - The purpose of this script is to generate a database file from a sentences.csv file (showing sentences themselves) and links.csv (translations between those sentences). It also traverses the sentence graph to find sentences that are one indirect translation away (e.g. Cantonese -> English -> French).
+  - Run `python3 -m tatoeba.parse help` to view instructions.

--- a/src/dictionaries/tatoeba/parse.py
+++ b/src/dictionaries/tatoeba/parse.py
@@ -215,7 +215,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 16:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m tatoeba.parse <database filename> "
                 "<Tatoeba sentences file> <Tatoeba links file> "
                 "<source language> <target language> "
                 "<source name> <source short name> "
@@ -227,8 +227,8 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 -m tatoeba.parse yue-eng.db "
-                "./tatoeba/data/sentences.csv ./tatoeba/data/links.csv "
+                "e.g. python3 -m tatoeba.parse tatoeba/developer/yue-eng.db "
+                "tatoeba/data/sentences.csv tatoeba/data/links.csv "
                 "yue eng Tatoeba TTB 2018-07-09 "
                 '"Tatoeba is a collection of sentences." '
                 '"These files are released under CC BY 2.0 FR." '

--- a/src/dictionaries/two_shores_three_places/README.md
+++ b/src/dictionaries/two_shores_three_places/README.md
@@ -1,8 +1,9 @@
 #### Usage:
 - To install required packages: `pip install -r requirements.txt`
-- Specific usage instructions for each script are provided by the scripts themselves.
+- Specific usage instructions for the script are provided by the script itself.
 - Run the scripts from the `dictionaries` folder, e.g. `python3 -m two_shores_three_places.parse <database filename> <dict-同實異名.json>`.
 
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database file for all entries provided by the 兩岸三地生活差異詞語彙編-同實異名.csv and 兩岸三地生活差異詞語彙編-同名異實.csv files downloaded from https://github.com/g0v/moedict-data-csld.
+  - Run `python3 -m two_shores_three_places.parse help` to view instructions.

--- a/src/dictionaries/two_shores_three_places/parse.py
+++ b/src/dictionaries/two_shores_three_places/parse.py
@@ -193,9 +193,10 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 -m two_shores_three_places.parse lnsd.db "
-                "./two_shores_three_places/data/兩岸三地生活差異詞語彙編-同實異名.csv "
-                "./two_shores_three_places/data/兩岸三地生活差異詞語彙編-同名異實.csv "
+                "e.g. python3 -m two_shores_three_places.parse "
+                "two_shores_three_places/developer/lnsd.db "
+                "two_shores_three_places/data/兩岸三地生活差異詞語彙編-同實異名.csv "
+                "two_shores_three_places/data/兩岸三地生活差異詞語彙編-同名異實.csv "
                 '"兩岸三地生活差異詞語彙編—Two Shores Three Places" LNSD 2019-06-23 '
                 '"The Two Shores Three Places dictionary compares usage of common terms in Mainland China, Taiwan, and Hong Kong." '
                 '"《兩岸三地生活差異詞語彙編》由中華文化總會以 CC BY-NC-ND 4.0 之条款下提供。" '

--- a/src/dictionaries/unihan/README.md
+++ b/src/dictionaries/unihan/README.md
@@ -6,3 +6,4 @@
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database from the Dictionary-Like-Data, Readings, and Variants files downloaded from `https://www.unicode.org/Public/UCD/latest/ucd/Unihan.zip`.
+  - Run `python3 -m unihan.parse help` to view instructions.

--- a/src/dictionaries/unihan/parse.py
+++ b/src/dictionaries/unihan/parse.py
@@ -395,7 +395,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 13:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m unihan.parse <database filename> "
                 "<Unihan_DictionaryLikeData.txt filepath> "
                 "<Unihan_Readings.txt filepath> "
                 "<Unihan_Variants.txt filepath> "
@@ -406,8 +406,9 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 script.py unihan.db ./Unihan_DictionaryLikeData.txt "
-                "./Unihan_Readings.txt ./Unihan_Variants.txt Unihan UNI 2021-08-06 "
+                "e.g. python3 -m unihan.parse unihan/developer/unihan.db "
+                "unihan/data/Unihan_DictionaryLikeData.txt "
+                "unihan/data/Unihan_Readings.txt unihan/data/Unihan_Variants.txt Unihan UNI 2021-08-06 "
                 '"The Unihan database is the repository for the Unicode Consortium’s '
                 "collective knowledge regarding the CJK Unified Ideographs "
                 "contained in the Unicode Standard. It contains mapping data to "

--- a/src/dictionaries/wiktionary/README.md
+++ b/src/dictionaries/wiktionary/README.md
@@ -1,8 +1,9 @@
 #### Usage:
 - To install required packages: `pip install -r requirements.txt`
-- Specific usage instructions for each script are provided by the scripts themselves.
+- Specific usage instructions for the script are provided by the script itself.
 - **Run the scripts from the `dictionaries` folder, e.g. `python3 -m wiktionary.parse <database filename> <wiktionary.json file> <source name> <source short name> <source version> <source description> <source legal> <source link> <source update url> <source other>`.**
 
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database from the `wiktionary.json` file provided by Kaikki's wiktextract project. See [Kaikki's webpage](https://kaikki.org/dictionary/Chinese/nonsenses.html) or the [Github project](https://github.com/tatuylonen/wiktextract) for more details.
+  - Run `python3 -m wiktionary.parse help` to view instructions.

--- a/src/dictionaries/wiktionary/parse.py
+++ b/src/dictionaries/wiktionary/parse.py
@@ -38,6 +38,7 @@ import unicodedata
 # - 奇異筆: Basic Cantonese and Mandarin test
 # - 回去: Mandarin neutral tone
 # - 閪: Basic Cantonese test
+# - 女媧: has ü in Pinyin
 
 # Useful test examples:
 # - 呢度好閪热呀！ [Cantonese, simp.]nei¹ dou⁶ hou² hai¹ jit⁶ aa³! [Jyutping]
@@ -407,7 +408,7 @@ def process_mandarin_romanization(romanization):
                 converted_syllable = to_tone3(
                     syllable, v_to_u=True, neutral_tone_with_five=True
                 )
-                converted_syllable.replace("ü", "u:")
+                converted_syllable = converted_syllable.replace("ü", "u:")
 
                 # Erhua is not well supported in Jyut Dictionary, so convert "r" to "er"
                 if PINYIN_ERHUA_REGEX.match(syllable):
@@ -516,13 +517,11 @@ def parse_file(filename, words):
                 pinyin_jyutping_sentence.jyutping(trad, tone_numbers=True, spaces=True)
             ]
         if not pinyin_list:
-            pinyin_list = [
-                " ".join(
-                    lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True)
-                )
-                .lower()
-                .replace("v", "u:")
-            ]
+            generated_pinyin = " ".join(
+                lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True)
+            ).lower()
+            generated_pinyin = generated_pinyin.replace("v", "u:").replace("ü", "u:")
+            pinyin_list = [generated_pinyin]
 
         freq = zipf_frequency(trad, "zh")
 

--- a/src/dictionaries/wiktionary/parse.py
+++ b/src/dictionaries/wiktionary/parse.py
@@ -1018,7 +1018,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 11:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m wiktionary.parse <database filename> "
                 "<dict-wk.json filepath> "
                 "<source name> <source short name> "
                 "<source version> <source description> <source legal> "
@@ -1027,7 +1027,7 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 -m wiktionary.parse wiktionary.db ./dict-wk.json "
+                "e.g. python3 -m wiktionary.parse wiktionary/developer/wiktionary.db wiktionary/data/dict-wk.json "
                 '"Wiktionary" WT 2023-02-16 '
                 '"Wiktionary is a collaborative project to produce a free-content multilingual dictionary. '
                 'It aims to describe all words of all languages using definitions and descriptions in English." '

--- a/src/dictionaries/words_hk/README.md
+++ b/src/dictionaries/words_hk/README.md
@@ -1,8 +1,9 @@
 #### Usage:
 - To install required packages: `pip install -r requirements.txt`
-- Specific usage instructions for each script are provided by the scripts themselves.
+- Specific usage instructions for the script are provided by the script itself.
 - Run the scripts from the `dictionaries` folder, e.g. `python3 -m words_hk.parse <database filename>`.
 
 #### Scripts:
 - `parse.py`
   - This script generates a SQLite database from the `all.csv` file that is provided by words.hk.
+  - Run `python3 -m words_hk.parse help` to view instructions.

--- a/src/dictionaries/words_hk/parse.py
+++ b/src/dictionaries/words_hk/parse.py
@@ -405,7 +405,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 11:
         print(
             (
-                "Usage: python3 script.py <database filename> "
+                "Usage: python3 -m words_hk.parse <database filename> "
                 "<all.csv file> <source name> <source short name> "
                 "<source version> <source description> <source legal> "
                 "<source link> <source update url> <source other>"
@@ -413,7 +413,8 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 -m words_hk.parse words_hk.db words_hk/data/all.csv 粵典–words.hk WHK 2021-12-23 "
+                "e.g. python3 -m words_hk.parse words_hk/developer/words_hk.db "
+                "words_hk/data/all.csv 粵典–words.hk WHK 2021-12-23 "
                 '"《粵典》係一個大型嘅粵語辭典計劃。我哋會用Crowd-sourcing嘅方法，整一本大型、可持續發展嘅粵語辭典。" '
                 '"https://words.hk/base/hoifong/" "https://words.hk/" "" ""'
             )


### PR DESCRIPTION
# Description

This commit adds a parsing script for 廣州話正音字典, as provided by jyut.net. This dictionary provides pronunciation data and examples for characters only. It also corrects minor bugs in other parsing scripts, and updates documentation in various READMEs.

Closes #114.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with Python 3.11 on macOS 12.3.1. Manually inspected results.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
