### PR TITLE
#161: Use QString::fromStdString(x) instead of QString{x.c_str()}

### DIFF
--- a/src/jyut-dict/components/definitioncard/definitioncontentwidget.cpp
+++ b/src/jyut-dict/components/definitioncard/definitioncontentwidget.cpp
@@ -63,7 +63,7 @@ void DefinitionContentWidget::setEntry(const std::vector<Definition::Definition>
                                      0,
                                      Qt::AlignTop);
 
-        QString label{definitions[i].label.c_str()};
+        QString label = QString::fromStdString(definitions[i].label);
         if (!label.isEmpty()) {
             _definitionLabelLabels.push_back(
                 new QLabel{definitions[i].label.c_str(), this});
@@ -95,22 +95,22 @@ void DefinitionContentWidget::setEntry(const std::vector<Definition::Definition>
                 exampleText = definitions[i].sentences[j].getSimplified().c_str();
                 break;
             case EntryCharactersOptions::PREFER_SIMPLIFIED:
-                exampleText
-                    = QString{definitions[i].sentences[j].getSimplified().c_str()}
-                      + "<br>"
-                      + QString{
-                          definitions[i].sentences[j].getTraditional().c_str()};
+                exampleText = QString::fromStdString(
+                                  definitions[i].sentences[j].getSimplified())
+                              + "<br>"
+                              + QString::fromStdString(
+                                  definitions[i].sentences[j].getTraditional());
                 break;
             case EntryCharactersOptions::ONLY_TRADITIONAL:
                 exampleText
                     = definitions[i].sentences[j].getTraditional().c_str();
                 break;
             case EntryCharactersOptions::PREFER_TRADITIONAL:
-                exampleText
-                    = QString{definitions[i].sentences[j].getTraditional().c_str()}
-                      + "<br>"
-                      + QString{
-                          definitions[i].sentences[j].getSimplified().c_str()};
+                exampleText = QString::fromStdString(
+                                  definitions[i].sentences[j].getTraditional())
+                              + "<br>"
+                              + QString::fromStdString(
+                                  definitions[i].sentences[j].getSimplified());
                 break;
             }
 
@@ -146,12 +146,13 @@ void DefinitionContentWidget::setEntry(const std::vector<Definition::Definition>
             SourceSentence sentence = definitions[i].sentences[j];
             sentence.generatePhonetic(cantoneseOptions, mandarinOptions);
 
-            QString cantonese
-                = QString{sentence.getCantonesePhonetic(cantoneseOptions).c_str()}
-                      .trimmed();
-            QString mandarin
-                = QString{sentence.getMandarinPhonetic(mandarinOptions).c_str()}
-                      .trimmed();
+            QString cantonese = QString::fromStdString(
+                                    sentence.getCantonesePhonetic(
+                                        cantoneseOptions))
+                                    .trimmed();
+            QString mandarin = QString::fromStdString(
+                                   sentence.getMandarinPhonetic(mandarinOptions))
+                                   .trimmed();
 
             switch (Settings::getSettings()
                         ->value("Preview/phoneticOptions",
@@ -199,7 +200,8 @@ void DefinitionContentWidget::setEntry(const std::vector<Definition::Definition>
             if (!sets.empty()) {
                 auto set = sets[0].getSentences();
                 if (!set.empty()) {
-                    QString translation = set[0].sentence.c_str();
+                    QString translation = QString::fromStdString(
+                        set[0].sentence);
                     _exampleTranslationLabels.push_back(
                         new QLabel{"<ul style=\"list-style-type:none;\"><li>"
                                        + translation + "</li></ul>",

--- a/src/jyut-dict/components/entryview/entryheaderwidget.cpp
+++ b/src/jyut-dict/components/entryview/entryheaderwidget.cpp
@@ -100,13 +100,13 @@ void EntryHeaderWidget::setEntry(const Entry &entry)
                                cantoneseOptions,
                                mandarinOptions);
 
-    _chinese = QString{entry.getSimplified().c_str()};
-    _jyutping = QString{entry.getJyutping().c_str()};
+    _chinese = QString::fromStdString(entry.getSimplified());
+    _jyutping = QString::fromStdString(entry.getJyutping());
     // Pinyin by default follows CEDICT's convention of denoting "ü" with "u:",
     // but most TTS systems denote that vowel with "v". To get the TTS systems
     // to properly pronounce that word, we must convert "u:" to "v".
-    _pinyin = QString{
-        ChineseUtils::createPinyinWithV(entry.getPinyin()).c_str()};
+    _pinyin = QString::fromStdString(
+        ChineseUtils::createPinyinWithV(entry.getPinyin()));
 
     translateUI();
     setStyle(Utils::isDarkMode());

--- a/src/jyut-dict/components/entryview/entryviewsentencecardsection.cpp
+++ b/src/jyut-dict/components/entryview/entryviewsentencecardsection.cpp
@@ -181,9 +181,10 @@ void EntryViewSentenceCardSection::setEntry(const Entry &entry)
     _showLoadingIconTimer->start();
 
     // Actually start searching for sentences
-    _search->searchTraditionalSentences(QString{entry.getTraditional().c_str()}
-                                            .replace("%", "\\%")
-                                            .replace("_", "\\_"));
+    _search->searchTraditionalSentences(
+        QString::fromStdString(entry.getTraditional())
+            .replace("%", "\\%")
+            .replace("_", "\\_"));
     _title = entry
                  .getCharactersNoSecondary(
                      Settings::getSettings()

--- a/src/jyut-dict/components/sentencecard/sentencecontentwidget.cpp
+++ b/src/jyut-dict/components/sentencecard/sentencecontentwidget.cpp
@@ -64,7 +64,8 @@ void SentenceContentWidget::setSentenceSet(const SentenceSet &set)
         _sentenceNumberLabels.back()->setFixedWidth(definitionNumberWidth);
 
         _sentenceLabels.push_back(
-            new QLabel{QString{sentences[i].sentence.c_str()}.trimmed(), this});
+            new QLabel{QString::fromStdString(sentences[i].sentence).trimmed(),
+                       this});
         _sentenceLabels.back()->setProperty("language", sentences[i].language.c_str());
         _sentenceLabels.back()->setWordWrap(true);
         _sentenceLabels.back()->setTextInteractionFlags(Qt::TextSelectableByMouse);
@@ -106,15 +107,15 @@ void SentenceContentWidget::setSourceSentenceVector(
 
         SourceSentence sourceSentence = sourceSentences.at(i);
 
-        QString simplified = QString{sourceSentence.getSimplified().c_str()}
-                                 .trimmed();
+        QString simplified
+            = QString::fromStdString(sourceSentence.getSimplified()).trimmed();
         _simplifiedLabels.push_back(new QLabel{simplified, this});
         _simplifiedLabels.back()->setWordWrap(true);
         _simplifiedLabels.back()->setTextInteractionFlags(
             Qt::TextSelectableByMouse);
 
-        QString traditional = QString{sourceSentence.getTraditional().c_str()}
-                                  .trimmed();
+        QString traditional
+            = QString::fromStdString(sourceSentence.getTraditional()).trimmed();
         _traditionalLabels.push_back(new QLabel{traditional, this});
         _traditionalLabels.back()->setWordWrap(true);
         _traditionalLabels.back()->setTextInteractionFlags(
@@ -134,27 +135,27 @@ void SentenceContentWidget::setSourceSentenceVector(
 
         sourceSentence.generatePhonetic(cantoneseOptions, mandarinOptions);
 
-        QString cantonesePronunciation = QString{sourceSentence
-                                                     .getCantonesePhonetic(
-                                                         cantoneseOptions)
-                                                     .c_str()}
-                                             .trimmed();
+        QString cantonesePronunciation
+            = QString::fromStdString(
+                  sourceSentence.getCantonesePhonetic(cantoneseOptions))
+                  .trimmed();
         _cantoneseLabels.push_back(new QLabel{cantonesePronunciation, this});
         _cantoneseLabels.back()->setWordWrap(true);
         _cantoneseLabels.back()->setTextInteractionFlags(
             Qt::TextSelectableByMouse);
 
-        QString mandarinPronunciation
-            = QString{sourceSentence.getMandarinPhonetic(mandarinOptions).c_str()}
-                  .trimmed();
+        QString mandarinPronunciation = QString::fromStdString(
+                                            sourceSentence.getMandarinPhonetic(
+                                                mandarinOptions))
+                                            .trimmed();
         _mandarinLabels.push_back(new QLabel{mandarinPronunciation, this});
         _mandarinLabels.back()->setWordWrap(true);
         _mandarinLabels.back()->setTextInteractionFlags(Qt::TextSelectableByMouse);
 
         SentenceSet targetSentenceSet = sourceSentence.getSentenceSets()[0];
-        QString sentence
-            = QString{targetSentenceSet.getSentences()[0].sentence.c_str()}
-                  .trimmed();
+        QString sentence = QString::fromStdString(
+                               targetSentenceSet.getSentences()[0].sentence)
+                               .trimmed();
         _sentenceLabels.push_back(new QLabel{sentence, this});
         _sentenceLabels.back()->setProperty("language",
                                             targetSentenceSet.getSentences()[0].language.c_str());

--- a/src/jyut-dict/components/sentencesearchresult/sentenceresultlistdelegate.cpp
+++ b/src/jyut-dict/components/sentencesearchresult/sentenceresultlistdelegate.cpp
@@ -227,8 +227,9 @@ void SentenceResultListDelegate::paint(QPainter *painter,
     }
 #ifdef Q_OS_WIN
     oldFont = font;
-    QString snippetLanguage = QString{sentence.getSentenceSnippetLanguage()
-            .c_str()}.trimmed();
+    QString snippetLanguage = QString::fromStdString(
+                                  sentence.getSentenceSnippetLanguage())
+                                  .trimmed();
     if (snippetLanguage == "cmn" || snippetLanguage == "yue") {
         font = QFont{"Microsoft Yahei"};
     } else {

--- a/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
+++ b/src/jyut-dict/components/sentenceview/sentenceviewheaderwidget.cpp
@@ -58,14 +58,15 @@ void SentenceViewHeaderWidget::setSourceSentence(const SourceSentence &sentence)
     clearPronunciationLabels();
 
     _sourceLanguageLabel->setProperty("language",
-                                      QString{sentence.getSourceLanguage().c_str()});
+                                      QString::fromStdString(
+                                          sentence.getSourceLanguage()));
     _sourceLanguageLabel->setText(
         Utils::getLanguageFromISO639(sentence.getSourceLanguage()).trimmed());
 
     _simplifiedLabel->setText(
-        QString{sentence.getSimplified().c_str()}.trimmed());
+        QString::fromStdString(sentence.getSimplified()).trimmed());
     _traditionalLabel->setText(
-        QString{sentence.getTraditional().c_str()}.trimmed());
+        QString::fromStdString(sentence.getTraditional()).trimmed());
 
     CantoneseOptions cantoneseOptions
         = Settings::getSettings()
@@ -88,12 +89,12 @@ void SentenceViewHeaderWidget::setSourceSentence(const SourceSentence &sentence)
                                cantoneseOptions,
                                mandarinOptions);
 
-    _chinese = QString{sentence.getSimplified().empty()
-                           ? sentence.getSimplified().c_str()
-                           : sentence.getTraditional().c_str()};
-    _jyutping = QString{sentence.getJyutping().c_str()};
-    _pinyin = QString{
-        ChineseUtils::createPinyinWithV(sentence.getPinyin()).c_str()};
+    _chinese = QString::fromStdString(sentence.getSimplified().empty()
+                                          ? sentence.getSimplified()
+                                          : sentence.getTraditional());
+    _jyutping = QString::fromStdString(sentence.getJyutping());
+    _pinyin = QString::fromStdString(
+        ChineseUtils::createPinyinWithV(sentence.getPinyin()));
 
     translateUI();
     setStyle(Utils::isDarkMode());

--- a/src/jyut-dict/logic/database/queryparseutils.cpp
+++ b/src/jyut-dict/logic/database/queryparseutils.cpp
@@ -40,7 +40,8 @@ std::vector<Entry> parseEntries(QSqlQuery &query, bool parseDefinitions)
 
         if (parseDefinitions) {
             // Parse JSON returned by query
-            QJsonDocument doc = QJsonDocument::fromJson(QString{definition.c_str()}.toUtf8());
+            QJsonDocument doc = QJsonDocument::fromJson(
+                QString::fromStdString(definition).toUtf8());
             // Each object in the array represents a group of definitions
             // that are all from the same source
             foreach (const QJsonValue &definitionGroup, doc.array()) {
@@ -141,7 +142,7 @@ std::vector<SourceSentence> parseSentences(QSqlQuery &query)
         if (!combinedTargetSentencesData.empty()) {
             // Parse JSON returned by query
             QJsonDocument doc = QJsonDocument::fromJson(
-                QString{combinedTargetSentencesData.c_str()}.toUtf8());
+                QString::fromStdString(combinedTargetSentencesData).toUtf8());
             // Parse each of the sentence translation groups
             foreach (const QJsonValue &translation_set, doc.array()) {
                 std::string sentenceSourceName

--- a/src/jyut-dict/logic/database/sqldatabaseutils.cpp
+++ b/src/jyut-dict/logic/database/sqldatabaseutils.cpp
@@ -603,7 +603,8 @@ std::pair<bool, std::string> SQLDatabaseUtils::insertSourcesIntoDatabase(
             // already existed in the database. Since we want to preserve
             // dictionary order, we will need to insert at the old dictionary ID
             // which is given by the map.
-            QString sourceid{old_source_ids[sourcename.toStdString()].c_str()};
+            QString sourceid = QString::fromStdString(
+                old_source_ids[sourcename.toStdString()]);
 
             insertQuery.prepare("INSERT INTO sources "
                                 "  (source_id, sourcename, sourceshortname, "

--- a/src/jyut-dict/logic/search/sqlsearch.cpp
+++ b/src/jyut-dict/logic/search/sqlsearch.cpp
@@ -43,7 +43,7 @@ void prepareJyutpingBindValues(const QString &searchTerm, QString &globTerm)
         = ChineseUtils::constructRomanisationQuery(jyutpingWords,
                                                    globJoinDelimiter);
 
-    globTerm = QString{query.c_str()}
+    globTerm = QString::fromStdString(query)
                + QString{(searchExactMatch || dontAppendWildcard) ? "" : "*"};
 }
 
@@ -90,7 +90,7 @@ void preparePinyinBindValues(const QString &searchTerm, QString &globTerm)
         = ChineseUtils::constructRomanisationQuery(pinyinWords,
                                                    globJoinDelimiter);
 
-    globTerm = QString{query.c_str()}
+    globTerm = QString::fromStdString(query)
                + QString{(searchExactMatch || dontAppendWildcard) ? "" : "*"};
 }
 

--- a/src/jyut-dict/logic/update/jyutdictionaryreleasechecker.cpp
+++ b/src/jyut-dict/logic/update/jyutdictionaryreleasechecker.cpp
@@ -105,7 +105,8 @@ bool JyutDictionaryReleaseChecker::parseJSON(const std::string &data,
          std::stoi(localVersionNumberComponents[1]),
          std::stoi(localVersionNumberComponents[2])});
 
-    QJsonDocument doc = QJsonDocument::fromJson(QString{data.c_str()}.toUtf8());
+    QJsonDocument doc = QJsonDocument::fromJson(
+        QString::fromStdString(data.c_str()).toUtf8());
     QJsonValue version;
     foreach (version, doc.array()) {
         QJsonObject versionObject = version.toObject();

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -468,7 +468,7 @@ std::string convertJyutpingToYale(const std::string &jyutping,
         Utils::split(jyutpingCopy, ' ', syllables);
     } else {
         bool valid_jyutping
-            = segmentJyutping(QString{jyutping.c_str()},
+            = segmentJyutping(QString::fromStdString(jyutping),
                               syllables,
                               /* removeSpecialCharacters */ false,
                               /* removeGlobCharacters */ false);
@@ -617,7 +617,7 @@ std::string convertJyutpingToIPA(const std::string &jyutping,
         }
         Utils::split(jyutpingCopy, ' ', syllables);
     } else {
-        bool validJyutping = segmentJyutping(QString{jyutping.c_str()},
+        bool validJyutping = segmentJyutping(QString::fromStdString(jyutping),
                                              syllables,
                                              /* removeSpecialCharacters */ false,
                                              /* removeGlobCharacters */ false);
@@ -892,7 +892,7 @@ std::string convertPinyinToZhuyin(const std::string &pinyin,
         }
         Utils::split(pinyinCopy, ' ', syllables);
     } else {
-        segmentPinyin(QString{pinyin.c_str()}, syllables);
+        segmentPinyin(QString::fromStdString(pinyin), syllables);
     }
 
     std::vector<std::string> zhuyin_syllables;
@@ -1103,7 +1103,7 @@ std::string convertPinyinToIPA(const std::string &pinyin,
         }
         Utils::split(pinyinCopy, ' ', syllables);
     } else {
-        segmentPinyin(QString{pinyin.c_str()}, syllables);
+        segmentPinyin(QString::fromStdString(pinyin), syllables);
     }
 
     std::vector<std::string> ipa_syllables;

--- a/src/jyut-dict/logic/utils/utils.cpp
+++ b/src/jyut-dict/logic/utils/utils.cpp
@@ -5,44 +5,43 @@
 #include <string>
 
 namespace Utils {
-    void split(const std::string &string,
-               const char delimiter,
-               std::vector<std::string> &result)
-    {
-        result.clear();
-        std::stringstream ss(string);
-        std::string word;
+void split(const std::string &string,
+           const char delimiter,
+           std::vector<std::string> &result)
+{
+    result.clear();
+    std::stringstream ss(string);
+    std::string word;
 
-        while (std::getline(ss, word, delimiter)) {
-            if (word.length() > 0 && word[0] != delimiter) {
-                result.push_back(word);
-            }
+    while (std::getline(ss, word, delimiter)) {
+        if (word.length() > 0 && word[0] != delimiter) {
+            result.push_back(word);
         }
     }
+}
 
-    void split(const std::string &string,
-               const std::string delimiter,
-               std::vector<std::string> &result)
-    {
-        result.clear();
+void split(std::string_view string,
+           const std::string delimiter,
+           std::vector<std::string> &result)
+{
+    result.clear();
 
-        size_t previous = 0;
-        size_t current = 0;
-        while ((current = string.find(delimiter, previous))
-               != std::string::npos) {
-            std::string substr = string.substr(previous, current - previous);
-            if (substr != delimiter) {
-                result.push_back(substr);
-            }
-            previous = current + delimiter.length();
+    size_t previous = 0;
+    size_t current = 0;
+    while ((current = string.find(delimiter, previous)) != std::string::npos) {
+        std::string_view substr = string.substr(previous, current - previous);
+        if (substr != delimiter) {
+            result.push_back(std::string{substr});
         }
-        result.push_back(string.substr(previous));
+        previous = current + delimiter.length();
     }
+    result.push_back(std::string{string.substr(previous)});
+}
 
-    void trim(const std::string &string, std::string &result)
-    {
-        result = std::regex_replace(string,
-                                    std::regex("^\\s+|\\s+$|(\\s)\\s+"),
-                                    "$1");
-    }
+void trim(const std::string &string, std::string &result)
+{
+    result = std::regex_replace(string,
+                                std::regex("^\\s+|\\s+$|(\\s)\\s+"),
+                                "$1");
+}
 }

--- a/src/jyut-dict/logic/utils/utils.h
+++ b/src/jyut-dict/logic/utils/utils.h
@@ -72,7 +72,7 @@ constexpr auto VARIANT = "install";
                const char delimiter,
                std::vector<std::string> &result);
 
-    void split(const std::string &string,
+    void split(std::string_view string,
                const std::string delimiter,
                std::vector<std::string> &result);
 

--- a/src/jyut-dict/logic/utils/utils_qt.cpp
+++ b/src/jyut-dict/logic/utils/utils_qt.cpp
@@ -95,7 +95,7 @@ QString getLanguageFromISO639(std::string language)
     try {
         result = languageMap.at(language);
     } catch (std::out_of_range &e) {
-        QLocale locale{QString{language.c_str()}};
+        QLocale locale{QString::fromStdString(language.c_str())};
         result = locale.languageToString(locale.language());
     }
     return result;

--- a/src/jyut-dict/windows/updatewindow.cpp
+++ b/src/jyut-dict/windows/updatewindow.cpp
@@ -136,7 +136,7 @@ void UpdateAvailableWindow::translateUI()
            "Click \"Download\" to get the new version.")
             .arg(QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                              Strings::PRODUCT_NAME))
-            .arg(QString{_versionNumber.c_str()})
+            .arg(QString::fromStdString(_versionNumber))
             .arg(Utils::CURRENT_VERSION));
     _noButton->setText(tr("Cancel"));
     _showMoreButton->setText(tr("Show Details"));


### PR DESCRIPTION
# Description

- Using QString::fromStdString() should be a little bit more efficient when converting from an std::string to a QString. (See [here](https://stackoverflow.com/questions/4338067/convert-stdstring-to-qstring).)
- Also replaces an instance of const std::string & with std::string_view.

Part of improvements as part of #161.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
