### PR TITLE
#41: Add tests for fuzzy Jyutping in SQL Search unit test

### DIFF
--- a/src/jyut-dict/logic/search/test/TestSqlSearch/tst_sqlsearch.cpp
+++ b/src/jyut-dict/logic/search/test/TestSqlSearch/tst_sqlsearch.cpp
@@ -681,6 +681,18 @@ void TestSqlSearch::searchJyutping()
         observer.resultsReady.wait(lock);
         QCOMPARE(observer.testFailed, false);
     }
+    search.searchJyutping("yuet? ????");
+    {
+        std::unique_lock lock{observer.mutex};
+        observer.resultsReady.wait(lock);
+        QCOMPARE(observer.testFailed, false);
+    }
+    search.searchJyutping("yuetshow");
+    {
+        std::unique_lock lock{observer.mutex};
+        observer.resultsReady.wait(lock);
+        QCOMPARE(observer.testFailed, false);
+    }
     search.searchJyutping("????? ????$");
     {
         std::unique_lock lock{observer.mutex};


### PR DESCRIPTION
# Description

This commit adds two tests that use fuzzy Jyutping in the SQL Search unit test.

# How Has This Been Tested?

Run on macOS.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
