### PR TITLE
#28: Add data from Wikipedia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ CMakeLists.txt.user*
 **/unihan/archive_*
 **/unihan/data/*
 **/unihan/developer/*
+**/wiki/archive_*
+**/wiki/data/*
+**/wiki/developer/*
 **/wiktionary/archive_*
 **/wiktionary/data/*
 **/wiktionary/developer/*

--- a/src/dictionaries/wiki/README.md
+++ b/src/dictionaries/wiki/README.md
@@ -1,0 +1,9 @@
+#### Usage:
+- To install required packages: `pip install -r requirements.txt`
+- Specific usage instructions for the script are provided by the script itself.
+- **Run the scripts from the `dictionaries` folder, e.g. `python3 -m wiki.parse <database filename> <page.db file> <langlinks.db file> <source language> <destination language> <source name> <source short name> <source version> <source description> <source legal> <source link> <source update url> <source contents>`.**
+
+#### Scripts:
+- `parse.py`
+  - This script generates a SQLite database from dumped `langlinks` and `page` SQL files provided by Wikimedia. For example, the dumped files for the Cantonese Wikipedia are available [here](https://dumps.wikimedia.org/zh_yuewiki/20240201/). The langlinks file is called `zh_yuewiki-<DATE>-langlinks.sql.gz`, and the page file is called `zh_yuewiki-<DATE>-page.sql.gz`. These files must be extracted, then converted from MySQL to SQLite3 format using something like [mysql2sqlite](https://github.com/dumblob/mysql2sqlite). **Remove all unique constraints from the generated SQLite3 command**, otherwise your will be missing a significant number of articles!
+  - Run `python3 -m wiki.parse help` to view instructions.

--- a/src/dictionaries/wiki/parse.py
+++ b/src/dictionaries/wiki/parse.py
@@ -1,0 +1,231 @@
+import jieba
+import opencc
+import pinyin_jyutping_sentence
+from pypinyin import lazy_pinyin, Style
+from pypinyin_dict.phrase_pinyin_data import cc_cedict
+from wordfreq import zipf_frequency
+import wikipedia
+
+from database import database, objects
+
+from collections import defaultdict, namedtuple
+import copy
+import csv
+from itertools import chain
+import logging
+import re
+import sqlite3
+import sys
+import time
+import traceback
+
+yue_converter = opencc.OpenCC("hk2s.json")
+zh_converter = opencc.OpenCC("tw2s.json")
+wikipedia.set_rate_limiting(True)
+
+
+def insert_words(c, words):
+    # Because the sentence id is presumed to be unique by Tatoeba, we will give it
+    # a namespace of 999999999 potential sentences. Thus, words.hk sentences will start
+    # at rowid 1000000000.
+    example_id = 1000000000
+
+    for key in words:
+        for entry in words[key]:
+            trad = entry.traditional
+            simp = entry.simplified
+            jyut = entry.jyutping
+            pin = entry.pinyin
+            freq = entry.freq
+
+            entry_id = database.get_entry_id(c, trad, simp, pin, jyut, freq)
+
+            if entry_id == -1:
+                entry_id = database.insert_entry(c, trad, simp, pin, jyut, freq, None)
+                if entry_id == -1:
+                    logging.warning(f"Could not insert word {trad}, uh oh!")
+                    continue
+
+            # Insert each meaning for the entry
+            for definition in entry.definitions:
+                definition_id = database.insert_definition(
+                    c, definition.definition, definition.label, entry_id, 1, None
+                )
+                if definition_id == -1:
+                    # Try to find definition if we got an error
+                    definition_id = database.get_definition_id(
+                        c, definition.definition, definition.label, entry_id, 1
+                    )
+                    if definition_id == -1:
+                        logging.warning(
+                            f"Could not insert definition {definition} for word {trad}, uh oh!"
+                        )
+                        continue
+
+
+def write(db_name, source, words):
+    print("Writing to database file")
+
+    db = sqlite3.connect(db_name)
+    c = db.cursor()
+
+    database.write_database_version(c)
+
+    database.drop_tables(c)
+    database.create_tables(c)
+
+    # Add source information to table
+    database.insert_source(
+        c,
+        source.name,
+        source.shortname,
+        source.version,
+        source.description,
+        source.legal,
+        source.link,
+        source.update_url,
+        source.other,
+        None,
+    )
+
+    insert_words(c, words)
+
+    database.generate_indices(c)
+
+    db.commit()
+    db.close()
+
+
+def parse_file(page_filepath, langlinks_filepath, words):
+    db = sqlite3.connect(page_filepath)
+    c = db.cursor()
+
+    c.execute(f"ATTACH DATABASE '{langlinks_filepath}' AS langlinks")
+
+    # Get the list of all non-redirect article pages in this Wikipedia
+    c.execute(
+        ("""SELECT 
+           page_id, page_title, l.ll_title 
+         FROM 
+           page AS p
+         JOIN 
+           langlinks.langlinks AS l
+         ON 
+           p.page_id = l.ll_from 
+         WHERE 
+           page_namespace = 0 
+         AND 
+           page_is_redirect = 0 
+         AND 
+           ll_lang = 'en'""")
+    )
+    rows = c.fetchall()
+
+    for i, row in enumerate(rows):
+        if not i % 100:
+            logging.info(f"Processed entry #{i}")
+
+        trad = str(row[1]).replace("_", " ")
+        simp = yue_converter.convert(trad)
+        jyut = pinyin_jyutping_sentence.jyutping(
+                trad, tone_numbers=True, spaces=True
+            )
+        pin = (
+            " ".join(lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True))
+            .lower()
+            .replace("v", "u:")
+        )
+
+        if "搞清楚" in trad:
+            # This is a disambiguation page, skip
+            continue
+
+        wikipedia.set_lang("zh-yue")
+        definition_components = []
+        cannot_be_parsed = False
+        timeouts = 0
+        while True:
+            try:
+                definition_components.append(wikipedia.summary(trad, auto_suggest=False, sentences=1))
+                break
+            except wikipedia.exceptions.DisambiguationError:
+                logging.warning(f"DisambiguationError for word {trad}")
+                cannot_be_parsed = True
+                break
+            except TimeoutError:
+                logging.warning(f"Timed out for word {trad}, retrying")
+                timeouts += 1
+                time.sleep(120 * timeouts)
+            except Exception as e:
+                logging.error(e)
+                break
+        if cannot_be_parsed:
+            continue
+
+        wikipedia.set_lang("en")
+        english_term = str(row[2])
+        definition_components.append(english_term)
+        timeouts = 0
+        while True:
+            try:
+                english_description = wikipedia.summary(english_term, auto_suggest=False, sentences=1)
+                english_description = english_description.replace(" ", "ﾠ")
+                definition_components.append(english_description)
+                break
+            except wikipedia.exceptions.DisambiguationError:
+                logging.warning(f"DisambiguationError for English word {english_term}")
+                break
+            except TimeoutError:
+                logging.warning(f"Timed out for English word {english_term}, retrying")
+                timeouts += 1
+                time.sleep(120 * timeouts)
+            except Exception as e:
+                logging.error(e)
+                break
+
+        definition = objects.Definition(definition="\n".join(definition_components))
+        freq = zipf_frequency(trad, "zh")
+
+        entry = objects.Entry(trad=trad, simp=simp, jyut=jyut, pin=pin, freq=freq, defs=[definition])
+        words[trad].append(entry)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 12:
+        print(
+            (
+                "Usage: python3 -m wikipedia.parse <database filename> "
+                "<page.db file> <langlinks.db file> <source name> <source short name> "
+                "<source version> <source description> <source legal> "
+                "<source link> <source update url> <source other>"
+            )
+        )
+        print(
+            (
+                "e.g. python3 -m wikipedia.parse wikipedia/developer/wikipedia.db "
+                "wikipedia/data/page.db wikipedia/data/langlinks.db Wikipedia WK 2024-01-01 "
+                '"Wikipedia[note 3] is a free-content online encyclopedia, written and maintained '
+                'by a community of volunteers, collectively known as Wikipedians, through open '
+                'collaboration and the use of wiki-based editing system MediaWiki." '
+                '"https://en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License"'
+                '"https://www.wikipedia.org/" "" ""'
+            )
+        )
+        sys.exit(1)
+
+    cc_cedict.load()
+
+    source = objects.SourceTuple(
+        sys.argv[4],
+        sys.argv[5],
+        sys.argv[6],
+        sys.argv[7],
+        sys.argv[8],
+        sys.argv[9],
+        sys.argv[10],
+        sys.argv[11],
+    )
+    logging.basicConfig(level='INFO') # Uncomment to enable debug logging
+    parsed_words = defaultdict(list)
+    parse_file(sys.argv[2], sys.argv[3], parsed_words)
+    write(sys.argv[1], source, parsed_words)

--- a/src/dictionaries/wiki/parse.py
+++ b/src/dictionaries/wiki/parse.py
@@ -288,7 +288,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 14:
         print(
             (
-                "Usage: python3 -m wikipedia.parse <database filename> "
+                "Usage: python3 -m wiki.parse <database filename> "
                 "<page.db file> <langlinks.db file> <source language> "
                 "<destination language> <source name> <source short name> "
                 "<source version> <source description> <source legal> "
@@ -297,7 +297,7 @@ if __name__ == "__main__":
         )
         print(
             (
-                "e.g. python3 -m wikipedia.parse wikipedia/developer/wikipedia.db "
+                "e.g. python3 -m wiki.parse wikipedia/developer/wikipedia.db "
                 "wikipedia/data/page.db wikipedia/data/langlinks.db zh-yue en Wikipedia WK 2024-01-01 "
                 '"Wikipedia is a free-content online encyclopedia, written and maintained '
                 "by a community of volunteers, collectively known as Wikipedians, through open "

--- a/src/dictionaries/wiki/parse.py
+++ b/src/dictionaries/wiki/parse.py
@@ -272,18 +272,18 @@ if __name__ == "__main__":
                 "<page.db file> <langlinks.db file> <source language> "
                 "<destination language> <source name> <source short name> "
                 "<source version> <source description> <source legal> "
-                "<source link> <source update url> <source other>"
+                "<source link> <source update url> <source contents>"
             )
         )
         print(
             (
                 "e.g. python3 -m wikipedia.parse wikipedia/developer/wikipedia.db "
                 "wikipedia/data/page.db wikipedia/data/langlinks.db zh-yue en Wikipedia WK 2024-01-01 "
-                '"Wikipedia[note 3] is a free-content online encyclopedia, written and maintained '
+                '"Wikipedia is a free-content online encyclopedia, written and maintained '
                 'by a community of volunteers, collectively known as Wikipedians, through open '
                 'collaboration and the use of wiki-based editing system MediaWiki." '
-                '"https://en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License"'
-                '"https://www.wikipedia.org/" "" ""'
+                '"Text is available under the Creative Commons Attribution-ShareAlike License 4.0."'
+                '"https://www.wikipedia.org/" "" "words"'
             )
         )
         sys.exit(1)

--- a/src/dictionaries/wiki/parse.py
+++ b/src/dictionaries/wiki/parse.py
@@ -197,6 +197,7 @@ def parse_file(page_filepath, langlinks_filepath, lang_src, lang_dest, words):
         rows = c.fetchall()
 
     for i in range(0, len(rows), 20):
+        # The maximum batch amount for a single Wikimedia API request is 20 items
         src_strings = [str(x[0]).replace("_", " ") for x in rows[i:i+20]]
         dest_strings = [str(x[1]).replace("_", " ") for x in rows[i:i+20]]
         correspondences = dict(zip(src_strings, dest_strings))
@@ -231,6 +232,8 @@ def parse_file(page_filepath, langlinks_filepath, lang_src, lang_dest, words):
                         trad.translate(WIDE_DIGIT_EQUIVALENT), tone_numbers=True, spaces=True
                     )
 
+                # If pinyin_jyutping_sentences cannot convert to Jyutping, use
+                # pycantonese to convert the character instead
                 han_chars = HAN_REGEX.findall(jyut)
                 for char in han_chars:
                     char_jyutping = pycantonese.characters_to_jyutping(char)[0][1]
@@ -297,7 +300,7 @@ if __name__ == "__main__":
         sys.argv[12],
         sys.argv[13],
     )
-    logging.basicConfig(level='INFO') # Uncomment to enable debug logging
+    # logging.basicConfig(level='INFO') # Uncomment to enable debug logging
     parsed_words = defaultdict(list)
     parse_file(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], parsed_words)
     write(sys.argv[1], source, parsed_words)

--- a/src/dictionaries/wiki/requirements.txt
+++ b/src/dictionaries/wiki/requirements.txt
@@ -2,7 +2,7 @@ jieba==0.42.1
 msgpack==1.0.2
 opencc==1.1.7
 pinyin_jyutping_sentence==1.0
+pycantonese==3.4.0
 pypinyin==0.43.0
 pypinyin-dict==0.1.0
-wikipedia==1.4.0
 wordfreq==2.5.1

--- a/src/dictionaries/wiki/requirements.txt
+++ b/src/dictionaries/wiki/requirements.txt
@@ -1,0 +1,8 @@
+jieba==0.42.1
+msgpack==1.0.2
+opencc==1.1.7
+pinyin_jyutping_sentence==1.0
+pypinyin==0.43.0
+pypinyin-dict==0.1.0
+wikipedia==1.4.0
+wordfreq==2.5.1

--- a/src/jyut-dict/logic/database/queryparseutils.cpp
+++ b/src/jyut-dict/logic/database/queryparseutils.cpp
@@ -81,8 +81,13 @@ std::vector<Entry> parseEntries(QSqlQuery &query, bool parseDefinitions)
                         }
                     }
 
-                    definitions.emplace_back(definition["definition"].toString().toStdString(),
-                                             definition["label"].toString().toStdString(),
+                    definitions.emplace_back(definition["definition"]
+                                                 .toString()
+                                                 .replace("ﾠ", " ")
+                                                 .toStdString(),
+                                             definition["label"]
+                                                 .toString()
+                                                 .toStdString(),
                                              sentences);
                 }
 

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -16,8 +16,9 @@ namespace ChineseUtils {
 static std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
 
 const static std::unordered_set<std::string> specialCharacters = {
-    ".", "。", ",", "，", "!",  "！", "?", "？", "%",  "－",
-    "…", "⋯",  ".", "·",  "\"", "“",  "”", "$",  "｜",
+    ".",  "。", ",",  "，", "!",  "！", "?",  "？", "%",  "－", "…",
+    "⋯",  ".",  "·",  "\"", "“",  "”",  "$",  "｜", "：", "(",  ")",
+    "１", "２", "３", "４", "５", "６", "７", "８", "９", "０",
 };
 
 const static std::unordered_map<std::string, std::string>
@@ -372,11 +373,6 @@ std::string compareStrings(const std::string &original,
             continue;
         }
 
-        if (std::find_if(currentCharacter.begin(), currentCharacter.end(), isalpha) != currentCharacter.end()) {
-            result += currentCharacter;
-            continue;
-        }
-
         result += Utils::SAME_CHARACTER_STRING;
     }
 
@@ -472,10 +468,14 @@ std::string convertJyutpingToYale(const std::string &jyutping,
         }
         Utils::split(jyutpingCopy, ' ', syllables);
     } else {
-        segmentJyutping(QString{jyutping.c_str()},
-                        syllables,
-                        /* removeSpecialCharacters */ false,
-                        /* removeGlobCharacters */ false);
+        bool valid_jyutping
+            = segmentJyutping(QString{jyutping.c_str()},
+                              syllables,
+                              /* removeSpecialCharacters */ false,
+                              /* removeGlobCharacters */ false);
+        if (!valid_jyutping) {
+            return "x";
+        }
     }
 
     std::vector<std::string> yale_syllables;
@@ -618,10 +618,13 @@ std::string convertJyutpingToIPA(const std::string &jyutping,
         }
         Utils::split(jyutpingCopy, ' ', syllables);
     } else {
-        segmentJyutping(QString{jyutping.c_str()},
-                        syllables,
-                        /* removeSpecialCharacters */ false,
-                        /* removeGlobCharacters */ false);
+        bool validJyutping = segmentJyutping(QString{jyutping.c_str()},
+                                             syllables,
+                                             /* removeSpecialCharacters */ false,
+                                             /* removeGlobCharacters */ false);
+        if (!validJyutping) {
+            return "x";
+        }
     }
 
     std::vector<std::string> ipa_syllables;


### PR DESCRIPTION
# Description

This PR adds a script to pull data based on interlanguage links for Wikipedia titles. For example,  [狼](https://zh-yue.wikipedia.org/wiki/%E7%8B%BC) on the Cantonese Wikipedia links to English [Wolf](https://en.wikipedia.org/wiki/Wolf), so that would be one entry in the Wikipedia Yue -> English dictionary.

Closes #28.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on Pop!_OS and macOS.

- [x] Test A

**Test Configuration**: pyenv virtualenv
* OS and version: macOS 14.1
* Toolchain: Python 3.12.1

- [x] Test B

**Test Configuration**: pyenv virtualenv
* OS and version: Pop!_OS 22.04
* Toolchain: Python 3.12.1

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
