### PR TITLE
#41: Improve auto-detection by first checking for existence of results

### DIFF
--- a/src/jyut-dict/logic/search/searchqueries.h
+++ b/src/jyut-dict/logic/search/searchqueries.h
@@ -288,6 +288,13 @@ constexpr auto SEARCH_TRADITIONAL_QUERY
       "  definitions "
       "FROM matching_entries; ";
 
+constexpr auto SEARCH_JYUTPING_EXISTS_QUERY = "SELECT EXISTS ( "
+                                              "  SELECT "
+                                              "    rowid "
+                                              "  FROM entries "
+                                              "  WHERE jyutping GLOB ? "
+                                              ") AS existence ";
+
 constexpr auto SEARCH_JYUTPING_QUERY
     = "WITH "
       "  matching_entry_ids AS ( "
@@ -432,6 +439,13 @@ constexpr auto SEARCH_JYUTPING_QUERY
       "  pinyin, "
       "  definitions "
       "FROM matching_entries; ";
+
+constexpr auto SEARCH_PINYIN_EXISTS_QUERY = "SELECT EXISTS ( "
+                                            "  SELECT "
+                                            "    rowid "
+                                            "  FROM entries "
+                                            "  WHERE pinyin GLOB ? "
+                                            ") AS existence ";
 
 constexpr auto SEARCH_PINYIN_QUERY
     = "WITH "


### PR DESCRIPTION
# Description

- For search terms that could be ambiguous (i.e. valid Jyutping and English), or valid Jyutping and Pinyin, etc.), first check for whether there are any terms that match the first detected script. If there are none, skip to the next, and finally fall through to English.
- Examples:
  - mango could be parsed as man[1-6] go[1-6] in Jyutping, but there are no results. It's not valid Pinyin, so we search for English.
  - wangdi could be parsed as wang[1-6] di[1-6] in Jyutping, but there are no results. It is valid Pinyin, and there are results, so we interpret this as a search for Pinyin.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] macOS

**Test Configuration**: Tested as described in #143.
* OS and version: macOS 14.1 Sonoma
* Toolchain: Xcode 15 clang/clang++
* Qt Version: Qt 5.15.12

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
