### PR TITLE
#160: Add unit tests for SQLDatabaseManager

### DIFF
--- a/src/jyut-dict/CMakeLists.txt
+++ b/src/jyut-dict/CMakeLists.txt
@@ -165,6 +165,7 @@ target_link_libraries(CantoneseDictionary
     PRIVATE KF5::Archive
 )
 
+add_subdirectory(logic/database/test/TestSqlDatabaseManager)
 add_subdirectory(logic/entry/test/TestDefinitionsSet)
 add_subdirectory(logic/entry/test/TestEntry)
 add_subdirectory(logic/sentence/test/TestSentenceSet)

--- a/src/jyut-dict/logic/database/sqldatabasemanager.cpp
+++ b/src/jyut-dict/logic/database/sqldatabasemanager.cpp
@@ -102,8 +102,7 @@ bool SQLDatabaseManager::backupDictionaryDatabase()
             QFile::remove(backupFilePath);
         }
         if (QFile::exists(oldFilePath)) {
-            QFile::copy(oldFilePath, backupFilePath);
-            QFile::remove(oldFilePath);
+            QFile::rename(oldFilePath, backupFilePath);
         }
     }
 

--- a/src/jyut-dict/logic/database/sqldatabasemanager.cpp
+++ b/src/jyut-dict/logic/database/sqldatabasemanager.cpp
@@ -15,6 +15,11 @@
 // FLATPAK or APPIMAGE for the image one directory above,
 // or nothing for the .deb
 
+namespace {
+constexpr auto DICTIONARY_DATABASE_NAME = "dict.db";
+constexpr auto USER_DATABASE_NAME = "user.db";
+} // namespace
+
 SQLDatabaseManager::SQLDatabaseManager()
 {
     // Delete the old version of the dictionary

--- a/src/jyut-dict/logic/database/sqldatabasemanager.cpp
+++ b/src/jyut-dict/logic/database/sqldatabasemanager.cpp
@@ -102,7 +102,8 @@ bool SQLDatabaseManager::backupDictionaryDatabase()
             QFile::remove(backupFilePath);
         }
         if (QFile::exists(oldFilePath)) {
-            QFile::rename(oldFilePath, backupFilePath);
+            QFile::copy(oldFilePath, backupFilePath);
+            QFile::remove(oldFilePath);
         }
     }
 

--- a/src/jyut-dict/logic/database/sqldatabasemanager.h
+++ b/src/jyut-dict/logic/database/sqldatabasemanager.h
@@ -9,9 +9,6 @@
 // The userDatabase is the database that contains user data (e.g. favourites,
 // search history, etc.)
 
-constexpr auto DICTIONARY_DATABASE_NAME = "dict.db";
-constexpr auto USER_DATABASE_NAME = "user.db";
-
 class SQLDatabaseManager
 {
 public:

--- a/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/.gitignore
+++ b/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/.gitignore
@@ -1,0 +1,74 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+CMakeLists.txt.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/CMakeLists.txt
+++ b/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(TestSqlDatabaseManager LANGUAGES CXX)
+
+enable_testing()
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Sql Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Sql Test)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(TestSqlDatabaseManager tst_sqldatabasemanager.cpp)
+add_test(NAME TestSqlDatabaseManager COMMAND TestSqlDatabaseManager)
+
+target_link_libraries(TestSqlDatabaseManager
+    PRIVATE Qt${QT_VERSION_MAJOR}::Sql
+    PRIVATE Qt${QT_VERSION_MAJOR}::Test
+)
+target_include_directories(TestSqlDatabaseManager PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
+
+set_target_properties(TestSqlDatabaseManager PROPERTIES
+    MACOSX_BUNDLE TRUE
+)
+
+target_sources(TestSqlDatabaseManager
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../sqldatabasemanager.cpp
+)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG -DPORTABLE")
+

--- a/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/tst_sqldatabasemanager.cpp
+++ b/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/tst_sqldatabasemanager.cpp
@@ -76,10 +76,6 @@ void TestSqlDatabaseManager::backupAndRestore()
     QCOMPARE(databaseFile.remove(), true);
     QCOMPARE(databaseBackupFile.remove(), true);
     QCOMPARE(databaseBackupBackupFile.remove(), true);
-
-    databaseFile.close();
-    databaseBackupFile.close();
-    databaseBackupBackupFile.close();
 }
 
 QTEST_MAIN(TestSqlDatabaseManager)

--- a/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/tst_sqldatabasemanager.cpp
+++ b/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/tst_sqldatabasemanager.cpp
@@ -1,0 +1,78 @@
+#include <QtTest>
+
+#include "logic/database/sqldatabasemanager.h"
+
+#include <QSqlDatabase>
+
+class TestSqlDatabaseManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestSqlDatabaseManager();
+    ~TestSqlDatabaseManager();
+
+private slots:
+    void getDatabase();
+    void backupAndRestore();
+};
+
+TestSqlDatabaseManager::TestSqlDatabaseManager() {}
+
+TestSqlDatabaseManager::~TestSqlDatabaseManager() {}
+
+void TestSqlDatabaseManager::getDatabase()
+{
+    SQLDatabaseManager manager;
+    QCOMPARE(manager.isDatabaseOpen(), false);
+
+    QSqlDatabase database = manager.getDatabase();
+    QCOMPARE(manager.isDatabaseOpen(), true);
+    QCOMPARE(database.isOpen(), true);
+    QCOMPARE(database.isValid(), true);
+
+    manager.closeDatabase();
+    QCOMPARE(manager.isDatabaseOpen(), false);
+    QCOMPARE(database.isOpen(), false);
+}
+
+void TestSqlDatabaseManager::backupAndRestore()
+{
+    SQLDatabaseManager manager;
+
+    QFile databaseFile{manager.getDictionaryDatabasePath()};
+    QDir databaseDir{QFileInfo{databaseFile.fileName()}.absolutePath()};
+    QCOMPARE(databaseDir.mkpath(
+                 QFileInfo{databaseFile.fileName()}.absolutePath()),
+             true);
+    QCOMPARE(databaseFile.open(QIODevice::ReadWrite), true);
+    QCOMPARE(databaseFile.exists(), true);
+
+    manager.backupDictionaryDatabase();
+    QCOMPARE(databaseFile.exists(), true);
+
+    QFile databaseBackupFile{manager.getDictionaryDatabasePath() + "_1"};
+    QCOMPARE(databaseBackupFile.open(QIODevice::ReadOnly), true);
+    QCOMPARE(databaseBackupFile.exists(), true);
+
+    QCOMPARE(databaseFile.remove(), true);
+    QCOMPARE(databaseFile.exists(), false);
+
+    manager.restoreBackedUpDictionaryDatabase();
+
+    QCOMPARE(databaseBackupFile.exists(), true);
+    QCOMPARE(databaseFile.exists(), true);
+
+    manager.backupDictionaryDatabase();
+    QFile databaseBackupBackupFile{manager.getDictionaryDatabasePath() + "_2"};
+    QCOMPARE(databaseBackupBackupFile.open(QIODevice::ReadOnly), true);
+    QCOMPARE(databaseBackupBackupFile.exists(), true);
+
+    databaseFile.close();
+    databaseBackupFile.close();
+    databaseBackupBackupFile.close();
+}
+
+QTEST_MAIN(TestSqlDatabaseManager)
+
+#include "tst_sqldatabasemanager.moc"

--- a/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/tst_sqldatabasemanager.cpp
+++ b/src/jyut-dict/logic/database/test/TestSqlDatabaseManager/tst_sqldatabasemanager.cpp
@@ -48,7 +48,7 @@ void TestSqlDatabaseManager::backupAndRestore()
     QCOMPARE(databaseFile.open(QIODevice::ReadWrite), true);
     QCOMPARE(databaseFile.exists(), true);
 
-    manager.backupDictionaryDatabase();
+    QCOMPARE(manager.backupDictionaryDatabase(), true);
     QCOMPARE(databaseFile.exists(), true);
 
     QFile databaseBackupFile{manager.getDictionaryDatabasePath() + "_1"};
@@ -58,15 +58,24 @@ void TestSqlDatabaseManager::backupAndRestore()
     QCOMPARE(databaseFile.remove(), true);
     QCOMPARE(databaseFile.exists(), false);
 
-    manager.restoreBackedUpDictionaryDatabase();
+    QCOMPARE(manager.restoreBackedUpDictionaryDatabase(), true);
 
     QCOMPARE(databaseBackupFile.exists(), true);
     QCOMPARE(databaseFile.exists(), true);
 
-    manager.backupDictionaryDatabase();
+#ifdef Q_OS_WINDOWS
+    // On Windows, open files cannot be deleted.
+    databaseBackupFile.close();
+#endif
+
+    QCOMPARE(manager.backupDictionaryDatabase(), true);
     QFile databaseBackupBackupFile{manager.getDictionaryDatabasePath() + "_2"};
-    QCOMPARE(databaseBackupBackupFile.open(QIODevice::ReadOnly), true);
     QCOMPARE(databaseBackupBackupFile.exists(), true);
+    QCOMPARE(databaseBackupBackupFile.open(QIODevice::ReadOnly), true);
+
+    QCOMPARE(databaseFile.remove(), true);
+    QCOMPARE(databaseBackupFile.remove(), true);
+    QCOMPARE(databaseBackupBackupFile.remove(), true);
 
     databaseFile.close();
     databaseBackupFile.close();


### PR DESCRIPTION
# Description

This commit adds two unit tests for SQLDatabaseManager, opening/closing the database and backing up/restoring the database.

Part of a series of commits for #160.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on all three platforms, macOS, Windows, and Linux.

```
PASS	Executing test case TestSqlDatabaseManager
	Qt version: 5.15.2
	Qt build: Qt 5.15.2 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 5.3.1 20160406 (Red Hat 5.3.1-6))
	QTest version: 5.15.2
PASS	Executing test function initTestCase
PASS	TestSqlDatabaseManager::initTestCase
	Execution took 0.225096 ms.
PASS	Executing test function getDatabase
PASS	TestSqlDatabaseManager::getDatabase
	Execution took 6.00906 ms.
PASS	Executing test function backupAndRestore
PASS	TestSqlDatabaseManager::backupAndRestore
	Execution took 0.592482 ms.
PASS	Executing test function cleanupTestCase
PASS	TestSqlDatabaseManager::cleanupTestCase
	Execution took 0.002374 ms.
	Test execution took 7.23439 ms.
```

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
