### PR TITLE
#160: Unit-test Entry class

### DIFF
--- a/src/jyut-dict/CMakeLists.txt
+++ b/src/jyut-dict/CMakeLists.txt
@@ -165,6 +165,7 @@ target_link_libraries(CantoneseDictionary
     PRIVATE KF5::Archive
 )
 
+add_subdirectory(logic/entry/test/TestEntry)
 add_subdirectory(logic/sentence/test/TestSentenceSet)
 add_subdirectory(logic/sentence/test/TestSourceSentence)
 add_subdirectory(logic/settings/test/TestSettingsUtils)

--- a/src/jyut-dict/components/entrysearchresult/resultlistdelegate.cpp
+++ b/src/jyut-dict/components/entrysearchresult/resultlistdelegate.cpp
@@ -3,6 +3,7 @@
 #include "logic/entry/entry.h"
 #include "logic/entry/entrycharactersoptions.h"
 #include "logic/entry/entryphoneticoptions.h"
+#include "logic/settings/settings.h"
 #include "logic/settings/settingsutils.h"
 #include "logic/utils/utils_qt.h"
 

--- a/src/jyut-dict/components/mainwindow/maintoolbar.cpp
+++ b/src/jyut-dict/components/mainwindow/maintoolbar.cpp
@@ -1,6 +1,7 @@
 #include "maintoolbar.h"
 
 #include "logic/search/searchoptionsmediator.h"
+#include "logic/settings/settings.h"
 #include "logic/settings/settingsutils.h"
 #ifdef Q_OS_MAC
 #include "logic/utils/utils_mac.h"

--- a/src/jyut-dict/components/mainwindow/searchlineedit.cpp
+++ b/src/jyut-dict/components/mainwindow/searchlineedit.cpp
@@ -1,5 +1,6 @@
 #include "searchlineedit.h"
 
+#include "logic/settings/settings.h"
 #include "logic/settings/settingsutils.h"
 #ifdef Q_OS_MAC
 #include "logic/utils/utils_mac.h"

--- a/src/jyut-dict/logic/entry/definitionsset.h
+++ b/src/jyut-dict/logic/entry/definitionsset.h
@@ -25,6 +25,12 @@ struct Definition
         label{label},
         sentences(sentences)
     {}
+
+    bool operator==(const Definition &other) const
+    {
+        return definitionContent == other.definitionContent
+               && label == other.label && sentences == other.sentences;
+    }
 };
 
 }
@@ -40,6 +46,10 @@ public:
 
     friend std::ostream &operator<<(std::ostream &out,
                                     DefinitionsSet const &definitions);
+    bool operator==(const DefinitionsSet &other) const
+    {
+        return _source == other._source && _definitions == other._definitions;
+    }
 
     bool isEmpty() const;
 

--- a/src/jyut-dict/logic/entry/entry.cpp
+++ b/src/jyut-dict/logic/entry/entry.cpp
@@ -179,29 +179,30 @@ std::ostream &operator<<(std::ostream &out, const Entry &entry)
     return out;
 }
 
-std::string Entry::getCharacters(EntryCharactersOptions options, bool use_colours) const
+std::string Entry::getCharacters(EntryCharactersOptions options,
+                                 bool useColours) const
 {
     switch (options) {
         case (EntryCharactersOptions::ONLY_SIMPLIFIED): {
-            if (use_colours) {
+            if (useColours) {
                 return _colouredSimplified;
             }
             return _simplified;
         }
         case (EntryCharactersOptions::ONLY_TRADITIONAL): {
-            if (use_colours) {
+            if (useColours) {
                 return _colouredTraditional;
             }
             return _traditional;
         }
         case (EntryCharactersOptions::PREFER_SIMPLIFIED): {
-            if (use_colours) {
+            if (useColours) {
                 return _colouredSimplified + " [" + _colouredTraditionalDifference + "]";
             }
             return _simplified + " [" + _traditionalDifference + "]";
         }
         case (EntryCharactersOptions::PREFER_TRADITIONAL): {
-            if (use_colours) {
+            if (useColours) {
                 return _colouredTraditional + " [" + _colouredSimplifiedDifference + "]";
             }
             return _traditional + " [" + _simplifiedDifference + "]";
@@ -211,18 +212,19 @@ std::string Entry::getCharacters(EntryCharactersOptions options, bool use_colour
     return _simplified;
 }
 
-std::string Entry::getCharactersNoSecondary(EntryCharactersOptions options, bool use_colours) const
+std::string Entry::getCharactersNoSecondary(EntryCharactersOptions options,
+                                            bool useColours) const
 {
     switch (options) {
         case (EntryCharactersOptions::PREFER_SIMPLIFIED):
         case (EntryCharactersOptions::ONLY_SIMPLIFIED):
-            if (use_colours) {
+            if (useColours) {
                 return _colouredSimplified;
             }
             return _simplified;
         case (EntryCharactersOptions::PREFER_TRADITIONAL):
         case (EntryCharactersOptions::ONLY_TRADITIONAL):
-            if (use_colours) {
+            if (useColours) {
                 return _colouredTraditional;
             }
             return _traditional;
@@ -408,11 +410,6 @@ std::string Entry::getJyutping(void) const
     return _jyutping;
 }
 
-std::string Entry::getYale(void) const
-{
-    return _yale;
-}
-
 void Entry::setJyutping(const std::string &jyutping)
 {
     _jyutping = jyutping;
@@ -442,16 +439,6 @@ std::vector<int> Entry::getJyutpingNumbers() const
 std::string Entry::getPinyin(void) const
 {
     return _pinyin;
-}
-
-std::string Entry::getPrettyPinyin(void) const
-{
-    return _prettyPinyin;
-}
-
-std::string Entry::getNumberedPinyin(void) const
-{
-    return _numberedPinyin;
 }
 
 void Entry::setPinyin(const std::string &pinyin)

--- a/src/jyut-dict/logic/entry/entry.h
+++ b/src/jyut-dict/logic/entry/entry.h
@@ -4,8 +4,6 @@
 #include "logic/entry/definitionsset.h"
 #include "logic/entry/entrycharactersoptions.h"
 #include "logic/entry/entryphoneticoptions.h"
-#include "logic/sentence/sourcesentence.h"
-#include "logic/settings/settings.h"
 
 #include <QObject>
 #include <QVariant>
@@ -40,9 +38,9 @@ public:
     friend std::ostream &operator<<(std::ostream &out, const Entry &entry);
 
     std::string getCharacters(EntryCharactersOptions options,
-                              bool use_colours) const;
+                              bool useColours) const;
     std::string getCharactersNoSecondary(EntryCharactersOptions options,
-                                         bool use_colours) const;
+                                         bool useColours) const;
 
     std::string getSimplified(void) const;
     void setSimplified(std::string simplified);
@@ -68,13 +66,10 @@ public:
     std::string getMandarinPhonetic(MandarinOptions mandarinOptions) const;
 
     std::string getJyutping(void) const;
-    std::string getYale(void) const;
     void setJyutping(const std::string &jyutping);
     std::vector<int> getJyutpingNumbers() const;
 
     std::string getPinyin(void) const;
-    std::string getPrettyPinyin(void) const;
-    std::string getNumberedPinyin(void) const;
     void setPinyin(const std::string &pinyin);
     std::vector<int> getPinyinNumbers() const;
 

--- a/src/jyut-dict/logic/entry/test/TestEntry/.gitignore
+++ b/src/jyut-dict/logic/entry/test/TestEntry/.gitignore
@@ -1,0 +1,74 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+CMakeLists.txt.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/src/jyut-dict/logic/entry/test/TestEntry/CMakeLists.txt
+++ b/src/jyut-dict/logic/entry/test/TestEntry/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(TestEntry LANGUAGES CXX)
+
+enable_testing()
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(TestEntry tst_entry.cpp)
+add_test(NAME TestEntry COMMAND TestEntry)
+
+target_link_libraries(TestEntry PRIVATE Qt${QT_VERSION_MAJOR}::Test)
+target_include_directories(TestEntry PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
+
+target_sources(TestEntry
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../dictionary/dictionarysource.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../entry/definitionsset.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../entry/entry.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils/chineseutils.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils/utils.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../sentence/sentenceset.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../sentence/sourcesentence.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../settings/settings.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../settings/settingsutils.cpp
+)
+

--- a/src/jyut-dict/logic/entry/test/TestEntry/tst_entry.cpp
+++ b/src/jyut-dict/logic/entry/test/TestEntry/tst_entry.cpp
@@ -261,8 +261,7 @@ void TestEntry::getPhonetic()
     QCOMPARE(QString::fromStdString(
                  entry.getPhonetic(EntryPhoneticOptions::PREFER_CANTONESE,
                                    CantoneseOptions::CANTONESE_IPA)),
-             QString::fromStdString("tʰɔːi̯ ˨ ˩  säːn ˥  wäː ˧ ˥ (" + pinyin
-                                    + ")"));
+             QString::fromStdString("tʰɔːi̯˨˩  säːn˥  wäː˧˥ (" + pinyin + ")"));
 #endif
 
     QCOMPARE(QString::fromStdString(

--- a/src/jyut-dict/logic/entry/test/TestEntry/tst_entry.cpp
+++ b/src/jyut-dict/logic/entry/test/TestEntry/tst_entry.cpp
@@ -1,0 +1,297 @@
+#include <QtTest>
+
+#include "logic/entry/entry.h"
+#include "logic/entry/entrycharactersoptions.h"
+#include "logic/utils/chineseutils.h"
+
+class TestEntry : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestEntry();
+    ~TestEntry();
+
+private slots:
+    void getCharacters();
+    void simplifiedAndTraditional();
+
+    void cantonesePhonetic();
+    void cantoneseToneNumbers();
+    void mandarinPhonetic();
+    void mandarinToneNumbers();
+    void getPhonetic();
+
+    void definitions();
+
+    void refreshColours();
+
+    void specialCases();
+};
+
+TestEntry::TestEntry() {}
+
+TestEntry::~TestEntry() {}
+
+void TestEntry::getCharacters()
+{
+    std::string simplified{"清远"};
+    std::string traditional{"清遠"};
+    std::string jyutping{"cing1 jyun5"};
+    std::string pinyin{"qing1 yuan3"};
+    Entry entry{simplified, traditional, jyutping, pinyin, {}};
+
+    QCOMPARE(QString::fromStdString(
+                 entry.getCharacters(EntryCharactersOptions::ONLY_SIMPLIFIED,
+                                     /* useColours = */ false)),
+             QString::fromStdString(simplified));
+    QCOMPARE(QString::fromStdString(
+                 entry.getCharacters(EntryCharactersOptions::ONLY_TRADITIONAL,
+                                     /* useColours = */ false)),
+             QString::fromStdString(traditional));
+    QCOMPARE(QString::fromStdString(
+                 entry.getCharacters(EntryCharactersOptions::PREFER_SIMPLIFIED,
+                                     /* useColours = */ false)),
+             QString::fromStdString(
+                 simplified + " ["
+                 + ChineseUtils::compareStrings(simplified, traditional) + "]"));
+    QCOMPARE(QString::fromStdString(
+                 entry.getCharacters(EntryCharactersOptions::PREFER_TRADITIONAL,
+                                     /* useColours = */ false)),
+             QString::fromStdString(
+                 traditional + " ["
+                 + ChineseUtils::compareStrings(traditional, simplified) + "]"));
+    QCOMPARE(QString::fromStdString(entry.getCharactersNoSecondary(
+                 EntryCharactersOptions::ONLY_SIMPLIFIED,
+                 /* useColours = */ false)),
+             QString::fromStdString(simplified));
+    QCOMPARE(QString::fromStdString(entry.getCharactersNoSecondary(
+                 EntryCharactersOptions::PREFER_SIMPLIFIED,
+                 /* useColours = */ false)),
+             QString::fromStdString(simplified));
+    QCOMPARE(QString::fromStdString(entry.getCharactersNoSecondary(
+                 EntryCharactersOptions::ONLY_TRADITIONAL,
+                 /* useColours = */ false)),
+             QString::fromStdString(traditional));
+    QCOMPARE(QString::fromStdString(entry.getCharactersNoSecondary(
+                 EntryCharactersOptions::ONLY_TRADITIONAL,
+                 /* useColours = */ false)),
+             QString::fromStdString(traditional));
+}
+
+void TestEntry::simplifiedAndTraditional()
+{
+    std::string simplified{"清远"};
+    std::string traditional{"清遠"};
+    Entry entry{simplified, traditional, "", "", {}};
+
+    QCOMPARE(QString::fromStdString(entry.getSimplified()),
+             QString::fromStdString(simplified));
+    QCOMPARE(QString::fromStdString(entry.getTraditional()),
+             QString::fromStdString(traditional));
+
+    std::string newSimplified{"广州"};
+    entry.setSimplified(newSimplified);
+    QCOMPARE(QString::fromStdString(entry.getSimplified()),
+             QString::fromStdString(newSimplified));
+    QCOMPARE(QString::fromStdString(entry.getTraditional()),
+             QString::fromStdString(traditional));
+
+    std::string newTraditional{"廣州"};
+    entry.setTraditional(newTraditional);
+    QCOMPARE(QString::fromStdString(entry.getSimplified()),
+             QString::fromStdString(newSimplified));
+    QCOMPARE(QString::fromStdString(entry.getTraditional()),
+             QString::fromStdString(newTraditional));
+}
+
+void TestEntry::cantonesePhonetic()
+{
+    std::string simplified = "台山话";
+    std::string traditional = "臺山話";
+    std::string jyutping = "toi4 saan1 waa2";
+    std::string pinyin = "tai2 shan1 hua4";
+    Entry entry{simplified, traditional, jyutping, pinyin, {}};
+    entry.generatePhonetic(CantoneseOptions::RAW_JYUTPING
+                               | CantoneseOptions::PRETTY_YALE
+                               | CantoneseOptions::CANTONESE_IPA,
+                           MandarinOptions::NONE);
+
+    QCOMPARE(QString::fromStdString(
+                 entry.getCantonesePhonetic(CantoneseOptions::RAW_JYUTPING)),
+             QString::fromStdString(jyutping));
+    QCOMPARE(QString::fromStdString(entry.getJyutping()),
+             QString::fromStdString(jyutping));
+    QCOMPARE(QString::fromStdString(
+                 entry.getCantonesePhonetic(CantoneseOptions::PRETTY_YALE)),
+             "tòih sāan wá");
+#ifdef Q_OS_MAC
+    QCOMPARE(QString::fromStdString(
+                 entry.getCantonesePhonetic(CantoneseOptions::CANTONESE_IPA)),
+             QString{"tʰɔːi̯ ˨ ˩  säːn ˥  wäː ˧ ˥"});
+#elif defined(Q_OS_LINUX)
+    QCOMPARE(QString::fromStdString(
+                 entry.getCantonesePhonetic(CantoneseOptions::CANTONESE_IPA)),
+             QString{"tʰɔːi̯˨˩  säːn˥  wäː˧˥"});
+#endif
+}
+
+void TestEntry::cantoneseToneNumbers()
+{
+    std::string jyutping = "toi4 saan1 waa2";
+    Entry entry{"", "", jyutping, "", {}};
+
+    auto result = entry.getJyutpingNumbers();
+    std::vector<int> expected{4, 1, 2};
+    QCOMPARE(result, expected);
+
+    entry.setJyutping("mei5 gwok3");
+    result = entry.getJyutpingNumbers();
+    expected = {5, 3};
+    QCOMPARE(result, expected);
+
+    entry.setJyutping("gaa1naa4 daai6");
+    result = entry.getJyutpingNumbers();
+    expected = {1, 4, 6};
+    QCOMPARE(result, expected);
+}
+
+void TestEntry::mandarinPhonetic()
+{
+    std::string simplified = "台山话";
+    std::string traditional = "臺山話";
+    std::string jyutping = "toi4 saan1 waa2";
+    std::string pinyin = "tai2 shan1 hua4";
+    Entry entry{simplified, traditional, jyutping, pinyin, {}};
+    entry.generatePhonetic(CantoneseOptions::NONE,
+                           MandarinOptions::PRETTY_PINYIN
+                               | MandarinOptions::ZHUYIN
+                               | MandarinOptions::MANDARIN_IPA);
+
+    QCOMPARE(QString::fromStdString(
+                 entry.getMandarinPhonetic(MandarinOptions::RAW_PINYIN)),
+             QString::fromStdString(pinyin));
+    QCOMPARE(QString::fromStdString(entry.getPinyin()),
+             QString::fromStdString(pinyin));
+    QCOMPARE(QString::fromStdString(
+                 entry.getMandarinPhonetic(MandarinOptions::PRETTY_PINYIN)),
+             "tái shān huà");
+    QCOMPARE(QString::fromStdString(
+                 entry.getMandarinPhonetic(MandarinOptions::ZHUYIN)),
+             "ㄊㄞˊ ㄕㄢ ㄏㄨㄚˋ");
+#ifdef Q_OS_MAC
+    QCOMPARE(QString::fromStdString(
+                 entry.getMandarinPhonetic(MandarinOptions::MANDARIN_IPA)),
+             "tʰaɪ̯ ˧ ˥  ʂän ˥ ˥  xwä ˥ ˩");
+#elif defined(Q_OS_LINUX)
+    QCOMPARE(QString::fromStdString(
+                 entry.getMandarinPhonetic(MandarinOptions::MANDARIN_IPA)),
+             "tʰaɪ̯˧˥  ʂän˥˥  xwä˥˩");
+#endif
+}
+
+void TestEntry::mandarinToneNumbers()
+{
+    std::string pinyin = "tai2 shan1 hua4";
+    Entry entry{"", "", "", pinyin, {}};
+
+    auto result = entry.getPinyinNumbers();
+    std::vector<int> expected{2, 1, 4};
+    QCOMPARE(result, expected);
+
+    entry.setPinyin("mei3 guo2");
+    result = entry.getPinyinNumbers();
+    expected = {3, 2};
+    QCOMPARE(result, expected);
+
+    entry.setPinyin("jia1 na2 da4");
+    result = entry.getPinyinNumbers();
+    expected = {1, 2, 4};
+    QCOMPARE(result, expected);
+}
+
+void TestEntry::getPhonetic()
+{
+    std::string simplified = "台山话";
+    std::string traditional = "臺山話";
+    std::string jyutping = "toi4 saan1 waa2";
+    std::string pinyin = "tai2 shan1 hua4";
+    Entry entry{simplified, traditional, jyutping, pinyin, {}};
+    entry.generatePhonetic(CantoneseOptions::RAW_JYUTPING
+                               | CantoneseOptions::PRETTY_YALE
+                               | CantoneseOptions::CANTONESE_IPA,
+                           MandarinOptions::NUMBERED_PINYIN
+                               | MandarinOptions::PRETTY_PINYIN
+                               | MandarinOptions::ZHUYIN
+                               | MandarinOptions::MANDARIN_IPA);
+
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::ONLY_CANTONESE)),
+             QString::fromStdString(jyutping));
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::ONLY_MANDARIN)),
+             QString::fromStdString(pinyin));
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::PREFER_CANTONESE)),
+             QString::fromStdString(jyutping + " (" + pinyin + ")"));
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::PREFER_MANDARIN)),
+             QString::fromStdString(pinyin + " (" + jyutping + ")"));
+
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::ONLY_MANDARIN,
+                                   MandarinOptions::PRETTY_PINYIN)),
+             "tái shān huà");
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::PREFER_MANDARIN,
+                                   MandarinOptions::ZHUYIN)),
+             QString::fromStdString("ㄊㄞˊ ㄕㄢ ㄏㄨㄚˋ (" + jyutping + ")"));
+
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::ONLY_CANTONESE,
+                                   CantoneseOptions::PRETTY_YALE)),
+             "tòih sāan wá");
+#ifdef Q_OS_MAC
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::PREFER_CANTONESE,
+                                   CantoneseOptions::CANTONESE_IPA)),
+             QString::fromStdString("tʰɔːi̯ ˨ ˩  säːn ˥  wäː ˧ ˥ (" + pinyin
+                                    + ")"));
+#elif defined(Q_OS_LINUX)
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::PREFER_CANTONESE,
+                                   CantoneseOptions::CANTONESE_IPA)),
+             QString::fromStdString("tʰɔːi̯ ˨ ˩  säːn ˥  wäː ˧ ˥ (" + pinyin
+                                    + ")"));
+#endif
+
+    QCOMPARE(QString::fromStdString(
+                 entry.getPhonetic(EntryPhoneticOptions::PREFER_CANTONESE,
+                                   CantoneseOptions::PRETTY_YALE,
+                                   MandarinOptions::PRETTY_PINYIN)),
+             "tòih sāan wá (tái shān huà)");
+}
+
+void TestEntry::definitions()
+{
+    QSKIP("Not implemented yet");
+}
+
+void TestEntry::refreshColours()
+{
+    QSKIP("Not implemented yet");
+}
+
+void TestEntry::specialCases()
+{
+    Entry entry;
+    entry.setIsWelcome(true);
+    QCOMPARE(entry.isWelcome(), true);
+
+    entry.setIsEmpty(true);
+    QCOMPARE(entry.isEmpty(), true);
+}
+
+QTEST_APPLESS_MAIN(TestEntry)
+
+#include "tst_entry.moc"

--- a/src/jyut-dict/logic/entry/test/TestEntry/tst_entry.cpp
+++ b/src/jyut-dict/logic/entry/test/TestEntry/tst_entry.cpp
@@ -274,12 +274,69 @@ void TestEntry::getPhonetic()
 
 void TestEntry::definitions()
 {
-    QSKIP("Not implemented yet");
+    std::vector<Definition::Definition> definitions{
+        {"Chinatown", "", {}},
+        {"CL:條|条[tiao2],座[zuo4]", "", {}},
+    };
+
+    DefinitionsSet definitionsSet{"CC-CEDICT", definitions};
+
+    std::string simplified = "唐人街";
+    std::string traditional = "唐人街";
+    std::string jyutping = "tong4 jan4 gaai1";
+    std::string pinyin = "tang2 ren2 jie1";
+    Entry entry{simplified, traditional, jyutping, pinyin, {definitionsSet}};
+
+    QCOMPARE(entry.getDefinitionsSets(), {definitionsSet});
+    QCOMPARE(entry.getDefinitionSnippet(),
+             "Chinatown; CL:條|条[tiao2],座[zuo4]");
+
+    Definition::Definition additionalDefinition{
+        "響外國​城市​嘅​華​人​聚居地​（​量​詞​"
+        "："
+        "條）\nChinatown; an area in an overseas city heavily populated by "
+        "ethnic Chinese; literally \"Chinese street\"",
+        "名詞",
+        {}};
+    DefinitionsSet additionalDefinitionsSet{"粵典-words.hk",
+                                            {additionalDefinition}};
+    entry.addDefinitions("粵典-words.hk", {additionalDefinition});
+
+    std::vector<DefinitionsSet> sets{definitionsSet, additionalDefinitionsSet};
+    QCOMPARE(entry.getDefinitionsSets(), sets);
 }
 
 void TestEntry::refreshColours()
 {
-    QSKIP("Not implemented yet");
+    std::string simplified = "岭南文化";
+    std::string traditional = "嶺南文化";
+    std::string jyutping = "ling5 naam4 man4 faa3";
+    std::string pinyin = "ling3 nan2 wen2 hua4";
+    Entry entry{simplified, traditional, jyutping, pinyin, {}};
+
+    entry.refreshColours(EntryColourPhoneticType::CANTONESE);
+    QCOMPARE(
+        QString::fromStdString(
+            entry.getCharacters(EntryCharactersOptions::ONLY_SIMPLIFIED,
+                                /* useColours = */ true)),
+        "<font color=\"#068900\">\u5CAD</font><font "
+        "color=\"#c2185b\">\u5357</font><font "
+        "color=\"#c2185b\">\u6587</font><font color=\"#657ff1\">\u5316</font>");
+
+    entry.refreshColours(EntryColourPhoneticType::MANDARIN);
+    QCOMPARE(
+        QString::fromStdString(
+            entry.getCharacters(EntryCharactersOptions::ONLY_TRADITIONAL,
+                                /* useColours = */ true)),
+        "<font color=\"#18a6f2\">\u5DBA</font><font "
+        "color=\"#02ba1f\">\u5357</font><font "
+        "color=\"#02ba1f\">\u6587</font><font color=\"#9e77ff\">\u5316</font>");
+
+    entry.refreshColours(EntryColourPhoneticType::NONE);
+    QCOMPARE(QString::fromStdString(
+                 entry.getCharacters(EntryCharactersOptions::ONLY_TRADITIONAL,
+                                     /* useColours = */ true)),
+             "嶺南文化");
 }
 
 void TestEntry::specialCases()

--- a/src/jyut-dict/logic/sentence/sentenceset.h
+++ b/src/jyut-dict/logic/sentence/sentenceset.h
@@ -43,6 +43,10 @@ public:
                 const std::vector<Sentence::TargetSentence> &sentences);
     friend std::ostream &operator<<(std::ostream &out,
                                     const SentenceSet &sentence);
+    bool operator==(const SentenceSet &other) const
+    {
+        return _source == other._source && _sentences == other._sentences;
+    }
 
     bool isEmpty(void) const;
 

--- a/src/jyut-dict/logic/sentence/sourcesentence.h
+++ b/src/jyut-dict/logic/sentence/sourcesentence.h
@@ -23,6 +23,14 @@ public:
 
     friend std::ostream &operator<<(std::ostream &out,
                                     const SourceSentence &sourceSentence);
+    bool operator==(const SourceSentence &other) const
+    {
+        return _sourceLanguage == other._sourceLanguage
+               && _simplified == other._simplified
+               && _traditional == other._traditional
+               && _jyutping == other._jyutping && _pinyin == other._pinyin
+               && _sentences == other._sentences;
+    }
 
     std::string getSourceLanguage(void) const;
     void setSourceLanguage(std::string sourceLanguage);

--- a/src/jyut-dict/logic/sentence/test/TestSentenceSet/CMakeLists.txt
+++ b/src/jyut-dict/logic/sentence/test/TestSentenceSet/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(SentenceSet tst_sentenceset.cpp)

--- a/src/jyut-dict/logic/sentence/test/TestSourceSentence/tst_sourcesentence.cpp
+++ b/src/jyut-dict/logic/sentence/test/TestSourceSentence/tst_sourcesentence.cpp
@@ -94,7 +94,8 @@ void TestSourceSentence::generatePhonetic()
     sentence.generatePhonetic(CantoneseOptions::RAW_JYUTPING
                                   | CantoneseOptions::PRETTY_YALE
                                   | CantoneseOptions::CANTONESE_IPA,
-                              MandarinOptions::PRETTY_PINYIN
+                              MandarinOptions::NUMBERED_PINYIN
+                                  | MandarinOptions::PRETTY_PINYIN
                                   | MandarinOptions::ZHUYIN
                                   | MandarinOptions::MANDARIN_IPA);
     QCOMPARE(QString::fromStdString(
@@ -119,6 +120,9 @@ void TestSourceSentence::generatePhonetic()
              QString::fromStdString(pinyin));
     QCOMPARE(QString::fromStdString(sentence.getPinyin()),
              QString::fromStdString(pinyin));
+    QCOMPARE(QString::fromStdString(sentence.getMandarinPhonetic(
+                 MandarinOptions::NUMBERED_PINYIN)),
+             QString::fromStdString("tai2 shan1 hua4"));
     QCOMPARE(QString::fromStdString(
                  sentence.getMandarinPhonetic(MandarinOptions::PRETTY_PINYIN)),
              "tái shān huà");

--- a/src/jyut-dict/main.cpp
+++ b/src/jyut-dict/main.cpp
@@ -1,5 +1,7 @@
 #include "windows/mainwindow.h"
 
+#include "logic/settings/settings.h"
+
 #include <QApplication>
 #include <QSysInfo>
 


### PR DESCRIPTION
# Description

This commit adds unit tests for the Entry class, which represents an entry in the dictionary. In order to do that, it also adds `==` operator overloads to several of the classes it depends on (SourceSentence, DefinitionsSet, etc).

Part of a series of commits for #160.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on macOS, Windows, and Linux.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
