### PR TITLE
#160: Add unit tests for ChineseUtils

### DIFF
--- a/src/jyut-dict/logic/search/sqlsearch.cpp
+++ b/src/jyut-dict/logic/search/sqlsearch.cpp
@@ -223,37 +223,49 @@ bool SQLSearch::checkQueryIDCurrent(const unsigned long long queryID) const {
 void SQLSearch::searchSimplified(const QString &searchTerm)
 {
     unsigned long long queryID = generateAndSetQueryID();
-    runThread(&SQLSearch::searchSimplifiedThread, searchTerm, queryID);
+    runThread(&SQLSearch::searchSimplifiedThread,
+              searchTerm.normalized(QString::NormalizationForm_C),
+              queryID);
 }
 
 void SQLSearch::searchTraditional(const QString &searchTerm)
 {
     unsigned long long queryID = generateAndSetQueryID();
-    runThread(&SQLSearch::searchTraditionalThread, searchTerm, queryID);
+    runThread(&SQLSearch::searchTraditionalThread,
+              searchTerm.normalized(QString::NormalizationForm_C),
+              queryID);
 }
 
 void SQLSearch::searchJyutping(const QString &searchTerm)
 {
     unsigned long long queryID = generateAndSetQueryID();
-    runThread(&SQLSearch::searchJyutpingThread, searchTerm, queryID);
+    runThread(&SQLSearch::searchJyutpingThread,
+              searchTerm.normalized(QString::NormalizationForm_C),
+              queryID);
 }
 
 void SQLSearch::searchPinyin(const QString &searchTerm)
 {
     unsigned long long queryID = generateAndSetQueryID();
-    runThread(&SQLSearch::searchPinyinThread, searchTerm, queryID);
+    runThread(&SQLSearch::searchPinyinThread,
+              searchTerm.normalized(QString::NormalizationForm_C),
+              queryID);
 }
 
 void SQLSearch::searchEnglish(const QString &searchTerm)
 {
     unsigned long long queryID = generateAndSetQueryID();
-    runThread(&SQLSearch::searchEnglishThread, searchTerm, queryID);
+    runThread(&SQLSearch::searchEnglishThread,
+              searchTerm.normalized(QString::NormalizationForm_C),
+              queryID);
 }
 
 void SQLSearch::searchAutoDetect(const QString &searchTerm)
 {
     unsigned long long queryId = generateAndSetQueryID();
-    runThread(&SQLSearch::searchAutoDetectThread, searchTerm, queryId);
+    runThread(&SQLSearch::searchAutoDetectThread,
+              searchTerm.normalized(QString::NormalizationForm_C),
+              queryId);
 }
 
 void SQLSearch::searchByUnique(const QString &simplified,

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -719,7 +719,7 @@ std::string convertJyutpingToIPA(const std::string &jyutping,
 
     // Remove trailing space
     std::string result = ipa.str();
-    result.erase(result.end() - static_cast<long>(double_space.length()));
+    result.resize(result.size() - double_space.length());
 
     return result;
 }

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -1258,7 +1258,7 @@ std::string convertPinyinToIPA(const std::string &pinyin,
 
     // Remove trailing space
     std::string result = ipa.str();
-    result.erase(result.end() - static_cast<long>(double_space.length()));
+    result.resize(result.size() - double_space.length());
 
     return result;
 }

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -1346,8 +1346,8 @@ bool segmentPinyin(const QString &string,
         if (currentString == " " || currentString == "'" || isSpecialCharacter
             || isGlobCharacter) {
             if (initial_found) { // Add any incomplete word to the vector
-                QString previous_initial = string.mid(start_idx,
-                                                      end_idx - start_idx);
+                QString previous_initial
+                    = string.mid(start_idx, end_idx - start_idx).toLower();
                 syllables.push_back(previous_initial.toStdString());
                 if (finals.find(previous_initial.toStdString())
                     == finals.end()) {
@@ -1374,7 +1374,7 @@ bool segmentPinyin(const QString &string,
                     length++;
                     end_idx++;
                 }
-                QString glob = string.mid(new_end_index, length);
+                QString glob = string.mid(new_end_index, length).toLower();
                 syllables.push_back(glob.toStdString());
 
                 start_idx = end_idx;
@@ -1431,7 +1431,8 @@ bool segmentPinyin(const QString &string,
                     end_idx++;
                 }
 
-                QString syllable = string.mid(start_idx, end_idx - start_idx);
+                QString syllable
+                    = string.mid(start_idx, end_idx - start_idx).toLower();
                 syllables.push_back(syllable.toStdString());
                 start_idx = end_idx;
                 next_iteration = true;
@@ -1449,7 +1450,7 @@ bool segmentPinyin(const QString &string,
 
     // Then add whatever's left in the search term, minus whitespace.
     QString lastSyllable
-        = string.mid(start_idx, end_idx - start_idx).simplified();
+        = string.mid(start_idx, end_idx - start_idx).simplified().toLower();
     if (!lastSyllable.isEmpty() && lastSyllable != "'") {
         syllables.push_back(lastSyllable.toStdString());
         if (finals.find(lastSyllable.toStdString()) == finals.end()) {

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -1502,8 +1502,8 @@ bool segmentJyutping(const QString &string,
         if (currentString == " " || currentString == "'" || isSpecialCharacter
             || isGlobCharacter) {
             if (initial_found) { // Add any incomplete word to the vector
-                QString previous_initial = string.mid(start_idx,
-                                                      end_idx - start_idx);
+                QString previous_initial
+                    = string.mid(start_idx, end_idx - start_idx).toLower();
                 syllables.push_back(previous_initial.toStdString());
                 if (finals.find(previous_initial.toStdString())
                     == finals.end()) {
@@ -1530,7 +1530,7 @@ bool segmentJyutping(const QString &string,
                     length++;
                     end_idx++;
                 }
-                QString glob = string.mid(glob_start_idx, length);
+                QString glob = string.mid(glob_start_idx, length).toLower();
                 syllables.push_back(glob.toStdString());
 
                 start_idx = end_idx;
@@ -1549,14 +1549,14 @@ bool segmentJyutping(const QString &string,
         // This block checks for the latter case.
         if (currentString.at(0).isDigit()) {
             if (initial_found) {
-                QString previous_initial = string.mid(start_idx,
-                                                      end_idx - start_idx);
+                QString previous_initial
+                    = string.mid(start_idx, end_idx - start_idx).toLower();
                 auto searchResult = finals.find(previous_initial.toStdString());
                 if (searchResult != finals.end()) {
                     // Confirmed, last initial found was also a final
                     end_idx++;
-                    previous_initial = string.mid(start_idx,
-                                                  end_idx - start_idx);
+                    previous_initial
+                        = string.mid(start_idx, end_idx - start_idx).toLower();
                     syllables.push_back(previous_initial.toStdString());
                     start_idx = end_idx;
                     initial_found = false;
@@ -1580,8 +1580,8 @@ bool segmentJyutping(const QString &string,
             // Multiple initials in a row are only valid if previous "initial"
             // was actually a final (like m or ng)
             if (initial_found) {
-                QString first_initial = string.mid(start_idx,
-                                                   end_idx - start_idx);
+                QString first_initial
+                    = string.mid(start_idx, end_idx - start_idx).toLower();
                 searchResult = finals.find(first_initial.toStdString());
                 if (searchResult != finals.end()) {
                     syllables.push_back(first_initial.toStdString());
@@ -1617,7 +1617,8 @@ bool segmentJyutping(const QString &string,
                         end_idx++;
                     }
                 }
-                QString syllable = string.mid(start_idx, end_idx - start_idx);
+                QString syllable
+                    = string.mid(start_idx, end_idx - start_idx).toLower();
                 syllables.push_back(syllable.toStdString());
                 start_idx = end_idx;
                 component_found = true;
@@ -1637,7 +1638,7 @@ bool segmentJyutping(const QString &string,
 
     // Then add whatever's left in the search term, minus whitespace.
     QString lastSyllable
-        = string.mid(start_idx, end_idx - start_idx).simplified();
+        = string.mid(start_idx, end_idx - start_idx).simplified().toLower();
     if (!lastSyllable.isEmpty() && lastSyllable != "'") {
         syllables.push_back(lastSyllable.toStdString());
         if (finals.find(lastSyllable.toStdString()) == finals.end()) {

--- a/src/jyut-dict/logic/utils/chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/chineseutils.cpp
@@ -279,7 +279,10 @@ std::string applyColours(const std::string original,
                          const EntryColourPhoneticType type)
 {
     std::string coloured_string;
-    std::u32string converted_original = converter.from_bytes(original);
+    std::u32string converted_original = converter.from_bytes(
+        QString::fromStdString(original)
+            .normalized(QString::NormalizationForm_C)
+            .toStdString());
     size_t pos = 0;
     for (const auto &character : converted_original) {
         std::string originalCharacter = converter.to_bytes(character);
@@ -355,8 +358,14 @@ std::string compareStrings(const std::string &original,
                            const std::string &comparison)
 {
     std::string result;
-    std::u32string convertedOriginal = converter.from_bytes(original);
-    std::u32string convertedComparison = converter.from_bytes(comparison);
+    std::u32string convertedOriginal = converter.from_bytes(
+        QString::fromStdString(original)
+            .normalized(QString::NormalizationForm_C)
+            .toStdString());
+    std::u32string convertedComparison = converter.from_bytes(
+        QString::fromStdString(comparison)
+            .normalized(QString::NormalizationForm_C)
+            .toStdString());
 
     if (convertedOriginal.size() != convertedComparison.size()) {
         return result;

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/.gitignore
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/.gitignore
@@ -1,0 +1,74 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+CMakeLists.txt.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/CMakeLists.txt
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(TestChineseUtils LANGUAGES CXX)
+
+enable_testing()
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+
+add_executable(TestChineseUtils tst_chineseutils.cpp)
+add_test(NAME TestChineseUtils COMMAND TestChineseUtils)
+
+target_link_libraries(TestChineseUtils PRIVATE Qt${QT_VERSION_MAJOR}::Test)
+target_include_directories(TestChineseUtils PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
+
+target_sources(TestChineseUtils
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../ChineseUtils.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../utils.cpp)
+

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/CMakeLists.txt
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(TestChineseUtils PRIVATE Qt${QT_VERSION_MAJOR}::Test)
 target_include_directories(TestChineseUtils PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
 
 target_sources(TestChineseUtils
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../ChineseUtils.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../chineseutils.cpp
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../settings/settings.cpp
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../utils.cpp)
 

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/CMakeLists.txt
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/CMakeLists.txt
@@ -23,5 +23,6 @@ target_include_directories(TestChineseUtils PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/
 
 target_sources(TestChineseUtils
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../ChineseUtils.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../settings/settings.cpp
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../utils.cpp)
 

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -509,12 +509,15 @@ void TestChineseUtils::pinuyinToZhuyinMalformed()
 
 void TestChineseUtils::pinyinToIPASimple()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result = ChineseUtils::convertPinyinToIPA("ba1 da2 tong1");
-    qDebug() << QString::fromStdString(result);
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "pä ˥ ˥  tä ˧ ˥  tʰʊŋ ˥ ˥");
+#else
     QCOMPARE(result, "pä˥˥  tä˧˥  tʰʊŋ˥˥");
+#endif
 }
 
 void TestChineseUtils::pinyinToIPARejectNoTone()
@@ -537,127 +540,179 @@ void TestChineseUtils::pinyinToIPARejectSpecialCharacter()
 
 void TestChineseUtils::pinyinToIPANoSpaces()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result = ChineseUtils::convertPinyinToIPA("ba1da2tong1");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "pä ˥ ˥  tä ˧ ˥  tʰʊŋ ˥ ˥");
+#else
     QCOMPARE(result, "pä˥˥  tä˧˥  tʰʊŋ˥˥");
+#endif
 }
 
 void TestChineseUtils::pinyinToIPASpacesToSegment()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result
         = ChineseUtils::convertPinyinToIPA("ba1 da2 tong1",
                                            /* useSpacesToSegment = */ true);
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "pä ˥ ˥  tä ˧ ˥  tʰʊŋ ˥ ˥");
+#else
     QCOMPARE(result, "pä˥˥  tä˧˥  tʰʊŋ˥˥");
+#endif
 }
 
 void TestChineseUtils::pinyinToIPASpecialCaseNg()
 {
     std::string result = ChineseUtils::convertPinyinToIPA("ng5");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "ŋ̍ ");
+#else
     QCOMPARE(result, "ŋ̍");
+#endif
 }
 
 void TestChineseUtils::pinyinToIPASpecialCaseRi()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result = ChineseUtils::convertPinyinToIPA("ri4");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "ʐ̩ ˥ ˩");
+#else
     QCOMPARE(result, "ʐ̩˥˩");
+#endif
 }
 
 void TestChineseUtils::pinyinToIPASyllableWithV()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result = ChineseUtils::convertPinyinToIPA("nv3");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "ny ˨ ˩ ˦");
+#else
     QCOMPARE(result, "ny˨˩˦");
+#endif
 
     result = ChineseUtils::convertPinyinToIPA("qu4");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "t͡ɕʰy ˥ ˩");
+#else
     QCOMPARE(result, "t͡ɕʰy˥˩");
+#endif
 }
 
 void TestChineseUtils::pinyinToIPAVoicelessInitial()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result = ChineseUtils::convertPinyinToIPA("ge5");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "g̊ə ");
+#else
     QCOMPARE(result, "g̊ə");
+#endif
 
     result = ChineseUtils::convertPinyinToIPA("yi1 ge5");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "i ˥ ˥  g̊ə ˨");
+#else
     QCOMPARE(result, "i˥˥  g̊ə˨");
+#endif
 }
 
 void TestChineseUtils::pinyinToIPAToneThree()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result = ChineseUtils::convertPinyinToIPA("ke3");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "kʰɤ ˨ ˩ ˦");
+#else
     QCOMPARE(result, "kʰɤ˨˩˦");
+#endif
 
     result = ChineseUtils::convertPinyinToIPA("ke3 yi3");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "kʰɤ ˨ ˩ ˦ ꜔ ꜒  i ˨ ˩ ˦ ꜕ ꜖ ( ꜓ )");
+#else
     QCOMPARE(result, "kʰɤ˨˩˦꜔꜒  i˨˩˦꜕꜖(꜓)");
+#endif
 }
 
 void TestChineseUtils::pinyinToIPAToneFour()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result = ChineseUtils::convertPinyinToIPA("xia4 qu4");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "ɕjä ˥ ˩ ꜒ ꜔  t͡ɕʰy ˥ ˩");
+#else
     QCOMPARE(result, "ɕjä˥˩꜒꜔  t͡ɕʰy˥˩");
+#endif
 
     result = ChineseUtils::convertPinyinToIPA("xia4");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "ɕjä ˥ ˩");
+#else
     QCOMPARE(result, "ɕjä˥˩");
+#endif
 }
 
 void TestChineseUtils::pinyinToIPAOtherTone()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result = ChineseUtils::convertPinyinToIPA("ma1");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "mä ˥ ˥");
+#else
     QCOMPARE(result, "mä˥˥");
+#endif
 
     result = ChineseUtils::convertPinyinToIPA("ma2");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "mä ˧ ˥");
+#else
     QCOMPARE(result, "mä˧˥");
+#endif
 
     result = ChineseUtils::convertPinyinToIPA("ma5");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "mä ");
+#else
     QCOMPARE(result, "mä");
+#endif
 }
 void TestChineseUtils::pinyinToIPAErhua()
 {
-#if defined(Q_OS_WINDOWS)
+#ifdef Q_OS_WINDOWS
     QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
 #endif
     std::string result = ChineseUtils::convertPinyinToIPA("huar1");
-    qDebug() << result.c_str();
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "xu̯ɑɻ ˥ ˥");
+#else
     QCOMPARE(result, "xu̯ɑɻ˥˥");
+#endif
 
     result = ChineseUtils::convertPinyinToIPA("quanr1");
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "t͡ɕʰɥɑɻ ˥ ˥");
+#else
     QCOMPARE(result, "t͡ɕʰɥɑɻ˥˥");
+#endif
 }
 
 void TestChineseUtils::segmentJyutpingSimple()

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -47,6 +47,45 @@ private slots:
     void jyutpingToIPATones();
     void jyutpingToIPANoTone();
 
+    void prettyPinyinSimple();
+    void prettyPinyinRejectNoTone();
+    void prettyPinyinRejectSingleLetter();
+    void prettyPinyinRejectSpecialCharacter();
+    void prettyPinyinSecondaryVowel();
+    void prettyPinyinUmlaut();
+    void prettyPinyinTones();
+    void prettyPinyinNoTone();
+
+    void numberedPinyinSimple();
+
+    void pinyinWithVSimple();
+
+    void pinuyinToZhuyinSimple();
+    void pinuyinToZhuyinRejectNoTone();
+    void pinuyinToZhuyinRejectSingleLetter();
+    void pinuyinToZhuyinRejectSpecialCharacter();
+    void pinuyinToZhuyinNoSpaces();
+    void pinuyinToZhuyinSpacesToSegment();
+    void pinuyinToZhuyinSpecialInitial();
+    void pinuyinToZhuyinSpecialFinals();
+    void pinuyinToZhuyinErhua();
+    void pinuyinToZhuyinMalformed();
+
+    void pinyinToIPASimple();
+    void pinyinToIPARejectNoTone();
+    void pinyinToIPARejectSingleLetter();
+    void pinyinToIPARejectSpecialCharacter();
+    void pinyinToIPANoSpaces();
+    void pinyinToIPASpacesToSegment();
+    void pinyinToIPASpecialCaseNg();
+    void pinyinToIPASpecialCaseRi();
+    void pinyinToIPASyllableWithV();
+    void pinyinToIPAVoicelessInitial();
+    void pinyinToIPAToneThree();
+    void pinyinToIPAToneFour();
+    void pinyinToIPAOtherTone();
+    void pinyinToIPAErhua();
+
     void segmentJyutpingSimple();
     void segmentJyutpingNoDigits();
     void segmentJyutpingNoSpaces();
@@ -339,6 +378,256 @@ void TestChineseUtils::jyutpingToIPANoTone()
 {
     std::string result = ChineseUtils::convertJyutpingToIPA("mok");
     QCOMPARE(result, "mok");
+}
+
+void TestChineseUtils::prettyPinyinSimple()
+{
+    std::string result = ChineseUtils::createPrettyPinyin("shuai4 ge1");
+    QCOMPARE(result, "shuài gē");
+}
+
+void TestChineseUtils::prettyPinyinRejectNoTone()
+{
+    std::string result = ChineseUtils::createPrettyPinyin("ba");
+    QCOMPARE(result, "ba");
+}
+
+void TestChineseUtils::prettyPinyinRejectSingleLetter()
+{
+    std::string result = ChineseUtils::createPrettyPinyin("a");
+    QCOMPARE(result, "a");
+}
+
+void TestChineseUtils::prettyPinyinRejectSpecialCharacter()
+{
+    std::string result = ChineseUtils::createPrettyPinyin("-");
+    QCOMPARE(result, "-");
+}
+
+void TestChineseUtils::prettyPinyinSecondaryVowel()
+{
+    std::string result = ChineseUtils::createPrettyPinyin("hui4 tu2");
+    QCOMPARE(result, "huì tú");
+}
+
+void TestChineseUtils::prettyPinyinUmlaut()
+{
+    std::string result = ChineseUtils::createPrettyPinyin("nu:3 hai2");
+    QCOMPARE(result, "nǚ hái");
+}
+
+void TestChineseUtils::prettyPinyinTones()
+{
+    std::string result = ChineseUtils::createPrettyPinyin(
+        "ma1 ma2 ma3 ma4 ma5");
+    QCOMPARE(result, "mā má mǎ mà ma");
+}
+void TestChineseUtils::prettyPinyinNoTone()
+{
+    std::string result = ChineseUtils::createPrettyPinyin("nu");
+    QCOMPARE(result, "nu");
+}
+
+void TestChineseUtils::numberedPinyinSimple()
+{
+    std::string result = ChineseUtils::createNumberedPinyin("nu:3 hai2");
+    QCOMPARE(result, "nü3 hai2");
+}
+
+void TestChineseUtils::pinyinWithVSimple()
+{
+    std::string result = ChineseUtils::createPinyinWithV("nu:3 hai2");
+    QCOMPARE(result, "nv3 hai2");
+}
+
+void TestChineseUtils::pinuyinToZhuyinSimple()
+{
+    std::string result = ChineseUtils::convertPinyinToZhuyin("ba1 da2 tong1");
+    QCOMPARE(result, "ㄅㄚ ㄉㄚˊ ㄊㄨㄥ");
+}
+
+void TestChineseUtils::pinuyinToZhuyinRejectNoTone()
+{
+    std::string result = ChineseUtils::convertPinyinToZhuyin("ba");
+    QCOMPARE(result, "ba");
+}
+
+void TestChineseUtils::pinuyinToZhuyinRejectSingleLetter()
+{
+    std::string result = ChineseUtils::convertPinyinToZhuyin("a");
+    QCOMPARE(result, "a");
+}
+void TestChineseUtils::pinuyinToZhuyinRejectSpecialCharacter()
+{
+    std::string result = ChineseUtils::convertPinyinToZhuyin("-");
+    QCOMPARE(result, "-");
+}
+void TestChineseUtils::pinuyinToZhuyinNoSpaces()
+{
+    std::string result = ChineseUtils::convertPinyinToZhuyin("ba1da2tong1");
+    QCOMPARE(result, "ㄅㄚ ㄉㄚˊ ㄊㄨㄥ");
+}
+void TestChineseUtils::pinuyinToZhuyinSpacesToSegment()
+{
+    std::string result
+        = ChineseUtils::convertPinyinToZhuyin("ba1 da2 tong1",
+                                              /* useSpacesToSegment = */ true);
+    QCOMPARE(result, "ㄅㄚ ㄉㄚˊ ㄊㄨㄥ");
+}
+void TestChineseUtils::pinuyinToZhuyinSpecialInitial()
+{
+    std::string result = ChineseUtils::convertPinyinToZhuyin("qu4");
+    QCOMPARE(result, "ㄑㄩˋ");
+
+    result = ChineseUtils::convertPinyinToZhuyin("chi1");
+    QCOMPARE(result, "ㄔ");
+
+    result = ChineseUtils::convertPinyinToZhuyin("ri4");
+    QCOMPARE(result, "ㄖˋ");
+}
+void TestChineseUtils::pinuyinToZhuyinSpecialFinals()
+{
+    std::string result = ChineseUtils::convertPinyinToZhuyin("hm5");
+    QCOMPARE(result, "˙ㄏㄇ");
+
+    result = ChineseUtils::convertPinyinToZhuyin("hng5");
+    QCOMPARE(result, "˙ㄏㄫ");
+
+    result = ChineseUtils::convertPinyinToZhuyin("er2");
+    QCOMPARE(result, "ㄦˊ");
+}
+void TestChineseUtils::pinuyinToZhuyinErhua()
+{
+    std::string result = ChineseUtils::convertPinyinToZhuyin("quanr1");
+    QCOMPARE(result, "ㄑㄩㄢㄦ");
+}
+void TestChineseUtils::pinuyinToZhuyinMalformed()
+{
+    std::string result = ChineseUtils::convertPinyinToZhuyin("chzng2 quanr1");
+    QCOMPARE(result, "chzng2 ㄑㄩㄢㄦ");
+}
+
+void TestChineseUtils::pinyinToIPASimple()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("ba1 da2 tong1");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "pä˥˥  tä˧˥  tʰʊŋ˥˥");
+}
+
+void TestChineseUtils::pinyinToIPARejectNoTone()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("ba");
+    QCOMPARE(result, "ba");
+}
+
+void TestChineseUtils::pinyinToIPARejectSingleLetter()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("a");
+    QCOMPARE(result, "a");
+}
+
+void TestChineseUtils::pinyinToIPARejectSpecialCharacter()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("-");
+    QCOMPARE(result, "-");
+}
+
+void TestChineseUtils::pinyinToIPANoSpaces()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("ba1da2tong1");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "pä˥˥  tä˧˥  tʰʊŋ˥˥");
+}
+
+void TestChineseUtils::pinyinToIPASpacesToSegment()
+{
+    std::string result
+        = ChineseUtils::convertPinyinToIPA("ba1 da2 tong1",
+                                           /* useSpacesToSegment = */ true);
+    qDebug() << result.c_str();
+    QCOMPARE(result, "pä˥˥  tä˧˥  tʰʊŋ˥˥");
+}
+
+void TestChineseUtils::pinyinToIPASpecialCaseNg()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("ng5");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "ŋ̍");
+}
+
+void TestChineseUtils::pinyinToIPASpecialCaseRi()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("ri4");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "ʐ̩˥˩");
+}
+
+void TestChineseUtils::pinyinToIPASyllableWithV()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("nv3");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "ny˨˩˦");
+
+    result = ChineseUtils::convertPinyinToIPA("qu4");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "t͡ɕʰy˥˩");
+}
+
+void TestChineseUtils::pinyinToIPAVoicelessInitial()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("ge5");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "g̊ə");
+
+    result = ChineseUtils::convertPinyinToIPA("yi1 ge5");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "i˥˥  g̊ə˨");
+}
+
+void TestChineseUtils::pinyinToIPAToneThree()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("ke3");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "kʰɤ˨˩˦");
+
+    result = ChineseUtils::convertPinyinToIPA("ke3 yi3");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "kʰɤ˨˩˦꜔꜒  i˨˩˦꜕꜖(꜓)");
+}
+
+void TestChineseUtils::pinyinToIPAToneFour()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("xia4 qu4");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "ɕjä˥˩꜒꜔  t͡ɕʰy˥˩");
+
+    result = ChineseUtils::convertPinyinToIPA("xia4");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "ɕjä˥˩");
+}
+
+void TestChineseUtils::pinyinToIPAOtherTone()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("ma1");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "mä˥˥");
+
+    result = ChineseUtils::convertPinyinToIPA("ma2");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "mä˧˥");
+
+    result = ChineseUtils::convertPinyinToIPA("ma5");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "mä");
+}
+void TestChineseUtils::pinyinToIPAErhua()
+{
+    std::string result = ChineseUtils::convertPinyinToIPA("huar1");
+    qDebug() << result.c_str();
+    QCOMPARE(result, "xu̯ɑɻ˥˥");
+
+    result = ChineseUtils::convertPinyinToIPA("quanr1");
+    QCOMPARE(result, "t͡ɕʰɥɑɻ˥˥");
 }
 
 void TestChineseUtils::segmentJyutpingSimple()

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -22,30 +22,30 @@ private slots:
     void compareStringsMultibyteGraphemesWithAlpha();
     void compareStringsCompatibilityVariantNormalization();
 
-    // void jyutpingToYaleSimple();
-    // void jyutpingToYaleRejectNoTone();
-    // void jyutpingToYaleRejectSingleLetter();
-    // void jyutpingToYaleRejectSpecialCharacter();
-    // void jyutpingToYaleNoSpaces();
-    // void jyutpingToYaleSpacesToSegment();
-    // void jyutpingToYaleSpecialFinal();
-    // void jyutpingToYaleLightTone();
-    // void jyutpingToYaleSpecialSyllable();
-    // void jyutpingToYaleTones();
-    // void jyutpingToYaleNoTone();
+    void jyutpingToYaleSimple();
+    void jyutpingToYaleRejectNoTone();
+    void jyutpingToYaleRejectSingleLetter();
+    void jyutpingToYaleRejectSpecialCharacter();
+    void jyutpingToYaleNoSpaces();
+    void jyutpingToYaleSpacesToSegment();
+    void jyutpingToYaleSpecialFinal();
+    void jyutpingToYaleLightTone();
+    void jyutpingToYaleSpecialSyllable();
+    void jyutpingToYaleTones();
+    void jyutpingToYaleNoTone();
 
-    // void jyutpingToIPASimple();
-    // void jyutpingToIPARejectNoTone();
-    // void jyutpingToIPARejectSingleLetter();
-    // void jyutpingToIPARejectSpecialCharacter();
-    // void jyutpingToIPANoSpaces();
-    // void jyutpingToIPASpacesToSegment();
-    // void jyutpingToIPAPreprocessInitial();
-    // void jyutpingToIPASpecialSyllable();
-    // void jyutpingToIPACheckedTone();
-    // void jyutpingToIPASpecialFinal();
-    // void jyutpingToIPATones();
-    // void jyutpingToIPANoTone();
+    void jyutpingToIPASimple();
+    void jyutpingToIPARejectNoTone();
+    void jyutpingToIPARejectSingleLetter();
+    void jyutpingToIPARejectSpecialCharacter();
+    void jyutpingToIPANoSpaces();
+    void jyutpingToIPASpacesToSegment();
+    void jyutpingToIPAPreprocessInitial();
+    void jyutpingToIPASpecialSyllable();
+    void jyutpingToIPACheckedTone();
+    void jyutpingToIPASpecialFinal();
+    void jyutpingToIPATones();
+    void jyutpingToIPANoTone();
 
     void segmentJyutpingSimple();
     void segmentJyutpingNoDigits();
@@ -161,6 +161,183 @@ void TestChineseUtils::compareStringsCompatibilityVariantNormalization()
 {
     std::string result = ChineseUtils::compareStrings("響", "響");
     QCOMPARE(result, Utils::SAME_CHARACTER_STRING);
+}
+
+void TestChineseUtils::jyutpingToYaleSimple()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale("si1 zi2 saan1");
+    QCOMPARE(result, "sī jí sāan");
+}
+
+void TestChineseUtils::jyutpingToYaleRejectNoTone()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale("joeng");
+    QCOMPARE(result, "joeng");
+}
+
+void TestChineseUtils::jyutpingToYaleRejectSingleLetter()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale("a");
+    QCOMPARE(result, "a");
+}
+
+void TestChineseUtils::jyutpingToYaleRejectSpecialCharacter()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale("-");
+    QCOMPARE(result, "x");
+}
+
+void TestChineseUtils::jyutpingToYaleNoSpaces()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale("si1zi2saan1");
+    QCOMPARE(result, "sī jí sāan");
+}
+
+void TestChineseUtils::jyutpingToYaleSpacesToSegment()
+{
+    std::string result
+        = ChineseUtils::convertJyutpingToYale("si1 zi2 saan1",
+                                              /* usSpacesToSegment = */ true);
+    QCOMPARE(result, "sī jí sāan");
+}
+
+void TestChineseUtils::jyutpingToYaleSpecialFinal()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale("goek3jyun5");
+    QCOMPARE(result, "geuk yúhn");
+}
+
+void TestChineseUtils::jyutpingToYaleLightTone()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale("lok6 jyu5");
+    QCOMPARE(result, "lohk yúh");
+}
+
+void TestChineseUtils::jyutpingToYaleSpecialSyllable()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale("m4 hai6");
+    QCOMPARE(result, "m̀h haih");
+}
+
+void TestChineseUtils::jyutpingToYaleTones()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale(
+        "saam1 gau2 sei3 ling4 ng5 ji6 cat1 baat3 luk6");
+    QCOMPARE(result, "sāam gáu sei lìhng ńgh yih chāt baat luhk");
+}
+
+void TestChineseUtils::jyutpingToYaleNoTone()
+{
+    std::string result = ChineseUtils::convertJyutpingToYale("mit");
+    QCOMPARE(result, "mit");
+}
+
+void TestChineseUtils::jyutpingToIPASimple()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA("joeng4 sing4");
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "jœ̽ːŋ ˨ ˩  sɪŋ ˨ ˩");
+#else
+    QCOMPARE(result, "jœ̽ːŋ˨˩  sɪŋ˨˩");
+#endif
+}
+
+void TestChineseUtils::jyutpingToIPARejectNoTone()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA("joeng");
+    QCOMPARE(result, "joeng");
+}
+
+void TestChineseUtils::jyutpingToIPARejectSingleLetter()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA("a");
+    QCOMPARE(result, "a");
+}
+
+void TestChineseUtils::jyutpingToIPARejectSpecialCharacter()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA("-");
+    QCOMPARE(result, "x");
+}
+
+void TestChineseUtils::jyutpingToIPANoSpaces()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA("faa1sing4");
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "fäː ˥  sɪŋ ˨ ˩");
+#else
+    QCOMPARE(result, "fäː˥  sɪŋ˨˩");
+#endif
+}
+
+void TestChineseUtils::jyutpingToIPASpacesToSegment()
+{
+    std::string result
+        = ChineseUtils::convertJyutpingToIPA("joeng4 sing4",
+                                             /* useSpacesToSegment = */ true);
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "jœ̽ːŋ ˨ ˩  sɪŋ ˨ ˩");
+#else
+    QCOMPARE(result, "jœ̽ːŋ˨˩  sɪŋ˨˩");
+#endif
+}
+
+void TestChineseUtils::jyutpingToIPAPreprocessInitial()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA("zyu2 sung3");
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "t͡ʃyː ˧ ˥  sʊŋ ˧");
+#else
+    QCOMPARE(result, "t͡ʃyː˧˥  sʊŋ˧");
+#endif
+}
+
+void TestChineseUtils::jyutpingToIPASpecialSyllable()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA("m4");
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "m̩ ˨ ˩");
+#else
+    QCOMPARE(result, "m̩˨˩");
+#endif
+}
+
+void TestChineseUtils::jyutpingToIPACheckedTone()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA(
+        "sik6 si2 o1 faan6");
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "sɪk̚ ˨  siː ˧ ˥  ɔː ˥  fäːn ˨");
+#else
+    QCOMPARE(result, "sɪk̚˨ siː˧˥ ɔː˥ fäːn˨");
+#endif
+}
+
+void TestChineseUtils::jyutpingToIPASpecialFinal()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA("uk1 kei2 jan4");
+#ifdef Q_OS_MAC
+    QCOMPARE(result, "ʊk̚ ˥  kʰei̯ ˧ ˥  jɐn ˨ ˩");
+#else
+    QCOMPARE(result, "ʊk̚˥ kʰei̯˧˥ jɐn˨˩");
+#endif
+}
+void TestChineseUtils::jyutpingToIPATones()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA(
+        "saam1 gau2 sei3 ling4 ng5 ji6 cat1 baat3 luk6");
+#ifdef Q_OS_MAC
+    QCOMPARE(result,
+             "säːm ˥  kɐu̯ ˧ ˥  sei̯ ˧  lɪŋ ˨ ˩  ŋ̍ ˩ ˧  jiː ˨  t͡sʰɐt̚ ˥  päːt̚ ˧  "
+             "lʊk̚ ˨");
+#else
+    QCOMPARE(result, "säːm˥ kɐu̯˧˥ sei̯˧ lɪŋ˨˩ ŋ̍˩˧ jiː˨ t͡sʰɐt̚˥ päːt̚˧ lʊk̚˨");
+#endif
+}
+void TestChineseUtils::jyutpingToIPANoTone()
+{
+    std::string result = ChineseUtils::convertJyutpingToIPA("mok");
+    QCOMPARE(result, "mok");
 }
 
 void TestChineseUtils::segmentJyutpingSimple()

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -32,6 +32,27 @@ private slots:
     void segmentJyutpingMultipleFinalsConsonantsOnly();
     void segmentJyutpingMultipleFinals();
     void segmentJyutpingGarbage();
+
+    void segmentPinyinSimple();
+    void segmentPinyinNoDigits();
+    void segmentPinyinNoSpaces();
+    void segmentPinyinNoDigitsNoSpaces();
+    void segmentPinyinNoDigitsApostrophe();
+    void segmentPinyinDigitsApostrophe();
+    void segmentPinyinRemoveSpecialCharacters();
+    void segmentPinyinKeepGlobCharacters();
+    void segmentPinyinKeepGlobCharactersNoWhitespace();
+    void segmentPinyinKeepMultipleGlobCharacters();
+    void segmentPinyinKeepMultipleGlobCharactersWhitespace();
+    void segmentPinyinKeepMultipleGlobCharactersWhitespaceSurround();
+    void segmentPinyinGlobCharactersTrimWhitespace();
+    void segmentPinyinKeepSpecialCharacters();
+    void segmentPinyinRemoveWhitespace();
+    void segmentPinyinLower();
+    void segmentPinyinLowerWithDigits();
+    void segmentPinyinMultipleFinalsVowelsOnly();
+    void segmentPinyinMultipleFinals();
+    void segmentPinyinGarbage();
 };
 
 TestChineseUtils::TestChineseUtils() {}
@@ -243,6 +264,200 @@ void TestChineseUtils::segmentJyutpingGarbage()
     QCOMPARE(valid, false);
 }
 
+void TestChineseUtils::segmentPinyinSimple()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang3 dong1", result);
+    std::vector<std::string> expected = {"guang3", "dong1"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinNoDigits()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang dong", result);
+    std::vector<std::string> expected = {"guang", "dong"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinNoSpaces()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang3dong1", result);
+    std::vector<std::string> expected = {"guang3", "dong1"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinNoDigitsNoSpaces()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guangdong", result);
+    std::vector<std::string> expected = {"guang", "dong"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinNoDigitsApostrophe()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("xi'an", result);
+    std::vector<std::string> expected = {"xi", "an"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinDigitsApostrophe()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("xi1'an", result);
+    std::vector<std::string> expected = {"xi1", "an"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinRemoveSpecialCharacters()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang*dong!!", result);
+    std::vector<std::string> expected = {"guang", "dong"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinKeepGlobCharacters()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang* dong?",
+                                result,
+                                /* removeSpecialCharacters = */ true,
+                                /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"guang", "* ", "dong", "?"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinKeepGlobCharactersNoWhitespace()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang*dong?",
+                                result,
+                                /* removeSpecialCharacters = */ true,
+                                /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"guang", "*", "dong", "?"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinKeepMultipleGlobCharacters()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang?* dong",
+                                result,
+                                /* removeSpecialCharacters = */ true,
+                                /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"guang", "?", "* ", "dong"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinKeepMultipleGlobCharactersWhitespace()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang? * dong",
+                                result,
+                                /* removeSpecialCharacters = */ true,
+                                /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"guang", "? ", "* ", "dong"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinKeepMultipleGlobCharactersWhitespaceSurround()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang ? * dong",
+                                result,
+                                /* removeSpecialCharacters = */ true,
+                                /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"guang", " ? ", "* ", "dong"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinGlobCharactersTrimWhitespace()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang  ?            *      dong",
+                                result,
+                                /* removeSpecialCharacters = */ true,
+                                /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"guang", " ? ", "* ", "dong"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinKeepSpecialCharacters()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guang？ dong1",
+                                result,
+                                /* removeSpecialCharacters = */ false);
+    std::vector<std::string> expected = {"guang", "？", "dong1"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinRemoveWhitespace()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("  guang                           dong      ",
+                                result,
+                                /* removeSpecialCharacters = */ true,
+                                /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"guang", "dong"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinLower()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("gUanGdOnG", result);
+    std::vector<std::string> expected = {"guang", "dong"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinLowerWithDigits()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("guAng3dONg1", result);
+    std::vector<std::string> expected = {"guang3", "dong1"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinMultipleFinalsVowelsOnly()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("ee",
+                                result,
+                                /* removeSpecialCharacters = */ true,
+                                /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"e", "e"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinMultipleFinals()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentPinyin("angang",
+                                result,
+                                /* removeSpecialCharacters = */ true,
+                                /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"ang", "ang"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentPinyinGarbage()
+{
+    std::vector<std::string> result;
+    bool valid
+        = ChineseUtils::segmentPinyin("kljnxclkjvnl",
+                                      result,
+                                      /* removeSpecialCharacters = */ true,
+                                      /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"kljnxclkjvnl"};
+    QCOMPARE(result, expected);
+    QCOMPARE(valid, false);
+}
+
 QTEST_APPLESS_MAIN(TestChineseUtils)
 
-#include "tst_testchineseutils.moc"
+#include "tst_chineseutils.moc"

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -1,6 +1,8 @@
 #include <QtTest>
 
+#include "logic/settings/settings.h"
 #include "logic/utils/chineseutils.h"
+#include "logic/utils/utils.h"
 
 class TestChineseUtils : public QObject
 {
@@ -11,6 +13,40 @@ public:
     ~TestChineseUtils();
 
 private slots:
+    void applyColoursJyutping();
+    void applyColoursPinyin();
+
+    void compareStringsSimple();
+    void compareStringsSingleMultibyteGrapheme();
+    void compareStringsMultipleMultibyteGraphemes();
+    void compareStringsMultibyteGraphemesWithAlpha();
+    void compareStringsCompatibilityVariantNormalization();
+
+    // void jyutpingToYaleSimple();
+    // void jyutpingToYaleRejectNoTone();
+    // void jyutpingToYaleRejectSingleLetter();
+    // void jyutpingToYaleRejectSpecialCharacter();
+    // void jyutpingToYaleNoSpaces();
+    // void jyutpingToYaleSpacesToSegment();
+    // void jyutpingToYaleSpecialFinal();
+    // void jyutpingToYaleLightTone();
+    // void jyutpingToYaleSpecialSyllable();
+    // void jyutpingToYaleTones();
+    // void jyutpingToYaleNoTone();
+
+    // void jyutpingToIPASimple();
+    // void jyutpingToIPARejectNoTone();
+    // void jyutpingToIPARejectSingleLetter();
+    // void jyutpingToIPARejectSpecialCharacter();
+    // void jyutpingToIPANoSpaces();
+    // void jyutpingToIPASpacesToSegment();
+    // void jyutpingToIPAPreprocessInitial();
+    // void jyutpingToIPASpecialSyllable();
+    // void jyutpingToIPACheckedTone();
+    // void jyutpingToIPASpecialFinal();
+    // void jyutpingToIPATones();
+    // void jyutpingToIPANoTone();
+
     void segmentJyutpingSimple();
     void segmentJyutpingNoDigits();
     void segmentJyutpingNoSpaces();
@@ -58,6 +94,74 @@ private slots:
 TestChineseUtils::TestChineseUtils() {}
 
 TestChineseUtils::~TestChineseUtils() {}
+
+void TestChineseUtils::applyColoursJyutping()
+{
+    std::string text = "唔係";
+    std::vector<int> tones = {4, 6};
+    std::string result
+        = ChineseUtils::applyColours(text,
+                                     tones,
+                                     Settings::defaultJyutpingToneColours,
+                                     {},
+                                     EntryColourPhoneticType::CANTONESE);
+    std::string expected = "<font color=\""
+                           + Settings::defaultJyutpingToneColours[4]
+                           + "\">唔</font>" + "<font color=\""
+                           + Settings::defaultJyutpingToneColours[6]
+                           + "\">係</font>";
+    QCOMPARE(result, expected);
+}
+void TestChineseUtils::applyColoursPinyin()
+{
+    std::string text = "不是";
+    std::vector<int> tones = {2, 4};
+    std::string result
+        = ChineseUtils::applyColours(text,
+                                     tones,
+                                     {},
+                                     Settings::defaultPinyinToneColours,
+                                     EntryColourPhoneticType::MANDARIN);
+    std::string expected = "<font color=\""
+                           + Settings::defaultPinyinToneColours[2]
+                           + "\">不</font>" + "<font color=\""
+                           + Settings::defaultPinyinToneColours[4]
+                           + "\">是</font>";
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::compareStringsSimple()
+{
+    std::string result = ChineseUtils::compareStrings("語言藝術", "语言艺术");
+    QCOMPARE(result, "语－艺术");
+}
+
+void TestChineseUtils::compareStringsSingleMultibyteGrapheme()
+{
+    std::string result = ChineseUtils::compareStrings("賵", "赗");
+    QCOMPARE(result, "赗");
+}
+
+void TestChineseUtils::compareStringsMultipleMultibyteGraphemes()
+{
+    std::string result = ChineseUtils::compareStrings("齮齕", "𬺈龁");
+    QCOMPARE(result, "𬺈龁");
+}
+
+void TestChineseUtils::compareStringsMultibyteGraphemesWithAlpha()
+{
+    std::string result = ChineseUtils::compareStrings("齮aaaa齕", "𬺈aaaa龁");
+    QCOMPARE(result,
+             "𬺈" + std::string{Utils::SAME_CHARACTER_STRING}
+                 + Utils::SAME_CHARACTER_STRING + Utils::SAME_CHARACTER_STRING
+                 + Utils::SAME_CHARACTER_STRING + "龁");
+}
+
+void TestChineseUtils::compareStringsCompatibilityVariantNormalization()
+{
+    std::string result = ChineseUtils::compareStrings("響", "響");
+    QCOMPARE(result, Utils::SAME_CHARACTER_STRING);
+}
 
 void TestChineseUtils::segmentJyutpingSimple()
 {

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -1,0 +1,248 @@
+#include <QtTest>
+
+#include "logic/utils/chineseutils.h"
+
+class TestChineseUtils : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestChineseUtils();
+    ~TestChineseUtils();
+
+private slots:
+    void segmentJyutpingSimple();
+    void segmentJyutpingNoDigits();
+    void segmentJyutpingNoSpaces();
+    void segmentJyutpingNoDigitsNoSpaces();
+    void segmentJyutpingNoDigitsApostrophe();
+    void segmentJyutpingDigitsApostrophe();
+    void segmentJyutpingRemoveSpecialCharacters();
+    void segmentJyutpingKeepGlobCharacters();
+    void segmentJyutpingKeepGlobCharactersNoWhitespace();
+    void segmentJyutpingKeepMultipleGlobCharacters();
+    void segmentJyutpingKeepMultipleGlobCharactersWhitespace();
+    void segmentJyutpingKeepMultipleGlobCharactersWhitespaceSurround();
+    void segmentJyutpingGlobCharactersTrimWhitespace();
+    void segmentJyutpingKeepSpecialCharacters();
+    void segmentJyutpingRemoveWhitespace();
+    void segmentJyutpingLower();
+    void segmentJyutpingLowerWithDigits();
+    void segmentJyutpingMultipleFinalsVowelsOnly();
+    void segmentJyutpingMultipleFinalsConsonantsOnly();
+    void segmentJyutpingMultipleFinals();
+    void segmentJyutpingGarbage();
+};
+
+TestChineseUtils::TestChineseUtils() {}
+
+TestChineseUtils::~TestChineseUtils() {}
+
+void TestChineseUtils::segmentJyutpingSimple()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m4 goi1", result);
+    std::vector<std::string> expected = {"m4", "goi1"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingNoDigits()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m goi", result);
+    std::vector<std::string> expected = {"m", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingNoSpaces()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m4goi1", result);
+    std::vector<std::string> expected = {"m4", "goi1"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingNoDigitsNoSpaces()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("mgoi", result);
+    std::vector<std::string> expected = {"m", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingNoDigitsApostrophe()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m'aam", result);
+    std::vector<std::string> expected = {"m", "aam"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingDigitsApostrophe()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m4'aam", result);
+    std::vector<std::string> expected = {"m4", "aam"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingRemoveSpecialCharacters()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m*goi", result);
+    std::vector<std::string> expected = {"m", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingKeepGlobCharacters()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m* goi",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"m", "* ", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingKeepGlobCharactersNoWhitespace()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m*goi",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"m", "*", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingKeepMultipleGlobCharacters()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m?* goi",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"m", "?", "* ", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingKeepMultipleGlobCharactersWhitespace()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m? * goi",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"m", "? ", "* ", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingKeepMultipleGlobCharactersWhitespaceSurround()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m ? * goi",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"m", " ? ", "* ", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingGlobCharactersTrimWhitespace()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m  ?            *      goi",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"m", " ? ", "* ", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingKeepSpecialCharacters()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m？ goi",
+                                  result,
+                                  /* removeSpecialCharacters = */ false);
+    std::vector<std::string> expected = {"m", "？", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingRemoveWhitespace()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("  m                           goi      ",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"m", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingLower()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("mGoI", result);
+    std::vector<std::string> expected = {"m", "goi"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingLowerWithDigits()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("m4GoI1", result);
+    std::vector<std::string> expected = {"m4", "goi1"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingMultipleFinalsVowelsOnly()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("aaaa",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"aa", "aa"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingMultipleFinalsConsonantsOnly()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("ngng",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"ng", "ng"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingMultipleFinals()
+{
+    std::vector<std::string> result;
+    ChineseUtils::segmentJyutping("amam",
+                                  result,
+                                  /* removeSpecialCharacters = */ true,
+                                  /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"am", "am"};
+    QCOMPARE(result, expected);
+}
+
+void TestChineseUtils::segmentJyutpingGarbage()
+{
+    std::vector<std::string> result;
+    bool valid
+        = ChineseUtils::segmentJyutping("kljnxclkjvnl",
+                                        result,
+                                        /* removeSpecialCharacters = */ true,
+                                        /* removeGlobCharacters = */ false);
+    std::vector<std::string> expected = {"kljnxclkjvnl"};
+    QCOMPARE(result, expected);
+    QCOMPARE(valid, false);
+}
+
+QTEST_APPLESS_MAIN(TestChineseUtils)
+
+#include "tst_testchineseutils.moc"

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -309,7 +309,7 @@ void TestChineseUtils::jyutpingToIPACheckedTone()
 #ifdef Q_OS_MAC
     QCOMPARE(result, "sɪk̚ ˨  siː ˧ ˥  ɔː ˥  fäːn ˨");
 #else
-    QCOMPARE(result, "sɪk̚˨ siː˧˥ ɔː˥ fäːn˨");
+    QCOMPARE(result, "sɪk̚˨  siː˧˥  ɔː˥  fäːn˨");
 #endif
 }
 
@@ -319,7 +319,7 @@ void TestChineseUtils::jyutpingToIPASpecialFinal()
 #ifdef Q_OS_MAC
     QCOMPARE(result, "ʊk̚ ˥  kʰei̯ ˧ ˥  jɐn ˨ ˩");
 #else
-    QCOMPARE(result, "ʊk̚˥ kʰei̯˧˥ jɐn˨˩");
+    QCOMPARE(result, "ʊk̚˥  kʰei̯˧˥  jɐn˨˩");
 #endif
 }
 void TestChineseUtils::jyutpingToIPATones()
@@ -331,7 +331,8 @@ void TestChineseUtils::jyutpingToIPATones()
              "säːm ˥  kɐu̯ ˧ ˥  sei̯ ˧  lɪŋ ˨ ˩  ŋ̍ ˩ ˧  jiː ˨  t͡sʰɐt̚ ˥  päːt̚ ˧  "
              "lʊk̚ ˨");
 #else
-    QCOMPARE(result, "säːm˥ kɐu̯˧˥ sei̯˧ lɪŋ˨˩ ŋ̍˩˧ jiː˨ t͡sʰɐt̚˥ päːt̚˧ lʊk̚˨");
+    QCOMPARE(result,
+             "säːm˥  kɐu̯˧˥  sei̯˧  lɪŋ˨˩  ŋ̍˩˧  jiː˨  t͡sʰɐt̚˥  päːt̚˧  lʊk̚˨");
 #endif
 }
 void TestChineseUtils::jyutpingToIPANoTone()

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -133,7 +133,7 @@ void TestChineseUtils::applyColoursPinyin()
 void TestChineseUtils::compareStringsSimple()
 {
     std::string result = ChineseUtils::compareStrings("語言藝術", "语言艺术");
-    QCOMPARE(result, "语－艺术");
+    QCOMPARE(result, "语" + std::string{Utils::SAME_CHARACTER_STRING} + "艺术");
 }
 
 void TestChineseUtils::compareStringsSingleMultibyteGrapheme()

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -509,8 +509,11 @@ void TestChineseUtils::pinuyinToZhuyinMalformed()
 
 void TestChineseUtils::pinyinToIPASimple()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result = ChineseUtils::convertPinyinToIPA("ba1 da2 tong1");
-    qDebug() << result.c_str();
+    qDebug() << QString::fromStdString(result);
     QCOMPARE(result, "pä˥˥  tä˧˥  tʰʊŋ˥˥");
 }
 
@@ -534,6 +537,9 @@ void TestChineseUtils::pinyinToIPARejectSpecialCharacter()
 
 void TestChineseUtils::pinyinToIPANoSpaces()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result = ChineseUtils::convertPinyinToIPA("ba1da2tong1");
     qDebug() << result.c_str();
     QCOMPARE(result, "pä˥˥  tä˧˥  tʰʊŋ˥˥");
@@ -541,6 +547,9 @@ void TestChineseUtils::pinyinToIPANoSpaces()
 
 void TestChineseUtils::pinyinToIPASpacesToSegment()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result
         = ChineseUtils::convertPinyinToIPA("ba1 da2 tong1",
                                            /* useSpacesToSegment = */ true);
@@ -557,6 +566,9 @@ void TestChineseUtils::pinyinToIPASpecialCaseNg()
 
 void TestChineseUtils::pinyinToIPASpecialCaseRi()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result = ChineseUtils::convertPinyinToIPA("ri4");
     qDebug() << result.c_str();
     QCOMPARE(result, "ʐ̩˥˩");
@@ -564,6 +576,9 @@ void TestChineseUtils::pinyinToIPASpecialCaseRi()
 
 void TestChineseUtils::pinyinToIPASyllableWithV()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result = ChineseUtils::convertPinyinToIPA("nv3");
     qDebug() << result.c_str();
     QCOMPARE(result, "ny˨˩˦");
@@ -575,6 +590,9 @@ void TestChineseUtils::pinyinToIPASyllableWithV()
 
 void TestChineseUtils::pinyinToIPAVoicelessInitial()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result = ChineseUtils::convertPinyinToIPA("ge5");
     qDebug() << result.c_str();
     QCOMPARE(result, "g̊ə");
@@ -586,6 +604,9 @@ void TestChineseUtils::pinyinToIPAVoicelessInitial()
 
 void TestChineseUtils::pinyinToIPAToneThree()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result = ChineseUtils::convertPinyinToIPA("ke3");
     qDebug() << result.c_str();
     QCOMPARE(result, "kʰɤ˨˩˦");
@@ -597,6 +618,9 @@ void TestChineseUtils::pinyinToIPAToneThree()
 
 void TestChineseUtils::pinyinToIPAToneFour()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result = ChineseUtils::convertPinyinToIPA("xia4 qu4");
     qDebug() << result.c_str();
     QCOMPARE(result, "ɕjä˥˩꜒꜔  t͡ɕʰy˥˩");
@@ -608,6 +632,9 @@ void TestChineseUtils::pinyinToIPAToneFour()
 
 void TestChineseUtils::pinyinToIPAOtherTone()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result = ChineseUtils::convertPinyinToIPA("ma1");
     qDebug() << result.c_str();
     QCOMPARE(result, "mä˥˥");
@@ -622,6 +649,9 @@ void TestChineseUtils::pinyinToIPAOtherTone()
 }
 void TestChineseUtils::pinyinToIPAErhua()
 {
+#if defined(Q_OS_WINDOWS)
+    QSKIP("IPA tone comparison doesn't work on Windows, skipping test");
+#endif
     std::string result = ChineseUtils::convertPinyinToIPA("huar1");
     qDebug() << result.c_str();
     QCOMPARE(result, "xu̯ɑɻ˥˥");


### PR DESCRIPTION
# Description

This commit adds several unit tests for the ChineseUtils namespace, including:
* Jyutping to Yale conversion
* Jyutping to IPA conversion
* Pinyin to Zhuyin conversion
* Pinyin to IPA conversion
* Pinyin to Pretty Pinyin and Pinyin with V conversion
* Jyutping segmentation
* Pinyin segmentation
* Tone colour application logic
* Character comparison logic

One diff among many for #160.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on all three platforms. On Mac and Linux, output should look something like the following:

```
********* Start testing of TestChineseUtils *********
Config: Using QtTest library 5.15.12, Qt 5.15.12 (arm64-little_endian-lp64 shared (dynamic) release build; by Clang 15.0.0 (clang-1500.0.40.1) (Apple)), osx 14.3
PASS   : TestChineseUtils::initTestCase()
PASS   : TestChineseUtils::applyColoursJyutping()
PASS   : TestChineseUtils::applyColoursPinyin()
PASS   : TestChineseUtils::compareStringsSimple()
PASS   : TestChineseUtils::compareStringsSingleMultibyteGrapheme()
PASS   : TestChineseUtils::compareStringsMultipleMultibyteGraphemes()
PASS   : TestChineseUtils::compareStringsMultibyteGraphemesWithAlpha()
PASS   : TestChineseUtils::compareStringsCompatibilityVariantNormalization()
PASS   : TestChineseUtils::jyutpingToYaleSimple()
PASS   : TestChineseUtils::jyutpingToYaleRejectNoTone()
PASS   : TestChineseUtils::jyutpingToYaleRejectSingleLetter()
PASS   : TestChineseUtils::jyutpingToYaleRejectSpecialCharacter()
PASS   : TestChineseUtils::jyutpingToYaleNoSpaces()
PASS   : TestChineseUtils::jyutpingToYaleSpacesToSegment()
PASS   : TestChineseUtils::jyutpingToYaleSpecialFinal()
PASS   : TestChineseUtils::jyutpingToYaleLightTone()
PASS   : TestChineseUtils::jyutpingToYaleSpecialSyllable()
PASS   : TestChineseUtils::jyutpingToYaleTones()
PASS   : TestChineseUtils::jyutpingToYaleNoTone()
PASS   : TestChineseUtils::jyutpingToIPASimple()
PASS   : TestChineseUtils::jyutpingToIPARejectNoTone()
PASS   : TestChineseUtils::jyutpingToIPARejectSingleLetter()
PASS   : TestChineseUtils::jyutpingToIPARejectSpecialCharacter()
PASS   : TestChineseUtils::jyutpingToIPANoSpaces()
PASS   : TestChineseUtils::jyutpingToIPASpacesToSegment()
PASS   : TestChineseUtils::jyutpingToIPAPreprocessInitial()
PASS   : TestChineseUtils::jyutpingToIPASpecialSyllable()
PASS   : TestChineseUtils::jyutpingToIPACheckedTone()
PASS   : TestChineseUtils::jyutpingToIPASpecialFinal()
PASS   : TestChineseUtils::jyutpingToIPATones()
PASS   : TestChineseUtils::jyutpingToIPANoTone()
PASS   : TestChineseUtils::prettyPinyinSimple()
PASS   : TestChineseUtils::prettyPinyinRejectNoTone()
PASS   : TestChineseUtils::prettyPinyinRejectSingleLetter()
PASS   : TestChineseUtils::prettyPinyinRejectSpecialCharacter()
PASS   : TestChineseUtils::prettyPinyinSecondaryVowel()
PASS   : TestChineseUtils::prettyPinyinUmlaut()
PASS   : TestChineseUtils::prettyPinyinTones()
PASS   : TestChineseUtils::prettyPinyinNoTone()
PASS   : TestChineseUtils::numberedPinyinSimple()
PASS   : TestChineseUtils::pinyinWithVSimple()
PASS   : TestChineseUtils::pinuyinToZhuyinSimple()
PASS   : TestChineseUtils::pinuyinToZhuyinRejectNoTone()
PASS   : TestChineseUtils::pinuyinToZhuyinRejectSingleLetter()
PASS   : TestChineseUtils::pinuyinToZhuyinRejectSpecialCharacter()
PASS   : TestChineseUtils::pinuyinToZhuyinNoSpaces()
PASS   : TestChineseUtils::pinuyinToZhuyinSpacesToSegment()
PASS   : TestChineseUtils::pinuyinToZhuyinSpecialInitial()
PASS   : TestChineseUtils::pinuyinToZhuyinSpecialFinals()
PASS   : TestChineseUtils::pinuyinToZhuyinErhua()
PASS   : TestChineseUtils::pinuyinToZhuyinMalformed()
PASS   : TestChineseUtils::pinyinToIPASimple()
PASS   : TestChineseUtils::pinyinToIPARejectNoTone()
PASS   : TestChineseUtils::pinyinToIPARejectSingleLetter()
PASS   : TestChineseUtils::pinyinToIPARejectSpecialCharacter()
PASS   : TestChineseUtils::pinyinToIPANoSpaces()
PASS   : TestChineseUtils::pinyinToIPASpacesToSegment()
PASS   : TestChineseUtils::pinyinToIPASpecialCaseNg()
PASS   : TestChineseUtils::pinyinToIPASpecialCaseRi()
PASS   : TestChineseUtils::pinyinToIPASyllableWithV()
PASS   : TestChineseUtils::pinyinToIPAVoicelessInitial()
PASS   : TestChineseUtils::pinyinToIPAToneThree()
PASS   : TestChineseUtils::pinyinToIPAToneFour()
PASS   : TestChineseUtils::pinyinToIPAOtherTone()
PASS   : TestChineseUtils::pinyinToIPAErhua()
PASS   : TestChineseUtils::segmentJyutpingSimple()
PASS   : TestChineseUtils::segmentJyutpingNoDigits()
PASS   : TestChineseUtils::segmentJyutpingNoSpaces()
PASS   : TestChineseUtils::segmentJyutpingNoDigitsNoSpaces()
PASS   : TestChineseUtils::segmentJyutpingNoDigitsApostrophe()
PASS   : TestChineseUtils::segmentJyutpingDigitsApostrophe()
PASS   : TestChineseUtils::segmentJyutpingRemoveSpecialCharacters()
PASS   : TestChineseUtils::segmentJyutpingKeepGlobCharacters()
PASS   : TestChineseUtils::segmentJyutpingKeepGlobCharactersNoWhitespace()
PASS   : TestChineseUtils::segmentJyutpingKeepMultipleGlobCharacters()
PASS   : TestChineseUtils::segmentJyutpingKeepMultipleGlobCharactersWhitespace()
PASS   : TestChineseUtils::segmentJyutpingKeepMultipleGlobCharactersWhitespaceSurround()
PASS   : TestChineseUtils::segmentJyutpingGlobCharactersTrimWhitespace()
PASS   : TestChineseUtils::segmentJyutpingKeepSpecialCharacters()
PASS   : TestChineseUtils::segmentJyutpingRemoveWhitespace()
PASS   : TestChineseUtils::segmentJyutpingLower()
PASS   : TestChineseUtils::segmentJyutpingLowerWithDigits()
PASS   : TestChineseUtils::segmentJyutpingMultipleFinalsVowelsOnly()
PASS   : TestChineseUtils::segmentJyutpingMultipleFinalsConsonantsOnly()
PASS   : TestChineseUtils::segmentJyutpingMultipleFinals()
PASS   : TestChineseUtils::segmentJyutpingGarbage()
PASS   : TestChineseUtils::segmentPinyinSimple()
PASS   : TestChineseUtils::segmentPinyinNoDigits()
PASS   : TestChineseUtils::segmentPinyinNoSpaces()
PASS   : TestChineseUtils::segmentPinyinNoDigitsNoSpaces()
PASS   : TestChineseUtils::segmentPinyinNoDigitsApostrophe()
PASS   : TestChineseUtils::segmentPinyinDigitsApostrophe()
PASS   : TestChineseUtils::segmentPinyinRemoveSpecialCharacters()
PASS   : TestChineseUtils::segmentPinyinKeepGlobCharacters()
PASS   : TestChineseUtils::segmentPinyinKeepGlobCharactersNoWhitespace()
PASS   : TestChineseUtils::segmentPinyinKeepMultipleGlobCharacters()
PASS   : TestChineseUtils::segmentPinyinKeepMultipleGlobCharactersWhitespace()
PASS   : TestChineseUtils::segmentPinyinKeepMultipleGlobCharactersWhitespaceSurround()
PASS   : TestChineseUtils::segmentPinyinGlobCharactersTrimWhitespace()
PASS   : TestChineseUtils::segmentPinyinKeepSpecialCharacters()
PASS   : TestChineseUtils::segmentPinyinRemoveWhitespace()
PASS   : TestChineseUtils::segmentPinyinLower()
PASS   : TestChineseUtils::segmentPinyinLowerWithDigits()
PASS   : TestChineseUtils::segmentPinyinMultipleFinalsVowelsOnly()
PASS   : TestChineseUtils::segmentPinyinMultipleFinals()
PASS   : TestChineseUtils::segmentPinyinGarbage()
PASS   : TestChineseUtils::cleanupTestCase()
Totals: 107 passed, 0 failed, 0 skipped, 0 blacklisted, 13ms
********* Finished testing of TestChineseUtils *********
```

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
