### PR TITLE
#161: Modify .gitignore and add keyboard shortcuts to transcription window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ CMakeLists.txt.user*
 # Qt Builds
 *dist/
 
+# Qt Linguist artifacts
+src/jyut-dict/resources/translations/*.json
+
 # vim
 **.swp
 
@@ -92,6 +95,7 @@ CMakeLists.txt.user*
 **/cantodict/data/*
 **/cantodict/developer/*
 **/cedict/archive_*
+**/cedict/data/YFDICT.txt
 **/cedict/developer/*
 **/cfdict-xml/archive_*
 **/cfdict-xml/data/*

--- a/src/jyut-dict/windows/transcriptionwindow.cpp
+++ b/src/jyut-dict/windows/transcriptionwindow.cpp
@@ -122,9 +122,34 @@ void TranscriptionWindow::changeEvent(QEvent *event)
 
 void TranscriptionWindow::keyPressEvent(QKeyEvent *event)
 {
-    if (event->key() == Qt::Key_Escape || event->key() == Qt::Key_Enter
-        || event->key() == Qt::Key_Return) {
+    switch (event->key()) {
+    case Qt::Key_Escape:
+        [[fallthrough]];
+    case Qt::Key_Enter:
+        [[fallthrough]];
+    case Qt::Key_Return: {
         doneAction();
+        break;
+    }
+    case Qt::Key_E:
+        [[fallthrough]];
+    case Qt::Key_F:
+        [[fallthrough]];
+    case Qt::Key_Y: {
+        _englishButton->click();
+        break;
+    }
+    case Qt::Key_C:
+        [[fallthrough]];
+    case Qt::Key_G: {
+        _cantoneseButton->click();
+        break;
+    }
+    case Qt::Key_M:
+        [[fallthrough]];
+    case Qt::Key_P:
+        _mandarinButton->click();
+        break;
     }
 }
 


### PR DESCRIPTION
# Description

Tiny commit, adds a few paths to .gitignore and allows for keyboard shortcuts in transcription window.

# How Has This Been Tested?

Tested on macOS.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
