### PR TITLE
#161: Update build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Place the database, named `dict.db`, in `src/jyut-dict/resources/db/`
 1. Install [Craft](https://community.kde.org/Craft).
 2. Install various dependencies using Craft:
 ```
-craft libs/qt/multimedia
+craft libs/qt/qtmultimedia
 craft libs/qt/qtspeech
 craft karchive
 ```


### PR DESCRIPTION
# Description

One of the dependencies for the Craft build on Windows/Mac was incorrectly specified (should be `libs/qt/qtmultimedia` instead of `libs/qt/multimedia`).

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?
N/A

# Checklist:

- [x] I have made corresponding changes to the documentation
