### PR TITLE
#160: Write unit tests for DefinitionsSet

### DIFF
--- a/src/jyut-dict/CMakeLists.txt
+++ b/src/jyut-dict/CMakeLists.txt
@@ -165,6 +165,7 @@ target_link_libraries(CantoneseDictionary
     PRIVATE KF5::Archive
 )
 
+add_subdirectory(logic/entry/test/TestDefinitionsSet)
 add_subdirectory(logic/entry/test/TestEntry)
 add_subdirectory(logic/sentence/test/TestSentenceSet)
 add_subdirectory(logic/sentence/test/TestSourceSentence)

--- a/src/jyut-dict/logic/entry/test/TestDefinitionsSet/.gitignore
+++ b/src/jyut-dict/logic/entry/test/TestDefinitionsSet/.gitignore
@@ -1,0 +1,74 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+CMakeLists.txt.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/src/jyut-dict/logic/entry/test/TestDefinitionsSet/CMakeLists.txt
+++ b/src/jyut-dict/logic/entry/test/TestDefinitionsSet/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(TestDefinitionsSet LANGUAGES CXX)
+
+enable_testing()
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(TestDefinitionsSet tst_definitionsset.cpp)
+add_test(NAME TestDefinitionsSet COMMAND TestDefinitionsSet)
+
+target_link_libraries(TestDefinitionsSet PRIVATE Qt${QT_VERSION_MAJOR}::Test)
+target_include_directories(TestDefinitionsSet PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
+
+target_sources(TestDefinitionsSet
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../definitionsset.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../dictionary/dictionarysource.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../sentence/sentenceset.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../sentence/sourcesentence.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils/chineseutils.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils/utils.cpp
+)
+

--- a/src/jyut-dict/logic/entry/test/TestDefinitionsSet/tst_definitionsset.cpp
+++ b/src/jyut-dict/logic/entry/test/TestDefinitionsSet/tst_definitionsset.cpp
@@ -1,0 +1,97 @@
+#include <QtTest>
+
+#include "logic/entry/definitionsset.h"
+
+class TestDefinitionsSet : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestDefinitionsSet();
+    ~TestDefinitionsSet();
+
+private slots:
+    void isEmpty();
+    void addDefinitions();
+
+    void getSources();
+    void getDefinitions();
+};
+
+TestDefinitionsSet::TestDefinitionsSet() {}
+
+TestDefinitionsSet::~TestDefinitionsSet() {}
+
+void TestDefinitionsSet::isEmpty()
+{
+    DefinitionsSet set{"CC-CEDICT"};
+    QCOMPARE(set.isEmpty(), true);
+}
+
+void TestDefinitionsSet::addDefinitions()
+{
+    std::vector<Definition::Definition> definitions{
+        {"香港地區名；係香港嘅政治商業中心，大部份政府機構、銀行總行、跨國金融"
+         "機構、外國領事館嘅所在地",
+         "名詞",
+         {}},
+    };
+    DefinitionsSet set{"粵典—words.hk", definitions};
+    QCOMPARE(set.isEmpty(), false);
+    QCOMPARE(set.getDefinitions().size(), 1);
+
+    set.pushDefinition({"Central (a place in Hong Kong)", "name", {}});
+    QCOMPARE(set.getDefinitions().size(), 2);
+}
+
+void TestDefinitionsSet::getSources()
+{
+    std::string sourceName = "粵典—words.hk";
+    std::string sourceShortName = "WHK";
+
+    QCOMPARE(DictionarySourceUtils::addSource(sourceName, sourceShortName),
+             true);
+
+    std::vector<Definition::Definition> definitions{
+        {"香港地區名；係香港嘅政治商業中心，大部份政府機構、銀行總行、跨國金融"
+         "機構、外國領事館嘅所在地",
+         "名詞",
+         {}},
+    };
+    DefinitionsSet set{"粵典—words.hk", definitions};
+    QCOMPARE(QString::fromStdString(set.getSource()),
+             QString::fromStdString(sourceName));
+    QCOMPARE(QString::fromStdString(set.getSourceLongString()),
+             QString::fromStdString(sourceName));
+    QCOMPARE(QString::fromStdString(set.getSourceShortString()),
+             QString::fromStdString(sourceShortName));
+
+    QCOMPARE(DictionarySourceUtils::removeSource(sourceName), true);
+}
+
+void TestDefinitionsSet::getDefinitions()
+{
+    std::vector<Definition::Definition> definitions{
+        {"Government of the Hong Kong Special Administrative Region",
+         "name",
+         {}},
+        {"香港地區名；係香港嘅政治商業中心，大部份政府機構、銀行總行、跨國金融"
+         "機構、外國領事館嘅所在地\nCentral, a central business district of "
+         "Hong Kong",
+         "名詞",
+         {}},
+    };
+    DefinitionsSet set{"粵典—words.hk", definitions};
+    QCOMPARE(set.isEmpty(), false);
+    QCOMPARE(set.getDefinitions(), definitions);
+    QCOMPARE(set.getDefinitions().size(), definitions.size());
+    QCOMPARE(
+        set.getDefinitionsSnippet(),
+        "Government of the Hong Kong Special Administrative Region; "
+        "香港地區名；係香港嘅政治商業中心，大部份政府機構、銀行總行、跨國金融"
+        "機構、外國領事館嘅所在地");
+}
+
+QTEST_APPLESS_MAIN(TestDefinitionsSet)
+
+#include "tst_definitionsset.moc"


### PR DESCRIPTION
# Description

This commit adds unit tests for the DefinitionsSet class.

Part of a series of commits for #160.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on macOS, Windows, and Linux.

```
PASS	Executing test case TestDefinitionsSet
	Qt version: 5.15.12
	Qt build: Qt 5.15.12 (x86_64-little_endian-llp64 shared (dynamic) release build; by GCC 11.2.0)
	QTest version: 5.15.12
PASS	Executing test function initTestCase
PASS	TestDefinitionsSet::initTestCase
	Execution took 0.1693 ms.
PASS	Executing test function isEmpty
PASS	TestDefinitionsSet::isEmpty
	Execution took 0.0156 ms.
PASS	Executing test function addDefinitions
PASS	TestDefinitionsSet::addDefinitions
	Execution took 0.0217 ms.
PASS	Executing test function getSources
PASS	TestDefinitionsSet::getSources
	Execution took 0.0795 ms.
PASS	Executing test function getDefinitions
PASS	TestDefinitionsSet::getDefinitions
	Execution took 0.0499 ms.
PASS	Executing test function cleanupTestCase
PASS	TestDefinitionsSet::cleanupTestCase
	Execution took 0.004 ms.
	Test execution took 0.5707 ms.
```

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
