### PR TITLE
#161: Fix warnings from Qt

### DIFF
--- a/src/jyut-dict/components/entrysearchresult/resultlistmodel.cpp
+++ b/src/jyut-dict/components/entrysearchresult/resultlistmodel.cpp
@@ -62,18 +62,13 @@ void ResultListModel::copyEntries(const std::vector<Entry> &entries, bool emptyQ
     }
 }
 
-void ResultListModel::setEntries(const std::vector<Entry> &entries)
-{
-    setEntries(entries, false);
-}
-
 void ResultListModel::setEntries(const std::vector<Entry> &entries, bool emptyQuery) {
     beginResetModel();
     _entries = entries;
+    endResetModel();
     if (_entries.empty() && !emptyQuery) {
         setEmpty();
     }
-    endResetModel();
 }
 
 void ResultListModel::setWelcome()

--- a/src/jyut-dict/components/entrysearchresult/resultlistmodel.h
+++ b/src/jyut-dict/components/entrysearchresult/resultlistmodel.h
@@ -33,8 +33,7 @@ public:
     ~ResultListModel() override;
 
     void callback(const std::vector<Entry> &entries, bool emptyQuery) override;
-    void setEntries(const std::vector<Entry> &entries);
-    void setEntries(const std::vector<Entry> &entries, bool emptyQuery);
+    void setEntries(const std::vector<Entry> &entries, bool emptyQuery = false);
     void setWelcome();
     void setEmpty();
 

--- a/src/jyut-dict/components/historyview/searchhistorylistmodel.cpp
+++ b/src/jyut-dict/components/historyview/searchhistorylistmodel.cpp
@@ -31,10 +31,10 @@ void SearchHistoryListModel::setEntries(
 {
     beginResetModel();
     _searchTerms = searchTerms;
+    endResetModel();
     if (_searchTerms.empty() && !emptyQuery) {
         setEmpty();
     }
-    endResetModel();
 }
 
 void SearchHistoryListModel::setEmpty(void)

--- a/src/jyut-dict/components/historyview/viewhistorylistmodel.cpp
+++ b/src/jyut-dict/components/historyview/viewhistorylistmodel.cpp
@@ -26,10 +26,10 @@ void ViewHistoryListModel::setEntries(const std::vector<Entry> &entries)
 void ViewHistoryListModel::setEntries(const std::vector<Entry> &entries, bool emptyQuery) {
     beginResetModel();
     _entries = entries;
+    endResetModel();
     if (_entries.empty() && !emptyQuery) {
         setEmpty();
     }
-    endResetModel();
 }
 
 void ViewHistoryListModel::setEmpty(void)


### PR DESCRIPTION
# Description

No user-facing change. Fixes a warning emitted by Qt when no search results are found — `endResetModel called without calling beginResetModel first` and `beginResetModel called without calling endResetModel first`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS 15.5.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
