### PR TITLE
#132: Remove std::any from Downloader class

### DIFF
--- a/src/jyut-dict/logic/download/downloader.cpp
+++ b/src/jyut-dict/logic/download/downloader.cpp
@@ -9,12 +9,10 @@
 
 Downloader::Downloader(QUrl url,
                        QString outputPath,
-                       std::any callbacks,
                        QObject *parent)
     : QObject{parent}
     , _url{url}
     , _outputPath{outputPath}
-    , _callbacks{callbacks}
 {}
 
 void Downloader::startDownload()
@@ -65,7 +63,7 @@ void Downloader::fileDownloaded(QNetworkReply *reply)
     }
     file.close();
 
-    emit downloaded(_outputPath, _callbacks);
+    emit downloaded(_outputPath);
 }
 
 QByteArray Downloader::downloadedData() const

--- a/src/jyut-dict/logic/download/downloader.h
+++ b/src/jyut-dict/logic/download/downloader.h
@@ -7,8 +7,6 @@
 #include <QNetworkRequest>
 #include <QObject>
 
-#include <any>
-
 // The Downloader class provides a simple interface to download a file
 // from a URL to a specified location on disk in a background thread.
 // This class is NOT thread-safe!
@@ -19,13 +17,12 @@ class Downloader : public QObject
 public:
     explicit Downloader(QUrl url,
                         QString outputPath,
-                        std::any callbacks,
                         QObject *parent = nullptr);
     void startDownload();
     QByteArray downloadedData() const;
 
 signals:
-    void downloaded(QString outputPath, std::any callbacks);
+    void downloaded(QString outputPath);
     void error(int err);
 
 private slots:
@@ -38,7 +35,6 @@ private:
     QByteArray _downloadedData;
     QUrl _url;
     QString _outputPath;
-    std::any _callbacks;
 };
 
 #endif // DOWNLOADER_H


### PR DESCRIPTION
# Description

Instead of threading the QNetworkReply success and failure callbacks through the `Downloader` class, I can just pass them through a capture-by value lambda.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on all three platforms, no functional difference from existing download flow.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
