### PR TITLE
#148: Improve romanization generation for dictionaries

### DIFF
--- a/src/dictionaries/aby/parse.py
+++ b/src/dictionaries/aby/parse.py
@@ -407,10 +407,11 @@ def parse_file(filename, words):
                                     parsed[0][1],
                                     style=Style.TONE3,
                                     neutral_tone_with_five=True,
+                                    v_to_u=True,
                                 )
                             )
                             .lower()
-                            .replace("v", "u:")
+                            .replace("ü", "u:")
                         )
                         variants = parsed[1:]
                     elif parsed_type == Type.POS:
@@ -744,10 +745,11 @@ def parse_file(filename, words):
                                 simplified,
                                 style=Style.TONE3,
                                 neutral_tone_with_five=True,
+                                v_to_u=True,
                             )
                         )
                         .lower()
-                        .replace("v", "u:")
+                        .replace("ü", "u:")
                     )
                     variant_entry.add_freq(zipf_frequency(traditional, "zh"))
                     words[variant_entry.traditional].append(variant_entry)

--- a/src/dictionaries/cantodict/parse.py
+++ b/src/dictionaries/cantodict/parse.py
@@ -118,7 +118,9 @@ PARENTHESES_PRONUNCIATION_REGEX_PATTERN = re.compile(
     r"\(jyutping\)\s*(.*\d)[,|;]?\s*\(pinyin\)\s*(.*\d)"
 )
 # This one searches for something in the format [粵拼: dei6 haa62 | 漢語: di4 xia5]
-PIPE_PRONUNCIATION_REGEX_PATTERN = re.compile(r"粵拼:\s*(.*\d)\s(?:\|\s*漢語:\s*(.*))\]")
+PIPE_PRONUNCIATION_REGEX_PATTERN = re.compile(
+    r"粵拼:\s*(.*\d)\s(?:\|\s*漢語:\s*(.*))\]"
+)
 # This one searches for something in the format 粵拼: ne1 -- 拼音: ne
 DASHES_PRONUNCIATION_REGEX_PATTERN = re.compile(
     r"粵拼:\s*(.*\d)\s*(?:\-\-\s*拼音:\s*(.*))?"
@@ -328,9 +330,18 @@ def parse_word_file(file_name, words):
         # CantoDict also indicates tone sandhi in pinyin with *, but we don't support that either
         pin = LITERARY_PINYIN_READING_REGEX_PATTERN.sub("", pin)
         if not pin:
-            pin = " ".join(
-                lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True)
-            ).lower()
+            pin = (
+                " ".join(
+                    lazy_pinyin(
+                        simp,
+                        style=Style.TONE3,
+                        neutral_tone_with_five=True,
+                        v_to_u=True,
+                    )
+                )
+                .lower()
+                .replace("ü", "u:")
+            )
         # Replace 'v' in Pinyin with the u: that CEDICT uses
         pin = pin.strip().replace("v", "u:")
         # Remove the zero-width spaces that sometimes show up

--- a/src/dictionaries/cedict/parse-set.py
+++ b/src/dictionaries/cedict/parse-set.py
@@ -1,10 +1,15 @@
+import pinyin_jyutping_sentence
+import pycantonese
 from wordfreq import zipf_frequency
 
 from database import database, objects
 
 import logging
+import re
 import sqlite3
 import sys
+
+HAN_REGEX = re.compile(r"[\u4e00-\u9fff]")
 
 sources = [
     objects.SourceTuple(
@@ -116,6 +121,19 @@ def parse_cc_cedict(filename, entries):
             trad = split[0]
             simp = split[1]
             pin = line[line.index("[") + 1 : line.index("]")].lower().replace("v", "u:")
+            jyut = pinyin_jyutping_sentence.jyutping(
+                trad,
+                tone_numbers=True,
+                spaces=True,
+            )
+
+            # If pinyin_jyutping_sentences cannot convert to Jyutping, use
+            # pycantonese to convert the character instead
+            han_chars = HAN_REGEX.findall(jyut)
+            for char in han_chars:
+                char_jyutping = pycantonese.characters_to_jyutping(char)[0][1]
+                if char_jyutping:
+                    jyut = jyut.replace(char, char_jyutping)
             eng = line[line.index("/") + 1 : -2].split("/")
             entry = objects.EntryWithCantoneseAndMandarin(
                 trad=trad, simp=simp, pin=pin, cedict_eng=eng

--- a/src/dictionaries/cedict/requirements.txt
+++ b/src/dictionaries/cedict/requirements.txt
@@ -1,2 +1,4 @@
 jieba==0.42.1
+pinyin_jyutping_sentence==1.0
+pycantonese==3.4.0
 wordfreq==2.5.1

--- a/src/dictionaries/cross_straits/parse.py
+++ b/src/dictionaries/cross_straits/parse.py
@@ -451,15 +451,21 @@ def parse_file(filename, words):
                                 # "yuan2  ．  qin2  {   [  9 0 b a  ]   }  fu1  《  dong1 tang2 lao3  ．  di4 san1 zhe2  》  ：  「  zhong1 xiao4 shi4 li4 shen1 zhi1 ben3  ，  zhe4 qian2 cai2 shi4 tang3 lai2 zhi1 wu4  。  」"
                                 # Finally, change_pinyin_to_match_phrase() calls split() on that string, and it sees:
                                 # ['yuan2', '．', 'qin2', '{', '[', '9', '0', 'b', 'a', ']', '}', 'fu1', '《', 'dong1', 'tang2', 'lao3', '．', 'di4', 'san1', 'zhe2', '》', '：', '「', 'zhong1']
-                                example_pinyin_list = lazy_pinyin(
-                                    converter.convert(example_text),
-                                    style=Style.TONE3,
-                                    neutral_tone_with_five=True,
+                                example_pinyin_list = (
+                                    " ".join(
+                                        lazy_pinyin(
+                                            converter.convert(example_text),
+                                            style=Style.TONE3,
+                                            neutral_tone_with_five=True,
+                                            v_to_u=True,
+                                        )
+                                    )
+                                    .lower()
+                                    .replace("ü", "u:")
+                                    .split()
                                 )
                                 example_pinyin = []
                                 for p in example_pinyin_list:
-                                    if p != "UV":
-                                        p = p.replace("v", "u:")
                                     if (
                                         p.isnumeric()
                                         or not p[-1].isnumeric()

--- a/src/dictionaries/cuhk/parse.py
+++ b/src/dictionaries/cuhk/parse.py
@@ -152,9 +152,16 @@ def parse_word_file(file_name, words):
 
         # Automatically generate pinyin
         pin = (
-            " ".join(lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True))
+            " ".join(
+                lazy_pinyin(
+                    simp,
+                    style=Style.TONE3,
+                    neutral_tone_with_five=True,
+                    v_to_u=True,
+                )
+            )
             .lower()
-            .replace("v", "u:")
+            .replace("ü", "u:")
         )
 
         # Extract the meanings

--- a/src/dictionaries/gzzj/parse.py
+++ b/src/dictionaries/gzzj/parse.py
@@ -110,13 +110,18 @@ def parse_file(filename, words):
             trad = unicodedata.normalize("NFKD", trad)
             simp = converter.convert(trad)
 
-            pin = lazy_pinyin(
-                simp,
-                style=Style.TONE3,
-                neutral_tone_with_five=True,
+            pin = (
+                " ".join(
+                    lazy_pinyin(
+                        simp,
+                        style=Style.TONE3,
+                        neutral_tone_with_five=True,
+                        v_to_u=True,
+                    )
+                )
+                .lower()
+                .replace("ü", "u:")
             )
-            pin = " ".join(pin).lower()
-            pin = pin.strip().replace("v", "u:")
             jyut = row["粵拼讀音"]
 
             freq = zipf_frequency(trad, "zh")
@@ -129,7 +134,9 @@ def parse_file(filename, words):
                 for definition in definitions:
                     defs.append(objects.DefinitionTuple(definition, "釋義", []))
             if row["(輔助檢索用異體)"]:
-                defs.append(objects.DefinitionTuple(row["(輔助檢索用異體)"], "異體", []))
+                defs.append(
+                    objects.DefinitionTuple(row["(輔助檢索用異體)"], "異體", [])
+                )
 
             if not defs:
                 defs.append(objects.DefinitionTuple("-", "", []))
@@ -141,13 +148,18 @@ def parse_file(filename, words):
                 trad = variant
                 trad = unicodedata.normalize("NFKD", trad)
                 simp = converter.convert(trad)
-                pin = lazy_pinyin(
-                    simp,
-                    style=Style.TONE3,
-                    neutral_tone_with_five=True,
+                pin = (
+                    " ".join(
+                        lazy_pinyin(
+                            simp,
+                            style=Style.TONE3,
+                            neutral_tone_with_five=True,
+                            v_to_u=True,
+                        )
+                    )
+                    .lower()
+                    .replace("ü", "u:")
                 )
-                pin = " ".join(pin).lower()
-                pin = pin.strip().replace("v", "u:")
                 freq = zipf_frequency(trad, "zh")
                 entry = objects.Entry(
                     variant, simp, pin, jyut, freq=freq, defs=copy.deepcopy(defs)

--- a/src/dictionaries/hsk3/parse.py
+++ b/src/dictionaries/hsk3/parse.py
@@ -112,10 +112,18 @@ def parse_file(filename, entries):
                 label = ""
 
             trad = converter.convert(simp)
-            pin = " ".join(
-                lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True)
-            ).lower()
-            pin = pin.strip().replace("v", "u:")
+            pin = (
+                " ".join(
+                    lazy_pinyin(
+                        simp,
+                        style=Style.TONE3,
+                        neutral_tone_with_five=True,
+                        v_to_u=True,
+                    )
+                )
+                .lower()
+                .replace("ü", "u:")
+            )
             jyut = pinyin_jyutping_sentence.jyutping(
                 trad, tone_numbers=True, spaces=True
             )

--- a/src/dictionaries/kaifangcidian/parse.py
+++ b/src/dictionaries/kaifangcidian/parse.py
@@ -122,9 +122,16 @@ def parse_file(filename_traditional, filename_simplified_jyutping, entries):
         jyut = " ".join(simplified[index + trad_len : index + trad_len + jyut_len])
 
         pin = (
-            " ".join(lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True))
+            " ".join(
+                lazy_pinyin(
+                    simp,
+                    style=Style.TONE3,
+                    neutral_tone_with_five=True,
+                    v_to_u=True,
+                )
+            )
             .lower()
-            .replace("v", "u:")
+            .replace("ü", "u:")
         )
 
         # Horrible data workaround 3:

--- a/src/dictionaries/moedict/parse.py
+++ b/src/dictionaries/moedict/parse.py
@@ -275,10 +275,18 @@ def parse_file(filename, words):
                                 # "yuan2  ．  qin2  {   [  9 0 b a  ]   }  fu1  《  dong1 tang2 lao3  ．  di4 san1 zhe2  》  ：  「  zhong1 xiao4 shi4 li4 shen1 zhi1 ben3  ，  zhe4 qian2 cai2 shi4 tang3 lai2 zhi1 wu4  。  」"
                                 # Finally, change_pinyin_to_match_phrase() calls split() on that string, and it sees:
                                 # ['yuan2', '．', 'qin2', '{', '[', '9', '0', 'b', 'a', ']', '}', 'fu1', '《', 'dong1', 'tang2', 'lao3', '．', 'di4', 'san1', 'zhe2', '》', '：', '「', 'zhong1']
-                                example_pinyin_list = lazy_pinyin(
-                                    converter.convert(example_text),
-                                    style=Style.TONE3,
-                                    neutral_tone_with_five=True,
+                                example_pinyin_list = (
+                                    " ".join(
+                                        lazy_pinyin(
+                                            converter.convert(example_text),
+                                            style=Style.TONE3,
+                                            neutral_tone_with_five=True,
+                                            v_to_u=True,
+                                        )
+                                    )
+                                    .lower()
+                                    .replace("ü", "u:")
+                                    .split()
                                 )
                                 example_pinyin = []
                                 for item in example_pinyin_list:
@@ -289,9 +297,6 @@ def parse_file(filename, words):
                                 example_pinyin = " ".join(example_pinyin).lower()
                                 example_pinyin = example_pinyin.translate(
                                     PUNCTUATION_TABLE
-                                )
-                                example_pinyin = example_pinyin.strip().replace(
-                                    "v", "u:"
                                 )
 
                                 # Since the pinyin returned by lazy_pinyin doesn't always match the pinyin
@@ -343,10 +348,18 @@ def parse_file(filename, words):
                         for quote in definition["quote"]:
                             quote_text = re.sub(WHITESPACE_REGEX_PATTERN, "", quote)
 
-                            quote_pinyin_list = lazy_pinyin(
-                                converter.convert(quote_text),
-                                style=Style.TONE3,
-                                neutral_tone_with_five=True,
+                            quote_pinyin_list = (
+                                " ".join(
+                                    lazy_pinyin(
+                                        converter.convert(example_text),
+                                        style=Style.TONE3,
+                                        neutral_tone_with_five=True,
+                                        v_to_u=True,
+                                    )
+                                )
+                                .lower()
+                                .replace("ü", "u:")
+                                .split()
                             )
                             quote_pinyin = []
                             for item in quote_pinyin_list:
@@ -356,7 +369,6 @@ def parse_file(filename, words):
                                     quote_pinyin.append(item)
                             quote_pinyin = " ".join(quote_pinyin).lower()
                             quote_pinyin = quote_pinyin.translate(PUNCTUATION_TABLE)
-                            quote_pinyin = quote_pinyin.strip().replace("v", "u:")
 
                             phrase_pinyin = pin
                             phrase_pinyin = re.sub(

--- a/src/dictionaries/tatoeba/parse.py
+++ b/src/dictionaries/tatoeba/parse.py
@@ -109,12 +109,18 @@ def parse_sentence_file(
                     simp = traditional_to_simplified_converter.convert(sentence)
                 pin = ""
                 if enable_pinyin:
-                    pin = " ".join(
-                        lazy_pinyin(
-                            simp, style=Style.TONE3, neutral_tone_with_five=True
+                    pin = (
+                        " ".join(
+                            lazy_pinyin(
+                                simp,
+                                style=Style.TONE3,
+                                neutral_tone_with_five=True,
+                                v_to_u=True,
+                            )
                         )
-                    ).lower()
-                    pin = pin.strip().replace("v", "u:")
+                        .lower()
+                        .replace("ü", "u:")
+                    )
                 jyut = ""
                 if enable_jyutping:
                     jyut = pinyin_jyutping_sentence.jyutping(

--- a/src/dictionaries/two_shores_three_places/parse.py
+++ b/src/dictionaries/two_shores_three_places/parse.py
@@ -129,13 +129,18 @@ def parse_same_meaning_file(filename, words):
                         line[2].replace("　", " "), accented=False
                     )
                 else:
-                    pin = lazy_pinyin(
-                        simp,
-                        style=Style.TONE3,
-                        neutral_tone_with_five=True,
+                    pin = (
+                        " ".join(
+                            lazy_pinyin(
+                                simp,
+                                style=Style.TONE3,
+                                neutral_tone_with_five=True,
+                                v_to_u=True,
+                            )
+                        )
+                        .lower()
+                        .replace("ü", "u:")
                     )
-                    pin = " ".join(pin).lower()
-                    pin = pin.strip().replace("v", "u:")
                 jyut = pinyin_jyutping_sentence.jyutping(
                     trad, tone_numbers=True, spaces=True
                 )
@@ -164,16 +169,23 @@ def parse_same_word_file(filename, words):
 
         trad = line[0]
         simp = converter.convert(trad)
-        pin = lazy_pinyin(
-            simp,
-            style=Style.TONE3,
-            neutral_tone_with_five=True,
+        pin = (
+            " ".join(
+                lazy_pinyin(
+                    simp,
+                    style=Style.TONE3,
+                    neutral_tone_with_five=True,
+                    v_to_u=True,
+                )
+            )
+            .lower()
+            .replace("ü", "u:")
         )
-        pin = " ".join(pin).lower()
-        pin = pin.strip().replace("v", "u:")
         jyut = pinyin_jyutping_sentence.jyutping(trad, tone_numbers=True, spaces=True)
         freq = zipf_frequency(trad, "zh")
-        defs = [objects.DefinitionTuple("​".join(jieba.cut(line[1])), "臺陸用法和差異", [])]
+        defs = [
+            objects.DefinitionTuple("​".join(jieba.cut(line[1])), "臺陸用法和差異", [])
+        ]
 
         entry = objects.Entry(trad, simp, pin, jyut, freq=freq, defs=defs)
         words.add(entry)

--- a/src/dictionaries/wiktionary/parse.py
+++ b/src/dictionaries/wiktionary/parse.py
@@ -517,10 +517,18 @@ def parse_file(filename, words):
                 pinyin_jyutping_sentence.jyutping(trad, tone_numbers=True, spaces=True)
             ]
         if not pinyin_list:
-            generated_pinyin = " ".join(
-                lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True)
-            ).lower()
-            generated_pinyin = generated_pinyin.replace("v", "u:").replace("ü", "u:")
+            pin = (
+                " ".join(
+                    lazy_pinyin(
+                        generated_pinyin,
+                        style=Style.TONE3,
+                        neutral_tone_with_five=True,
+                        v_to_u=True,
+                    )
+                )
+                .lower()
+                .replace("ü", "u:")
+            )
             pinyin_list = [generated_pinyin]
 
         freq = zipf_frequency(trad, "zh")

--- a/src/dictionaries/words_hk/parse.py
+++ b/src/dictionaries/words_hk/parse.py
@@ -199,9 +199,16 @@ def process_entry(line):
         trad = variant.split(":")[0]
         simp = converter.convert(trad)
         pin = (
-            " ".join(lazy_pinyin(simp, style=Style.TONE3, neutral_tone_with_five=True))
+            " ".join(
+                lazy_pinyin(
+                    simp,
+                    style=Style.TONE3,
+                    neutral_tone_with_five=True,
+                    v_to_u=True,
+                )
+            )
             .lower()
-            .replace("v", "u:")
+            .replace("ü", "u:")
         )
         freq = zipf_frequency(trad, "zh")
 
@@ -359,7 +366,9 @@ def process_entry(line):
         )
     if antonyms:
         definitions.append(
-            objects.Definition(definition="、".join(antonyms), label="反義詞", examples=[])
+            objects.Definition(
+                definition="、".join(antonyms), label="反義詞", examples=[]
+            )
         )
 
     # Assign definitions to each entry


### PR DESCRIPTION
# Description

This commit fixes PInyin generation where Pinyin containing "v"s gets incorrectly converted to "u:". An example of such a conversion is UV being converted into "uu:". This commit also generates Jyutping for CEDICT-style entries using `pinyin_jyutping_sentence` and `pycantonese`.

Closes #148.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
