### PR TITLE
#161: Remove static variable declaration in header file

### DIFF
--- a/src/jyut-dict/logic/dictionary/dictionarysource.cpp
+++ b/src/jyut-dict/logic/dictionary/dictionarysource.cpp
@@ -1,9 +1,16 @@
 #include "logic/dictionary/dictionarysource.h"
 
+#include <algorithm>
+#include <shared_mutex>
+
 namespace DictionarySourceUtils {
+
+std::unordered_map<std::string, std::string> name_to_short_name;
+std::shared_mutex map_mutex;
 
 std::string getSourceShortString(const std::string &source)
 {
+    std::shared_lock lock{map_mutex};
     auto result = name_to_short_name.find(source);
 
     if (result == name_to_short_name.end()) {
@@ -15,17 +22,19 @@ std::string getSourceShortString(const std::string &source)
 
 bool addSource(const std::string &sourcename, const std::string &shortsourcename)
 {
+    std::lock_guard lock{map_mutex};
     return name_to_short_name.insert({sourcename, shortsourcename}).second;
 }
 
 bool removeSource(const std::string &sourcename)
 {
+    std::lock_guard lock{map_mutex};
     auto index = std::find_if(name_to_short_name.begin(),
-                           name_to_short_name.end(),
-                           [sourcename](
-                               std::pair<std::string, std::string> source) {
-                               return source.first == sourcename;
-                           });
+                              name_to_short_name.end(),
+                              [sourcename](
+                                  std::pair<std::string, std::string> source) {
+                                  return source.first == sourcename;
+                              });
     if (index == name_to_short_name.end()) {
         return false;
     }

--- a/src/jyut-dict/logic/dictionary/dictionarysource.h
+++ b/src/jyut-dict/logic/dictionary/dictionarysource.h
@@ -3,10 +3,8 @@
 
 #include <QObject>
 
-#include <algorithm>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 // The name_to_short_name unordered_map contains mappings for long names to
 // nicknames of sources.
@@ -16,7 +14,7 @@
 
 namespace DictionarySourceUtils {
 
-static std::unordered_map<std::string, std::string> name_to_short_name{};
+extern std::unordered_map<std::string, std::string> name_to_short_name;
 
 std::string getSourceShortString(const std::string &source);
 bool addSource(const std::string &sourcename,


### PR DESCRIPTION
# Description

- The map name_to_short_name was declared static in a header file before. This meant that every translation unit would have its own copy of the vector. Not sure why it ever worked before, since the vector was only populated in main.cpp...
- Also added synchronization primitives for the unordered_map.

Part of commits for #161.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Built and run on all three platforms. All unit tests passed.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
