### PR TITLE
#119: Update version number to 2.23.0408

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Aaron Tan
+Copyright (c) 2023 Aaron Tan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/jyut-dict/logic/utils/utils.h
+++ b/src/jyut-dict/logic/utils/utils.h
@@ -1,7 +1,7 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#include "logic/strings/strings.h"
+#include <qglobal.h>
 
 #include <string>
 #include <vector>
@@ -59,7 +59,7 @@ namespace Utils {
 
     // Strings that are not language dependent should go here.
     // If they need to be translated, put them in strings.h
-    constexpr auto CURRENT_VERSION = "1.22.0207";
+    constexpr auto CURRENT_VERSION = "2.23.0408";
     constexpr auto AUTHOR_EMAIL = "mailto: hi@aaronhktan.com";
     constexpr auto DONATE_LINK = "https://www.paypal.me/cheeseisdisgusting";
     constexpr auto AUTHOR_GITHUB_LINK = "https://github.com/aaronhktan/";

--- a/src/jyut-dict/platform/linux/deb/create-deb.sh
+++ b/src/jyut-dict/platform/linux/deb/create-deb.sh
@@ -2,18 +2,18 @@
 
 # Zip up entirety of src/jyut-dict into a zip beside jyut-dict
 cd ../../../
-tar -cvzf ../jyut-dict_1.22.0207.tar.gz * --overwrite
+tar -cvzf ../jyut-dict_2.23.0408.tar.gz * --overwrite
 
 # Switch to src/ directory
 cd ../
 
 # Create folder matching current version of jyut-dict
-rm -rf jyut-dict_1.22.0207
-mkdir jyut-dict_1.22.0207
-cd jyut-dict_1.22.0207
+rm -rf jyut-dict_2.23.0408
+mkdir jyut-dict_2.23.0408
+cd jyut-dict_2.23.0408
 
 # Expand zip file into the folder
-tar -xvzf ../jyut-dict_1.22.0207.tar.gz --overwrite
+tar -xvzf ../jyut-dict_2.23.0408.tar.gz --overwrite
 
 # Delete unneeded files copied by make
 rm ./dict.db
@@ -24,7 +24,7 @@ cp -r ../jyut-dict/platform/linux/deb/debian ./debian
 
 # Creates an orig tar.gz file required for debuild
 # Also creates generic debian/ folder structure if previous command failed
-dh_make -c mit -s -f ../jyut-dict_1.22.0207.tar.gz -p jyut-dict_1.22.0207
+dh_make -c mit -s -f ../jyut-dict_2.23.0408.tar.gz -p jyut-dict_2.23.0408
 
 # Generate the .deb file.
 debuild

--- a/src/jyut-dict/platform/linux/deb/debian/changelog
+++ b/src/jyut-dict/platform/linux/deb/debian/changelog
@@ -1,3 +1,11 @@
+jyut-dict (2.23.0408) bionic; urgency=medium
+
+  * Support for Yale, Bopomofo, and IPA.
+  * Adjust interface size.
+  * Bug fixes.
+
+ -- Aaron Tan <hi@aaronhktan.com>  Sat, 8 Apr 2022 16:44:11 -0400
+
 jyut-dict (1.22.0207) bionic; urgency=medium
 
   * See examples with their definitions.

--- a/src/jyut-dict/platform/linux/deb/debian/files
+++ b/src/jyut-dict/platform/linux/deb/debian/files
@@ -1,3 +1,3 @@
-jyut-dict-dbgsym_1.22.0207-1_amd64.ddeb debug optional
-jyut-dict_1.22.0207-1_amd64.buildinfo utils optional
-jyut-dict_1.22.0207-1_amd64.deb utils optional
+jyut-dict-dbgsym_2.23.0408-1_amd64.ddeb debug optional
+jyut-dict_2.23.0408-1_amd64.buildinfo utils optional
+jyut-dict_2.23.0408-1_amd64.deb utils optional

--- a/src/jyut-dict/platform/mac/Info.plist
+++ b/src/jyut-dict/platform/mac/Info.plist
@@ -17,7 +17,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.22.0207</string>
+  <string>2.23.0408</string>
   <key>LSMinimumSystemVersion</key>
   <string>10.12</string>
   <key>LSBackgroundOnly</key>

--- a/src/jyut-dict/platform/windows/installer/config/config_32.xml
+++ b/src/jyut-dict/platform/windows/installer/config/config_32.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Installer>
     <Name>Jyut Dictionary</Name>
-    <Version>2022-02-07</Version>
+    <Version>2023-04-08</Version>
     <Title>Jyut Dictionary</Title>
     <Publisher>Aaron Tan</Publisher>
     <StartMenuDir>Jyut Dictionary</StartMenuDir>

--- a/src/jyut-dict/platform/windows/installer/config/config_64.xml
+++ b/src/jyut-dict/platform/windows/installer/config/config_64.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Installer>
     <Name>Jyut Dictionary</Name>
-    <Version>2022-02-07</Version>
+    <Version>2023-04-08</Version>
     <Title>Jyut Dictionary</Title>
     <Publisher>Aaron Tan</Publisher>
     <StartMenuDir>Jyut Dictionary</StartMenuDir>

--- a/src/jyut-dict/platform/windows/installer/packages/com.aaronhktan.cantonesedictionary/meta/LICENSE.md
+++ b/src/jyut-dict/platform/windows/installer/packages/com.aaronhktan.cantonesedictionary/meta/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Aaron Tan
+Copyright (c) 2023 Aaron Tan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/jyut-dict/platform/windows/installer/packages/com.aaronhktan.cantonesedictionary/meta/package.xml
+++ b/src/jyut-dict/platform/windows/installer/packages/com.aaronhktan.cantonesedictionary/meta/package.xml
@@ -10,8 +10,8 @@
     <Description xml:lang="zh_CN">粤语词典软件。</Description>
     <Description xml:lang="zh_HK">粵語辭典軟件。</Description>
     <Description xml:lang="zh_TW">粵語辭典軟件。</Description>
-    <Version>2022.02.07</Version>
-    <ReleaseDate>2022-02-07</ReleaseDate>
+    <Version>2023.04.08</Version>
+    <ReleaseDate>2023-04-08</ReleaseDate>
     <Licenses>
         <License name="MIT License" file="LICENSE.md" />
     </Licenses>


### PR DESCRIPTION
# Description

This commit sets the version number to 2.23.0408 across all documents and code.

Closes #119.

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Built on Qt 5.15.2 on macOS 12.3.1.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
