### PR TITLE
#178: Add ability to scroll through entry view using keyboard

### DIFF
--- a/src/jyut-dict/components/entryview/entryscrollarea.cpp
+++ b/src/jyut-dict/components/entryview/entryscrollarea.cpp
@@ -13,6 +13,7 @@ EntryScrollArea::EntryScrollArea(std::shared_ptr<SQLUserDataUtils> sqlUserUtils,
     _updateUITimer = new QTimer{this};
 
     setFrameShape(QFrame::NoFrame);
+    verticalScrollBar()->setFocusPolicy(Qt::StrongFocus);
 
     _scrollAreaWidget = new EntryScrollAreaWidget{sqlUserUtils, manager, this};
 
@@ -84,7 +85,43 @@ void EntryScrollArea::keyPressEvent(QKeyEvent *event)
 {
     if (isWindow() && event->key() == Qt::Key_Escape) {
         close();
+        return;
+    } else {
+        // Not sure why setting the focus policy of the scroll bar
+        // doesn't work, but this is a workaround!
+        switch (event->key()) {
+        case Qt::Key_Down: {
+            verticalScrollBar()->triggerAction(
+                QAbstractSlider::SliderSingleStepAdd);
+            break;
+        }
+        case Qt::Key_Up: {
+            verticalScrollBar()->triggerAction(
+                QAbstractSlider::SliderSingleStepSub);
+            break;
+        }
+        case Qt::Key_PageDown: {
+            verticalScrollBar()->triggerAction(
+                QAbstractSlider::SliderPageStepAdd);
+            break;
+        }
+        case Qt::Key_PageUp: {
+            verticalScrollBar()->triggerAction(
+                QAbstractSlider::SliderPageStepSub);
+            break;
+        }
+        case Qt::Key_Home: {
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderToMinimum);
+            break;
+        }
+        case Qt::Key_End: {
+            verticalScrollBar()->triggerAction(QAbstractSlider::SliderToMaximum);
+            break;
+        }
+        }
+        return;
     }
+    QWidget::keyPressEvent(event);
 }
 
 void EntryScrollArea::setEntry(const Entry &entry)


### PR DESCRIPTION
# Description

This commit adds ability to scroll through the entry view using the keyboard arrow keys, page up/down, and the home/end keys.

Closes #178.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Inspected manually on macOS, Linux, and Windows.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
