### PR TITLE
#133: Fix malformed Pinyin -> Zhuyin conversion

### DIFF
--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -964,6 +964,12 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
             std::string final;
             std::string er;
             if (final_match[1].length()) {
+                auto final_match_pos = zhuyinFinals.find(final_match[1]);
+                if (final_match_pos == zhuyinFinals.end()) {
+                    // No final could be converted, give up
+                    zhuyin_syllables.emplace_back(syllable);
+                    continue;
+                }
                 final = zhuyinFinals.at(final_match[1]);
             }
             if (final_match[2].length()) {


### PR DESCRIPTION
# Description

- When Pinyin final is malformed, give up immediately and continue to next syllable.

Closes #133.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Pop!_OS 22.04.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
