### PR TITLE
#160: Unit-test sentence classes

### DIFF
--- a/src/jyut-dict/CMakeLists.txt
+++ b/src/jyut-dict/CMakeLists.txt
@@ -168,6 +168,7 @@ target_link_libraries(CantoneseDictionary
 add_subdirectory(logic/settings/test/TestSettingsUtils)
 add_subdirectory(logic/utils/test/TestChineseUtils)
 add_subdirectory(logic/utils/test/TestScriptDetector)
+add_subdirectory(logic/sentence/test/TestSourceSentence)
 
 set_target_properties(CantoneseDictionary PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/platform/mac/Info.plist

--- a/src/jyut-dict/CMakeLists.txt
+++ b/src/jyut-dict/CMakeLists.txt
@@ -165,10 +165,11 @@ target_link_libraries(CantoneseDictionary
     PRIVATE KF5::Archive
 )
 
+add_subdirectory(logic/sentence/test/TestSentenceSet)
+add_subdirectory(logic/sentence/test/TestSourceSentence)
 add_subdirectory(logic/settings/test/TestSettingsUtils)
 add_subdirectory(logic/utils/test/TestChineseUtils)
 add_subdirectory(logic/utils/test/TestScriptDetector)
-add_subdirectory(logic/sentence/test/TestSourceSentence)
 
 set_target_properties(CantoneseDictionary PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/platform/mac/Info.plist

--- a/src/jyut-dict/logic/sentence/sentenceset.h
+++ b/src/jyut-dict/logic/sentence/sentenceset.h
@@ -25,6 +25,12 @@ struct TargetSentence
         language{language},
         directTarget(directTarget)
     {}
+
+    bool operator==(const TargetSentence &other) const
+    {
+        return sentence == other.sentence && language == other.language
+               && directTarget == other.directTarget;
+    }
 };
 
 }

--- a/src/jyut-dict/logic/sentence/sourcesentence.h
+++ b/src/jyut-dict/logic/sentence/sourcesentence.h
@@ -45,12 +45,10 @@ public:
     std::string getMandarinPhonetic(MandarinOptions mandarinOptions) const;
 
     std::string getJyutping(void) const;
-    std::string getYale(void) const;
     void setJyutping(const std::string &jyutping);
 
     std::string getPinyin(void) const;
     std::string getPrettyPinyin(void) const;
-    std::string getNumberedPinyin(void) const;
     void setPinyin(const std::string &pinyin);
 
     std::vector<SentenceSet> getSentenceSets(void) const;

--- a/src/jyut-dict/logic/sentence/test/TestSentenceSet/.gitignore
+++ b/src/jyut-dict/logic/sentence/test/TestSentenceSet/.gitignore
@@ -1,0 +1,74 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+CMakeLists.txt.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/src/jyut-dict/logic/sentence/test/TestSentenceSet/CMakeLists.txt
+++ b/src/jyut-dict/logic/sentence/test/TestSentenceSet/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(TestSentenceSet LANGUAGES CXX)
+
+enable_testing()
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(SentenceSet tst_sentenceset.cpp)
+add_test(NAME TestSentenceSet COMMAND TestSentenceSet)
+
+target_link_libraries(SentenceSet PRIVATE Qt${QT_VERSION_MAJOR}::Test)
+target_include_directories(SentenceSet PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
+
+target_sources(SentenceSet
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../sentenceset.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../dictionary/dictionarysource.cpp
+)

--- a/src/jyut-dict/logic/sentence/test/TestSentenceSet/tst_sentenceset.cpp
+++ b/src/jyut-dict/logic/sentence/test/TestSentenceSet/tst_sentenceset.cpp
@@ -1,0 +1,109 @@
+#include <QtTest>
+
+#include "logic/dictionary/dictionarysource.h"
+#include "logic/sentence/sentenceset.h"
+
+class TestSentenceSet : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestSentenceSet();
+    ~TestSentenceSet();
+
+private slots:
+    void isEmpty();
+    void addSentences();
+
+    void getSources();
+    void getSentences();
+};
+
+TestSentenceSet::TestSentenceSet() {}
+
+TestSentenceSet::~TestSentenceSet() {}
+
+void TestSentenceSet::isEmpty()
+{
+    SentenceSet set{"CC-CEDICT"};
+    QCOMPARE(set.isEmpty(), true);
+}
+
+void TestSentenceSet::addSentences()
+{
+    std::vector<Sentence::TargetSentence> targetSentences{
+        {"I don't even know where I flung the key at.", "eng", true},
+    };
+    SentenceSet set{"粵典—words.hk", targetSentences};
+    QCOMPARE(set.isEmpty(), false);
+    QCOMPARE(set.getSentences().size(), 1);
+
+    set.pushSentence({"shake your hands and shake your legs", "eng", true});
+    QCOMPARE(set.getSentences().size(), 2);
+}
+
+void TestSentenceSet::getSources()
+{
+    std::string sourceName = "粵典—words.hk";
+    std::string sourceShortName = "WHK";
+
+    QCOMPARE(DictionarySourceUtils::addSource(sourceName, sourceShortName),
+             true);
+
+    std::vector<Sentence::TargetSentence> targetSentences{
+        {"I don't even know where I flung the key at.", "eng", true},
+    };
+    SentenceSet set{"粵典—words.hk", targetSentences};
+    QCOMPARE(QString::fromStdString(set.getSource()),
+             QString::fromStdString(sourceName));
+    QCOMPARE(QString::fromStdString(set.getSourceLongString()),
+             QString::fromStdString(sourceName));
+    QCOMPARE(QString::fromStdString(set.getSourceShortString()),
+             QString::fromStdString(sourceShortName));
+
+    QCOMPARE(DictionarySourceUtils::removeSource(sourceName), true);
+}
+
+void TestSentenceSet::getSentences()
+{
+    std::vector<Sentence::TargetSentence> targetSentences{
+        {"I don't even know where I flung the key at.", "eng", true},
+        {"shake your hands and shake your legs", "eng", true},
+        {"While playing on the roundabout at the playground when "
+         "I was small, I was thrown out, and I hurt my chin so "
+         "badly I had to get stitched up at the hospital.",
+         "eng",
+         true},
+        {"to shake something off", "eng", true},
+        {"Can you stop shaking your wiener about?", "eng", true},
+    };
+    SentenceSet set{"粵典—words.hk", targetSentences};
+    QCOMPARE(set.isEmpty(), false);
+    QCOMPARE(set.getSentences(), targetSentences);
+    QCOMPARE(set.getSentences().size(), targetSentences.size());
+    QCOMPARE(set.getSentenceSnippet(), targetSentences);
+    QCOMPARE(set.getSentenceSnippet().size(), targetSentences.size());
+
+    std::vector<Sentence::TargetSentence> additionalTargetSentences = {
+        {"Someone upstairs plays loud music every night. The "
+         "volume is so loud that I can't watch the TV.",
+         "eng",
+         true},
+        {"There is a spider on your hand! Shake it off!!", "eng", true},
+    };
+    for (const auto &i : additionalTargetSentences) {
+        set.pushSentence(i);
+    }
+    auto allSentences = targetSentences;
+    allSentences.insert(allSentences.end(),
+                        additionalTargetSentences.begin(),
+                        additionalTargetSentences.end());
+    QCOMPARE(set.getSentences(), allSentences);
+    QCOMPARE(set.getSentences().size(), allSentences.size());
+    QCOMPARE(set.getSentenceSnippet(), targetSentences);
+    QCOMPARE(set.getSentenceSnippet().size(), targetSentences.size());
+}
+
+QTEST_APPLESS_MAIN(TestSentenceSet)
+
+#include "tst_sentenceset.moc"

--- a/src/jyut-dict/logic/sentence/test/TestSourceSentence/.gitignore
+++ b/src/jyut-dict/logic/sentence/test/TestSourceSentence/.gitignore
@@ -1,0 +1,74 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+CMakeLists.txt.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/src/jyut-dict/logic/sentence/test/TestSourceSentence/CMakeLists.txt
+++ b/src/jyut-dict/logic/sentence/test/TestSourceSentence/CMakeLists.txt
@@ -24,6 +24,6 @@ target_sources(SourceSentence
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../sentenceset.cpp
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../sourcesentence.cpp
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../dictionary/dictionarysource.cpp
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils/ChineseUtils.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils/chineseutils.cpp
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils/utils.cpp
 )

--- a/src/jyut-dict/logic/sentence/test/TestSourceSentence/CMakeLists.txt
+++ b/src/jyut-dict/logic/sentence/test/TestSourceSentence/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(SourceSentence LANGUAGES CXX)
+
+enable_testing()
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(SourceSentence tst_sourcesentence.cpp)
+add_test(NAME SourceSentence COMMAND SourceSentence)
+
+target_link_libraries(SourceSentence PRIVATE Qt${QT_VERSION_MAJOR}::Test)
+target_include_directories(SourceSentence PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
+
+target_sources(SourceSentence
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../sentenceset.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../sourcesentence.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../dictionary/dictionarysource.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils/ChineseUtils.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils/utils.cpp
+)

--- a/src/jyut-dict/logic/sentence/test/TestSourceSentence/tst_sourcesentence.cpp
+++ b/src/jyut-dict/logic/sentence/test/TestSourceSentence/tst_sourcesentence.cpp
@@ -1,0 +1,140 @@
+#include <QtTest>
+
+#include "logic/sentence/sourcesentence.h"
+
+class TestSourceSentence : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestSourceSentence();
+    ~TestSourceSentence();
+
+private slots:
+    void constructor();
+    void settersAndGetters();
+    void generatePhonetic();
+    void specialCases();
+};
+
+TestSourceSentence::TestSourceSentence() {}
+
+TestSourceSentence::~TestSourceSentence() {}
+
+void TestSourceSentence::constructor()
+{
+    std::string language = "yue";
+    std::string simplified = "台山话";
+    std::string traditional = "臺山話";
+    std::string jyutping = "toi4 saan1 waa2";
+    std::string pinyin = "tai2 shan1 hua4";
+    SourceSentence sentence{language,
+                            simplified,
+                            traditional,
+                            jyutping,
+                            pinyin,
+                            {}};
+
+    QCOMPARE(sentence.getSourceLanguage(), language);
+    QCOMPARE(sentence.getSimplified(), simplified);
+    QCOMPARE(sentence.getTraditional(), traditional);
+    QCOMPARE(QString::fromStdString(
+                 sentence.getCantonesePhonetic(CantoneseOptions::RAW_JYUTPING)),
+             QString::fromStdString(jyutping));
+    QCOMPARE(QString::fromStdString(
+                 sentence.getMandarinPhonetic(MandarinOptions::RAW_PINYIN)),
+             QString::fromStdString(pinyin));
+}
+
+void TestSourceSentence::settersAndGetters()
+{
+    Sentence::TargetSentence targetSentence{"Taishanese", "eng", true};
+    SentenceSet set = {"Wiktionary", {targetSentence}};
+
+    std::string language = "yue";
+    std::string simplified = "台山话";
+    std::string traditional = "臺山話";
+    std::string jyutping = "toi4 saan1 waa2";
+    std::string pinyin = "tai2 shan1 hua4";
+
+    SourceSentence sentence{"", "", "", "", "", {set}};
+    sentence.setSourceLanguage(language);
+    sentence.setSimplified(simplified);
+    sentence.setTraditional(traditional);
+    sentence.setJyutping(jyutping);
+    sentence.setPinyin(pinyin);
+
+    QCOMPARE(sentence.getSourceLanguage(), language);
+    QCOMPARE(sentence.getSimplified(), simplified);
+    QCOMPARE(sentence.getTraditional(), traditional);
+    QCOMPARE(QString::fromStdString(sentence.getJyutping()),
+             QString::fromStdString(jyutping));
+    QCOMPARE(QString::fromStdString(sentence.getPinyin()),
+             QString::fromStdString(pinyin));
+    QCOMPARE(QString::fromStdString(sentence.getSentenceSnippet()),
+             "Taishanese");
+    QCOMPARE(QString::fromStdString(sentence.getSentenceSnippetLanguage()),
+             "eng");
+}
+
+void TestSourceSentence::generatePhonetic()
+{
+    std::string language = "yue";
+    std::string simplified = "台山话";
+    std::string traditional = "臺山話";
+    std::string jyutping = "toi4 saan1 waa2";
+    std::string pinyin = "tai2 shan1 hua4";
+    SourceSentence sentence{language,
+                            simplified,
+                            traditional,
+                            jyutping,
+                            pinyin,
+                            {}};
+
+    sentence.generatePhonetic(CantoneseOptions::RAW_JYUTPING
+                                  | CantoneseOptions::PRETTY_YALE
+                                  | CantoneseOptions::CANTONESE_IPA,
+                              MandarinOptions::PRETTY_PINYIN
+                                  | MandarinOptions::ZHUYIN
+                                  | MandarinOptions::MANDARIN_IPA);
+    QCOMPARE(QString::fromStdString(
+                 sentence.getCantonesePhonetic(CantoneseOptions::RAW_JYUTPING)),
+             QString::fromStdString(jyutping));
+    QCOMPARE(QString::fromStdString(sentence.getJyutping()),
+             QString::fromStdString(jyutping));
+    QCOMPARE(QString::fromStdString(
+                 sentence.getCantonesePhonetic(CantoneseOptions::PRETTY_YALE)),
+             "tòih sāan wá");
+    QCOMPARE(QString::fromStdString(sentence.getCantonesePhonetic(
+                 CantoneseOptions::CANTONESE_IPA)),
+             QString{"tʰɔːi̯ ˨ ˩  säːn ˥  wäː ˧ ˥"});
+    QCOMPARE(QString::fromStdString(
+                 sentence.getMandarinPhonetic(MandarinOptions::RAW_PINYIN)),
+             QString::fromStdString(pinyin));
+    QCOMPARE(QString::fromStdString(sentence.getPinyin()),
+             QString::fromStdString(pinyin));
+    QCOMPARE(QString::fromStdString(
+                 sentence.getMandarinPhonetic(MandarinOptions::PRETTY_PINYIN)),
+             "tái shān huà");
+    QCOMPARE(QString::fromStdString(sentence.getPrettyPinyin()), "tái shān huà");
+    QCOMPARE(QString::fromStdString(
+                 sentence.getMandarinPhonetic(MandarinOptions::ZHUYIN)),
+             "ㄊㄞˊ ㄕㄢ ㄏㄨㄚˋ");
+    QCOMPARE(QString::fromStdString(
+                 sentence.getMandarinPhonetic(MandarinOptions::MANDARIN_IPA)),
+             "tʰaɪ̯ ˧ ˥  ʂän ˥ ˥  xwä ˥ ˩");
+}
+
+void TestSourceSentence::specialCases()
+{
+    SourceSentence sentence;
+    sentence.setIsEmpty(true);
+    QCOMPARE(sentence.isEmpty(), true);
+
+    sentence.setIsWelcome(true);
+    QCOMPARE(sentence.isWelcome(), true);
+}
+
+QTEST_APPLESS_MAIN(TestSourceSentence)
+
+#include "tst_sourcesentence.moc"

--- a/src/jyut-dict/logic/sentence/test/TestSourceSentence/tst_sourcesentence.cpp
+++ b/src/jyut-dict/logic/sentence/test/TestSourceSentence/tst_sourcesentence.cpp
@@ -105,9 +105,15 @@ void TestSourceSentence::generatePhonetic()
     QCOMPARE(QString::fromStdString(
                  sentence.getCantonesePhonetic(CantoneseOptions::PRETTY_YALE)),
              "tòih sāan wá");
+#ifdef Q_OS_MAC
     QCOMPARE(QString::fromStdString(sentence.getCantonesePhonetic(
                  CantoneseOptions::CANTONESE_IPA)),
              QString{"tʰɔːi̯ ˨ ˩  säːn ˥  wäː ˧ ˥"});
+#elif defined(Q_OS_LINUX)
+    QCOMPARE(QString::fromStdString(sentence.getCantonesePhonetic(
+                 CantoneseOptions::CANTONESE_IPA)),
+             QString{"tʰɔːi̯˨˩  säːn˥  wäː˧˥"});
+#endif
     QCOMPARE(QString::fromStdString(
                  sentence.getMandarinPhonetic(MandarinOptions::RAW_PINYIN)),
              QString::fromStdString(pinyin));
@@ -120,9 +126,15 @@ void TestSourceSentence::generatePhonetic()
     QCOMPARE(QString::fromStdString(
                  sentence.getMandarinPhonetic(MandarinOptions::ZHUYIN)),
              "ㄊㄞˊ ㄕㄢ ㄏㄨㄚˋ");
+#ifdef Q_OS_MAC
     QCOMPARE(QString::fromStdString(
                  sentence.getMandarinPhonetic(MandarinOptions::MANDARIN_IPA)),
              "tʰaɪ̯ ˧ ˥  ʂän ˥ ˥  xwä ˥ ˩");
+#elif defined(Q_OS_LINUX)
+    QCOMPARE(QString::fromStdString(
+                 sentence.getMandarinPhonetic(MandarinOptions::MANDARIN_IPA)),
+             "tʰaɪ̯˧˥  ʂän˥˥  xwä˥˩");
+#endif
 }
 
 void TestSourceSentence::specialCases()


### PR DESCRIPTION
# Description

This commit adds unit tests for the various sentence classes (SourceSentence and SentenceSet).

Part of a series of commits for #160.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran tests on all three platforms.

```
PASS	Executing test case TestSentenceSet
	Qt version: 5.15.12
	Qt build: Qt 5.15.12 (arm64-little_endian-lp64 shared (dynamic) release build; by Clang 15.0.0 (clang-1500.0.40.1) (Apple))
	QTest version: 5.15.12
PASS	Executing test function initTestCase
PASS	TestSentenceSet::initTestCase
	Execution took 0.0415 ms.
PASS	Executing test function isEmpty
PASS	TestSentenceSet::isEmpty
	Execution took 0.010291 ms.
PASS	Executing test function addSentences
PASS	TestSentenceSet::addSentences
	Execution took 0.007875 ms.
PASS	Executing test function getSources
PASS	TestSentenceSet::getSources
	Execution took 0.009041 ms.
PASS	Executing test function getSentences
PASS	TestSentenceSet::getSentences
	Execution took 0.022625 ms.
PASS	Executing test function cleanupTestCase
PASS	TestSentenceSet::cleanupTestCase
	Execution took 0.001125 ms.
	Test execution took 0.137041 ms.
PASS	Executing test case TestSourceSentence
	Qt version: 5.15.12
	Qt build: Qt 5.15.12 (arm64-little_endian-lp64 shared (dynamic) release build; by Clang 15.0.0 (clang-1500.0.40.1) (Apple))
	QTest version: 5.15.12
PASS	Executing test function initTestCase
PASS	TestSourceSentence::initTestCase
	Execution took 0.042458 ms.
PASS	Executing test function constructor
PASS	TestSourceSentence::constructor
	Execution took 0.008791 ms.
PASS	Executing test function settersAndGetters
PASS	TestSourceSentence::settersAndGetters
	Execution took 0.012625 ms.
PASS	Executing test function generatePhonetic
PASS	TestSourceSentence::generatePhonetic
	Execution took 1.22796 ms.
PASS	Executing test function specialCases
PASS	TestSourceSentence::specialCases
	Execution took 0.010291 ms.
PASS	Executing test function cleanupTestCase
PASS	TestSourceSentence::cleanupTestCase
	Execution took 0.001416 ms.
	Test execution took 1.36667 ms.
```

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
