### PR TITLE
#160: Write unit tests for SettingsUtils

### DIFF
--- a/src/jyut-dict/CMakeLists.txt
+++ b/src/jyut-dict/CMakeLists.txt
@@ -165,12 +165,9 @@ target_link_libraries(CantoneseDictionary
     PRIVATE KF5::Archive
 )
 
-add_subdirectory(
-    logic/utils/test/TestChineseUtils
-)
-add_subdirectory(
-    logic/utils/test/TestScriptDetector
-)
+add_subdirectory(logic/settings/test/TestSettingsUtils)
+add_subdirectory(logic/utils/test/TestChineseUtils)
+add_subdirectory(logic/utils/test/TestScriptDetector)
 
 set_target_properties(CantoneseDictionary PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/platform/mac/Info.plist

--- a/src/jyut-dict/logic/settings/settingsutils.cpp
+++ b/src/jyut-dict/logic/settings/settingsutils.cpp
@@ -133,6 +133,7 @@ bool migrateSettingsFromOneToTwo(QSettings &settings)
         }
     }
 
+    settings.setValue("Metadata/version", QVariant{SETTINGS_VERSION});
     settings.sync();
 
     return true;

--- a/src/jyut-dict/logic/settings/test/TestSettingsUtils/.gitignore
+++ b/src/jyut-dict/logic/settings/test/TestSettingsUtils/.gitignore
@@ -1,0 +1,74 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+CMakeLists.txt.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/src/jyut-dict/logic/settings/test/TestSettingsUtils/CMakeLists.txt
+++ b/src/jyut-dict/logic/settings/test/TestSettingsUtils/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(TestSettingsUtils LANGUAGES CXX)
+
+enable_testing()
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(TestSettingsUtils tst_settingsutils.cpp)
+add_test(NAME TestSettingsUtils COMMAND TestSettingsUtils)
+
+target_link_libraries(TestSettingsUtils PRIVATE Qt${QT_VERSION_MAJOR}::Test)
+target_include_directories(TestSettingsUtils PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
+
+target_sources(TestSettingsUtils
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../settings.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../settingsutils.cpp)
+

--- a/src/jyut-dict/logic/settings/test/TestSettingsUtils/tst_settingsutils.cpp
+++ b/src/jyut-dict/logic/settings/test/TestSettingsUtils/tst_settingsutils.cpp
@@ -1,0 +1,164 @@
+#include <QtTest>
+
+#include "logic/entry/entrycharactersoptions.h"
+#include "logic/entry/entryphoneticoptions.h"
+#include "logic/settings/settingsutils.h"
+
+#include <memory>
+
+class TestSettingsUtils : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestSettingsUtils();
+    ~TestSettingsUtils();
+
+private slots:
+    void migrateCantoneseOnlyOneToTwo();
+    void migrateMandarinOnlyOneToTwo();
+    void migratePreferCantoneseOneToTwo();
+    void migratePreferMandarinOneToTwo();
+};
+
+TestSettingsUtils::TestSettingsUtils()
+{
+    qRegisterMetaType<EntryCharactersOptions>("EntryCharactersOptions");
+    qRegisterMetaTypeStreamOperators<EntryCharactersOptions>(
+        "EntryCharactersOptions");
+    qRegisterMetaType<EntryPhoneticOptions>("EntryPhoneticOptions");
+    qRegisterMetaTypeStreamOperators<EntryPhoneticOptions>(
+        "EntryPhoneticOptions");
+    qRegisterMetaTypeStreamOperators<CantoneseOptions>("CantoneseOptions");
+    qRegisterMetaType<MandarinOptions>("MandarinOptions");
+    qRegisterMetaTypeStreamOperators<MandarinOptions>("MandarinOptions");
+    qRegisterMetaType<EntryColourPhoneticType>("EntryColourPhoneticType");
+}
+
+TestSettingsUtils::~TestSettingsUtils() {}
+
+void TestSettingsUtils::migrateCantoneseOnlyOneToTwo()
+{
+    std::unique_ptr<QSettings> settings = Settings::getSettings();
+    settings->clear();
+    settings->sync();
+
+    settings->setValue("characterOptions",
+                       QVariant::fromValue(
+                           EntryPhoneticOptions::ONLY_CANTONESE));
+    settings->setValue("phoneticOptions",
+                       QVariant::fromValue(
+                           EntryPhoneticOptions::ONLY_CANTONESE));
+    settings->sync();
+
+    Settings::migrateSettingsFromOneToTwo(*settings);
+
+    QCOMPARE(settings->value("Metadata/version"), QVariant{2});
+    QCOMPARE(settings->value("characterOptions"),
+             QVariant::fromValue(static_cast<EntryCharactersOptions>(
+                 EntryPhoneticOptions::ONLY_CANTONESE)));
+    QCOMPARE(settings->value("Preview/phoneticOptions"),
+             QVariant::fromValue(EntryPhoneticOptions::ONLY_CANTONESE));
+    QCOMPARE(settings->value("Entry/cantonesePronunciationOptions"),
+             QVariant::fromValue(CantoneseOptions::RAW_JYUTPING));
+    QCOMPARE(settings->value("Entry/mandarinPronunciationOptions"),
+             QVariant::fromValue(MandarinOptions::NONE));
+
+    settings->clear();
+    settings->sync();
+}
+
+void TestSettingsUtils::migrateMandarinOnlyOneToTwo()
+{
+    std::unique_ptr<QSettings> settings = Settings::getSettings();
+    settings->clear();
+    settings->sync();
+
+    settings->setValue("characterOptions",
+                       QVariant::fromValue(EntryPhoneticOptions::ONLY_MANDARIN));
+    settings->setValue("phoneticOptions",
+                       QVariant::fromValue(EntryPhoneticOptions::ONLY_MANDARIN));
+    settings->sync();
+
+    Settings::migrateSettingsFromOneToTwo(*settings);
+
+    QCOMPARE(settings->value("Metadata/version"), QVariant{2});
+    QCOMPARE(settings->value("characterOptions"),
+             QVariant::fromValue(static_cast<EntryCharactersOptions>(
+                 EntryPhoneticOptions::ONLY_MANDARIN)));
+    QCOMPARE(settings->value("Preview/phoneticOptions"),
+             QVariant::fromValue(EntryPhoneticOptions::ONLY_MANDARIN));
+    QCOMPARE(settings->value("Entry/cantonesePronunciationOptions"),
+             QVariant::fromValue(CantoneseOptions::NONE));
+    QCOMPARE(settings->value("Entry/mandarinPronunciationOptions"),
+             QVariant::fromValue(MandarinOptions::PRETTY_PINYIN));
+
+    settings->clear();
+    settings->sync();
+}
+
+void TestSettingsUtils::migratePreferCantoneseOneToTwo()
+{
+    std::unique_ptr<QSettings> settings = Settings::getSettings();
+    settings->clear();
+    settings->sync();
+
+    settings->setValue("characterOptions",
+                       QVariant::fromValue(
+                           EntryPhoneticOptions::PREFER_CANTONESE));
+    settings->setValue("phoneticOptions",
+                       QVariant::fromValue(
+                           EntryPhoneticOptions::PREFER_CANTONESE));
+    settings->sync();
+
+    Settings::migrateSettingsFromOneToTwo(*settings);
+
+    QCOMPARE(settings->value("Metadata/version"), QVariant{2});
+    QCOMPARE(settings->value("characterOptions"),
+             QVariant::fromValue(static_cast<EntryCharactersOptions>(
+                 EntryPhoneticOptions::PREFER_CANTONESE)));
+    QCOMPARE(settings->value("Preview/phoneticOptions"),
+             QVariant::fromValue(EntryPhoneticOptions::PREFER_CANTONESE));
+    QCOMPARE(settings->value("Entry/cantonesePronunciationOptions"),
+             QVariant::fromValue(CantoneseOptions::RAW_JYUTPING));
+    QCOMPARE(settings->value("Entry/mandarinPronunciationOptions"),
+             QVariant::fromValue(MandarinOptions::PRETTY_PINYIN));
+
+    settings->clear();
+    settings->sync();
+}
+
+void TestSettingsUtils::migratePreferMandarinOneToTwo()
+{
+    std::unique_ptr<QSettings> settings = Settings::getSettings();
+    settings->clear();
+    settings->sync();
+
+    settings->setValue("characterOptions",
+                       QVariant::fromValue(
+                           EntryPhoneticOptions::PREFER_MANDARIN));
+    settings->setValue("phoneticOptions",
+                       QVariant::fromValue(
+                           EntryPhoneticOptions::PREFER_MANDARIN));
+    settings->sync();
+
+    Settings::migrateSettingsFromOneToTwo(*settings);
+
+    QCOMPARE(settings->value("Metadata/version"), QVariant{2});
+    QCOMPARE(settings->value("characterOptions"),
+             QVariant::fromValue(static_cast<EntryCharactersOptions>(
+                 EntryPhoneticOptions::PREFER_MANDARIN)));
+    QCOMPARE(settings->value("Preview/phoneticOptions"),
+             QVariant::fromValue(EntryPhoneticOptions::PREFER_MANDARIN));
+    QCOMPARE(settings->value("Entry/cantonesePronunciationOptions"),
+             QVariant::fromValue(CantoneseOptions::RAW_JYUTPING));
+    QCOMPARE(settings->value("Entry/mandarinPronunciationOptions"),
+             QVariant::fromValue(MandarinOptions::PRETTY_PINYIN));
+
+    settings->clear();
+    settings->sync();
+}
+
+QTEST_MAIN(TestSettingsUtils)
+
+#include "tst_settingsutils.moc"

--- a/src/jyut-dict/logic/settings/test/TestSettingsUtils/tst_settingsutils.cpp
+++ b/src/jyut-dict/logic/settings/test/TestSettingsUtils/tst_settingsutils.cpp
@@ -15,6 +15,9 @@ public:
     ~TestSettingsUtils();
 
 private slots:
+    void noSettingsUpdate();
+    void clearSettings();
+
     void migrateCantoneseOnlyOneToTwo();
     void migrateMandarinOnlyOneToTwo();
     void migratePreferCantoneseOneToTwo();
@@ -36,6 +39,32 @@ TestSettingsUtils::TestSettingsUtils()
 }
 
 TestSettingsUtils::~TestSettingsUtils() {}
+
+void TestSettingsUtils::noSettingsUpdate()
+{
+    std::unique_ptr<QSettings> settings = Settings::getSettings();
+    settings->clear();
+    settings->setValue("Metadata/version", QVariant{Settings::SETTINGS_VERSION});
+    settings->sync();
+
+    Settings::updateSettings(*settings);
+    QCOMPARE(settings->value("Metadata/version"),
+             QVariant{Settings::SETTINGS_VERSION});
+    settings->clear();
+    settings->sync();
+}
+
+void TestSettingsUtils::clearSettings()
+{
+    std::unique_ptr<QSettings> settings = Settings::getSettings();
+    Settings::clearSettings(*settings);
+
+    QCOMPARE(settings->value("Metadata/version"),
+             QVariant{Settings::SETTINGS_VERSION});
+
+    settings->clear();
+    settings->sync();
+}
 
 void TestSettingsUtils::migrateCantoneseOnlyOneToTwo()
 {


### PR DESCRIPTION
# Description

This commit adds unit tests for migration and clearing functionality in SettingsUtils, i.e. migrating from version 0/1 to 2, and writing the current metadata version to file.

Part of a series of commits for #160.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on macOS.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
