### PR TITLE
#161: Add missing translations for microphone permissions dialog

### DIFF
--- a/src/jyut-dict/platform/mac/yue_Hans.lproj/InfoPlist.strings
+++ b/src/jyut-dict/platform/mac/yue_Hans.lproj/InfoPlist.strings
@@ -1,2 +1,4 @@
 "CFBundleDisplayName" = "粤语字典";
 "CFBundleName" = "粤语字典";
+"NSMicrophoneUsageDescription" = "粤语词典会为咗進行听写功能用你嘅麦克风。"
+"NSSpeechRecognitionUsageDescription" = "粤语词典会为咗進行听写功能用语音识别。"

--- a/src/jyut-dict/platform/mac/yue_Hant.lproj/InfoPlist.strings
+++ b/src/jyut-dict/platform/mac/yue_Hant.lproj/InfoPlist.strings
@@ -1,2 +1,4 @@
 "CFBundleDisplayName" = "粵語字典";
 "CFBundleName" = "粵語字典";
+"NSMicrophoneUsageDescription" = "粵語詞典會為咗進行聽寫功能用你嘅咪高風。"
+"NSSpeechRecognitionUsageDescription" = "粵語詞典會為咗進行聽寫功能用語音識別。"

--- a/src/jyut-dict/platform/mac/zh_Hans.lproj/InfoPlist.strings
+++ b/src/jyut-dict/platform/mac/zh_Hans.lproj/InfoPlist.strings
@@ -1,2 +1,4 @@
 "CFBundleDisplayName" = "粤语字典";
 "CFBundleName" = "粤语字典";
+"NSMicrophoneUsageDescription" = "粤语词典会为了進行听写功能用您的麦克风。"
+"NSSpeechRecognitionUsageDescription" = "粤语词典会为了進行听写功能用语音识别。"

--- a/src/jyut-dict/platform/mac/zh_Hant.lproj/InfoPlist.strings
+++ b/src/jyut-dict/platform/mac/zh_Hant.lproj/InfoPlist.strings
@@ -1,2 +1,4 @@
 "CFBundleDisplayName" = "粵語字典";
 "CFBundleName" = "粵語字典";
+"NSMicrophoneUsageDescription" = "粵語詞典會為了進行聽寫功能用您的麥克風。"
+"NSSpeechRecognitionUsageDescription" = "粵語詞典會為了進行聽寫功能用語音辨識。"


### PR DESCRIPTION
# Description

Added translations for microphone and speech recognition dialogs on macOS.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
