### PR TITLE
#155: Create FUNDING.yml file to enable Github Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: aaronhktan
+ko_fi: aaronhktan


### PR DESCRIPTION
# Description

This commit adds a FUNDING.yml file to enable Github Sponsors on this repository.

Closes #155.
