### PR TITLE
#161: Fix issues in Fuzzy Jyutping

### DIFF
--- a/src/jyut-dict/logic/search/sqlsearch.cpp
+++ b/src/jyut-dict/logic/search/sqlsearch.cpp
@@ -51,11 +51,12 @@ void prepareJyutpingBindValues(const QString &searchTerm,
                      ' ',
                      jyutpingSyllables);
     } else {
-        CantoneseUtils::segmentJyutping(correctedSearchTerm,
-                                        jyutpingSyllables,
-                                        /* removeSpecialCharacters */ true,
-                                        /* removeGlobCharacters */ false,
-                                        /* removeRegexCharacters= */ false);
+        CantoneseUtils::segmentJyutping(
+            correctedSearchTerm,
+            jyutpingSyllables,
+            /* removeSpecialCharacters */ true,
+            /* removeGlobCharacters */ false,
+            /* removeRegexCharacters= */ !fuzzyJyutping);
     }
 
     if (!searchExactMatch && fuzzyJyutping) {

--- a/src/jyut-dict/logic/utils/cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/cantoneseutils.cpp
@@ -570,6 +570,16 @@ bool jyutpingAutocorrect(const QString &in,
     }
     out.replace("eok", "oek");
 
+    out.replace("ao ", "au ");
+    out.replace("ao'", "au'");
+    if (out.endsWith("ao")) {
+        idx = out.lastIndexOf(("ao"));
+        out.replace(idx, 2, "au");
+    }
+    if (unsafeSubstitutions) {
+        out.replace("ao", "au"); // unsafe because of maa5 on1
+    }
+
     out.replace("ar", "aa");      // like in "char siu"
     out.replace("ee", "i");       // like in "lai see"
     out.replace("ay", "ei");      // like in "gong hay fat choy"
@@ -1029,7 +1039,7 @@ bool jyutpingAutocorrect(const QString &in,
 
     out.replace("ui", "(eo|u)i");
     out.replace("un", "(y!u|a|eo)n");
-    out.replace("ut", "(a|u)t");
+    out.replace("ut", "(a|y!u)t");
 
     return 0;
 }

--- a/src/jyut-dict/logic/utils/cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/cantoneseutils.cpp
@@ -592,7 +592,6 @@ bool jyutpingAutocorrect(const QString &in,
             out.replace(out.length() - 2, 2, "ei");
         }
 
-        int replacementIdx = out.indexOf("ey");
         // Initials for which <initial> + "-ei" exist in Jyutping
         std::unordered_set<QChar> closeFrontVowelCluster
             = {'p', 'f', 'd', 'n', 'l', 'h', 'w'};
@@ -601,6 +600,8 @@ bool jyutpingAutocorrect(const QString &in,
         // Initials for which both exist in Jyutping
         std::unordered_set<QChar> ambiguousVowelCluster
             = {'b', 'm', 'g', 'k', 'z', 's'};
+
+        int replacementIdx = out.indexOf("ey");
         switch (replacementIdx) {
         case -1: {
             break;

--- a/src/jyut-dict/logic/utils/cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/cantoneseutils.cpp
@@ -963,7 +963,7 @@ bool jyutpingAutocorrect(const QString &in,
         }
     }
 
-    // Check if the user intends to write an [-yt] or [jɐn], [jyn], [yn] cluster
+    // Check if the user intends to write an [-yt] or [jɐt], [jyt], [yt] cluster
     {
         // Initials for which <initial> + "-yu t-" exist in Jyutping
         std::unordered_set<QChar> closeFrontVowelCluster = {'z', 's', 'c', 'j'};

--- a/src/jyut-dict/logic/utils/cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/cantoneseutils.cpp
@@ -602,46 +602,46 @@ bool jyutpingAutocorrect(const QString &in,
             = {'b', 'm', 'g', 'k', 'z', 's'};
 
         int replacementIdx = out.indexOf("ey");
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 2, "ei");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
-            }
-
-            if (closeFrontVowelCluster.find(out.at(initialIdx))
-                != closeFrontVowelCluster.end()) {
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
                 out.replace(replacementIdx, 2, "ei");
-            } else if (openMidFrontVowelCluster.find(out.at(initialIdx))
-                       != openMidFrontVowelCluster.end()) {
-                out.replace(replacementIdx, 2, "e j");
-            } else if (ambiguousVowelCluster.find(out.at(initialIdx))
-                       != ambiguousVowelCluster.end()) {
-                // The [j-] cluster can only occur if what follows is not an initial
-                bool initialFound = false;
-                for (int initial_len = 2; initial_len > 0; initial_len--) {
-                    QString s{out.constBegin() + replacementIdx + 2,
-                              initial_len};
-                    if (initials.find(s.toStdString()) != initials.end()
-                        || s.toStdString() == "y") {
-                        initialFound = true;
+                break;
+            }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
+
+                if (closeFrontVowelCluster.find(out.at(initialIdx))
+                    != closeFrontVowelCluster.end()) {
+                    out.replace(replacementIdx, 2, "ei");
+                } else if (openMidFrontVowelCluster.find(out.at(initialIdx))
+                           != openMidFrontVowelCluster.end()) {
+                    out.replace(replacementIdx, 2, "e j");
+                } else if (ambiguousVowelCluster.find(out.at(initialIdx))
+                           != ambiguousVowelCluster.end()) {
+                    // The [j-] cluster can only occur if what follows is not an initial
+                    bool initialFound = false;
+                    for (int initial_len = 2; initial_len > 0; initial_len--) {
+                        QString s{out.constBegin() + replacementIdx + 2,
+                                  initial_len};
+                        if (initials.find(s.toStdString()) != initials.end()
+                            || s.toStdString() == "y") {
+                            initialFound = true;
+                        }
+                    }
+                    if (initialFound) {
+                        out.replace(replacementIdx, 2, "ei");
+                    } else {
+                        out.replace(replacementIdx, 2, "e j");
                     }
                 }
-                if (initialFound) {
-                    out.replace(replacementIdx, 2, "ei");
-                } else {
-                    out.replace(replacementIdx, 2, "e j");
-                }
+                break;
             }
-            break;
-        }
+            }
+            replacementIdx = out.indexOf("ey", replacementIdx + 1);
         }
     }
 
@@ -710,7 +710,7 @@ bool jyutpingAutocorrect(const QString &in,
         std::unordered_set<QChar> closeBackVowelCluster = {'b', 'm', 'k', 's'};
         // Initials for which both exist in Jyutping
         std::unordered_set<QChar> ambiguousVowelCluster
-            = {'p', 'm', 'f', 'd', 't', 'n', 'l', 'h', 'z', 'c', 's'};
+            = {'p', 'm', 'f', 'd', 't', 'n', 'l', 'g', 'h', 'z', 'c', 's'};
         int replacementIdx = out.indexOf("ow");
         while (replacementIdx != -1) {
             switch (replacementIdx) {

--- a/src/jyut-dict/logic/utils/cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/cantoneseutils.cpp
@@ -651,49 +651,50 @@ bool jyutpingAutocorrect(const QString &in,
             out.replace(out.length() - 2, 2, "ou");
         }
 
-        int replacementIdx = out.indexOf("oh");
         // Initials for which <initial> + "-ou" exist in Jyutping
         std::unordered_set<QChar> closeBackVowelCluster = {'n', 'j'};
         // Initials for which both "-ou" and "-o h-" exist in Jyutping
         std::unordered_set<QChar> ambiguousVowelCluster
             = {'b', 'p', 'm', 'f', 'd', 't', 'l', 'g', 'h', 'w', 'z', 'c', 's'};
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 2, "ou");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
-            }
 
-            if (closeBackVowelCluster.find(out.at(initialIdx))
-                != closeBackVowelCluster.end()) {
+        int replacementIdx = out.indexOf("oh");
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
                 out.replace(replacementIdx, 2, "ou");
-            } else if (ambiguousVowelCluster.find(out.at(initialIdx))
-                       != ambiguousVowelCluster.end()) {
-                // The [h-] cluster can only occur if what follows is not an initial
-                bool initialFound = false;
-                for (int initial_len = 2; initial_len > 0; initial_len--) {
-                    QString s{out.constBegin() + replacementIdx + 2,
-                              initial_len};
-                    if (initials.find(s.toStdString()) != initials.end()
-                        || s.toStdString() == "y") {
-                        initialFound = true;
+                break;
+            }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
+
+                if (closeBackVowelCluster.find(out.at(initialIdx))
+                    != closeBackVowelCluster.end()) {
+                    out.replace(replacementIdx, 2, "ou");
+                } else if (ambiguousVowelCluster.find(out.at(initialIdx))
+                           != ambiguousVowelCluster.end()) {
+                    // The [h-] cluster can only occur if what follows is not an initial
+                    bool initialFound = false;
+                    for (int initial_len = 2; initial_len > 0; initial_len--) {
+                        QString s{out.constBegin() + replacementIdx + 2,
+                                  initial_len};
+                        if (initials.find(s.toStdString()) != initials.end()
+                            || s.toStdString() == "y") {
+                            initialFound = true;
+                        }
+                    }
+                    if (initialFound) {
+                        out.replace(replacementIdx, 2, "ou");
+                    } else {
+                        out.replace(replacementIdx, 2, "o h");
                     }
                 }
-                if (initialFound) {
-                    out.replace(replacementIdx, 2, "ou");
-                } else {
-                    out.replace(replacementIdx, 2, "o h");
-                }
+                break;
             }
-            break;
-        }
+            }
+            replacementIdx = out.indexOf("oh", replacementIdx + 1);
         }
     }
 
@@ -704,49 +705,49 @@ bool jyutpingAutocorrect(const QString &in,
             out.replace(out.length() - 2, 2, "au");
         }
 
-        int replacementIdx = out.indexOf("ow");
         // Initials for which <initial> + "-(a)au" exist in Jyutping
         std::unordered_set<QChar> closeBackVowelCluster = {'b', 'm', 'k', 's'};
         // Initials for which both exist in Jyutping
         std::unordered_set<QChar> ambiguousVowelCluster
             = {'p', 'm', 'f', 'd', 't', 'n', 'l', 'h', 'z', 'c', 's'};
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 2, "au");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
-            }
-
-            if (closeBackVowelCluster.find(out.at(initialIdx))
-                != closeBackVowelCluster.end()) {
+        int replacementIdx = out.indexOf("ow");
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
                 out.replace(replacementIdx, 2, "au");
-            } else if (ambiguousVowelCluster.find(out.at(initialIdx))
-                       != ambiguousVowelCluster.end()) {
-                // The [w-] cluster can only occur if what follows is not an initial
-                bool initialFound = false;
-                for (int initial_len = 2; initial_len > 0; initial_len--) {
-                    QString s{out.constBegin() + replacementIdx + 2,
-                              initial_len};
-                    if (initials.find(s.toStdString()) != initials.end()
-                        || s.toStdString() == "y") {
-                        initialFound = true;
+                break;
+            }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
+
+                if (closeBackVowelCluster.find(out.at(initialIdx))
+                    != closeBackVowelCluster.end()) {
+                    out.replace(replacementIdx, 2, "au");
+                } else if (ambiguousVowelCluster.find(out.at(initialIdx))
+                           != ambiguousVowelCluster.end()) {
+                    // The [w-] cluster can only occur if what follows is not an initial
+                    bool initialFound = false;
+                    for (int initial_len = 2; initial_len > 0; initial_len--) {
+                        QString s{out.constBegin() + replacementIdx + 2,
+                                  initial_len};
+                        if (initials.find(s.toStdString()) != initials.end()
+                            || s.toStdString() == "y") {
+                            initialFound = true;
+                        }
+                    }
+                    if (initialFound) {
+                        out.replace(replacementIdx, 2, "au");
+                    } else {
+                        out.replace(replacementIdx, 2, "o w");
                     }
                 }
-                if (initialFound) {
-                    out.replace(replacementIdx, 2, "au");
-                } else {
-                    out.replace(replacementIdx, 2, "o w");
-                }
+                break;
             }
-            break;
-        }
+            }
+            replacementIdx = out.indexOf("ow", replacementIdx + 1);
         }
     }
 
@@ -757,243 +758,238 @@ bool jyutpingAutocorrect(const QString &in,
             out.replace(out.length() - 2, 2, "am");
         }
 
-        int replacementIdx = out.indexOf("um");
         // Initials for which <initial> + "am" exist in Jyutping
         std::unordered_set<QChar> openMidCentralVowelCluster
             = {'b', 'p', 'm', 'd', 't', 'n', 'l', 'k', 'h', 'z', 'c', 's', 'j'};
         // Initials for which <initial> + "-u m-" exist in Jyutping
         std::unordered_set<QChar> closeBackVowelCluster
             = {'f', 'w', 'a', 'e', 'i', 'o'};
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 2, "am");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
-            }
 
-            if (openMidCentralVowelCluster.find(out.at(initialIdx))
-                != openMidCentralVowelCluster.end()) {
+        int replacementIdx = out.indexOf("um");
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
                 out.replace(replacementIdx, 2, "am");
-            } else if (closeBackVowelCluster.find(out.at(initialIdx))
-                       != closeBackVowelCluster.end()) {
-                (void) 0; // Do nothing
-            } else if (out.at(initialIdx) == "g") {
-                // The [m-] cluster can only occur if what follows is not an initial
-                bool initialFound = false;
-                for (int initial_len = 2; initial_len > 0; initial_len--) {
-                    QString s{out.constBegin() + replacementIdx + 2,
-                              initial_len};
-                    if (initials.find(s.toStdString()) != initials.end()
-                        || s.toStdString() == "y") {
-                        initialFound = true;
+                break;
+            }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
+
+                if (openMidCentralVowelCluster.find(out.at(initialIdx))
+                    != openMidCentralVowelCluster.end()) {
+                    out.replace(replacementIdx, 2, "am");
+                } else if (closeBackVowelCluster.find(out.at(initialIdx))
+                           != closeBackVowelCluster.end()) {
+                    (void) 0; // Do nothing
+                } else if (out.at(initialIdx) == "g") {
+                    // The [m-] cluster can only occur if what follows is not an initial
+                    bool initialFound = false;
+                    for (int initial_len = 2; initial_len > 0; initial_len--) {
+                        QString s{out.constBegin() + replacementIdx + 2,
+                                  initial_len};
+                        if (initials.find(s.toStdString()) != initials.end()
+                            || s.toStdString() == "y") {
+                            initialFound = true;
+                        }
+                    }
+                    if (initialFound) {
+                        out.replace(replacementIdx, 2, "am");
+                    } else {
+                        out.replace(replacementIdx, 2, "u m");
                     }
                 }
-                if (initialFound) {
-                    out.replace(replacementIdx, 2, "am");
-                } else {
-                    out.replace(replacementIdx, 2, "u m");
-                }
+                break;
             }
-            break;
-        }
+            }
+            replacementIdx = out.indexOf("um", replacementIdx + 1);
         }
     }
 
     // Check if the user intends to write an [-yː j-] or [-ɐm] cluster
     {
-        int replacementIdx = out.indexOf("yum");
-
         // Initials for which <initial> + "-yu m-" exist in Jyutping
         std::unordered_set<QChar> closeFrontVowelCluster = {'z', 'c', 's', 'j'};
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 3, "jam");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
-            }
-
-            if (closeFrontVowelCluster.find(out.at(initialIdx))
-                != closeFrontVowelCluster.end()) {
-                out.replace(replacementIdx, 3, "yu m");
-            } else {
+        int replacementIdx = out.indexOf("yum");
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
                 out.replace(replacementIdx, 3, "jam");
+                break;
             }
-            break;
-        }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
+
+                if (closeFrontVowelCluster.find(out.at(initialIdx))
+                    != closeFrontVowelCluster.end()) {
+                    out.replace(replacementIdx, 3, "yu m");
+                } else {
+                    out.replace(replacementIdx, 3, "jam");
+                }
+                break;
+            }
+            }
+            replacementIdx = out.indexOf("yum", replacementIdx + 1);
         }
     }
 
     // Check if the user intends to write an [-yː p-] or [-ɐp] cluster
     {
-        int replacementIdx = out.indexOf("yup");
-
         // Initials for which <initial> + "-yu p-" exist in Jyutping
         std::unordered_set<QChar> closeFrontVowelCluster = {'z', 's', 'j'};
 
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 3, "jap");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
-            }
-
-            if (closeFrontVowelCluster.find(out.at(initialIdx))
-                != closeFrontVowelCluster.end()) {
-                out.replace(replacementIdx, 3, "yu p");
-            } else {
+        int replacementIdx = out.indexOf("yup");
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
                 out.replace(replacementIdx, 3, "jap");
+                break;
             }
-            break;
-        }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
+
+                if (closeFrontVowelCluster.find(out.at(initialIdx))
+                    != closeFrontVowelCluster.end()) {
+                    out.replace(replacementIdx, 3, "yu p");
+                } else {
+                    out.replace(replacementIdx, 3, "jap");
+                }
+                break;
+            }
+            }
+            replacementIdx = out.indexOf("yup", replacementIdx + 1);
         }
     }
 
     // Check if the user intends to write an [-yː k-] or [jʊk] cluster
     {
-        int replacementIdx = out.indexOf("yuk");
-
         // Initials for which <initial> + "-yu k-" exist in Jyutping
         std::unordered_set<QChar> closeFrontVowelCluster = {'z', 's', 'c', 'j'};
 
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 3, "juk");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
-            }
-
-            if (closeFrontVowelCluster.find(out.at(initialIdx))
-                != closeFrontVowelCluster.end()) {
-                out.replace(replacementIdx, 3, "yu k");
-            } else {
+        int replacementIdx = out.indexOf("yuk");
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
                 out.replace(replacementIdx, 3, "juk");
+                break;
             }
-            break;
-        }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
+
+                if (closeFrontVowelCluster.find(out.at(initialIdx))
+                    != closeFrontVowelCluster.end()) {
+                    out.replace(replacementIdx, 3, "yu k");
+                } else {
+                    out.replace(replacementIdx, 3, "juk");
+                }
+                break;
+            }
+            }
+            replacementIdx = out.indexOf("yuk", replacementIdx + 1);
         }
     }
 
     // Check if the user intends to write an [-yn g-] or [jʊŋ] cluster
     {
-        int replacementIdx = out.indexOf("yung");
-
         // Initials for which <initial> + "-yun g-" exist in Jyutping
         std::unordered_set<QChar> closeFrontVowelCluster = {'z', 's', 'c', 'j'};
 
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 4, "jung");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
-            }
-
-            if (closeFrontVowelCluster.find(out.at(initialIdx))
-                != closeFrontVowelCluster.end()) {
-                out.replace(replacementIdx, 4, "(yu)n g");
-            } else {
+        int replacementIdx = out.indexOf("yung");
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
                 out.replace(replacementIdx, 4, "jung");
+                break;
             }
-            break;
-        }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
+
+                if (closeFrontVowelCluster.find(out.at(initialIdx))
+                    != closeFrontVowelCluster.end()) {
+                    out.replace(replacementIdx, 4, "(yu)n g");
+                } else {
+                    out.replace(replacementIdx, 4, "jung");
+                }
+                break;
+            }
+            }
+            replacementIdx = out.indexOf("yung", replacementIdx + 1);
         }
     }
 
     // Check if the user intends to write an [-yn] or [jɐn], [jyn], [yn] cluster
     {
-        int replacementIdx = out.indexOf("yun");
-
         // Initials for which <initial> + "-yu n-" exist in Jyutping
         std::unordered_set<QChar> closeFrontVowelCluster = {'z', 's', 'c', 'j'};
 
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 3, "j(a|yu)n");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
+        int replacementIdx = out.indexOf("yun");
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
+                out.replace(replacementIdx, 3, "j(a|yu)n");
+                break;
             }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
 
-            if (closeFrontVowelCluster.find(out.at(initialIdx))
-                != closeFrontVowelCluster.end()) {
-                out.replace(replacementIdx, 3, "yun");
-            } else {
-                out.replace(replacementIdx, 3, "(ja|jyu|yu)n");
+                if (closeFrontVowelCluster.find(out.at(initialIdx))
+                    != closeFrontVowelCluster.end()) {
+                    out.replace(replacementIdx, 3, "yun");
+                } else {
+                    out.replace(replacementIdx, 3, "(ja|jyu|yu)n");
+                }
+                break;
             }
-            break;
-        }
+            }
+            replacementIdx = out.indexOf("yun", replacementIdx + 1);
         }
     }
 
     // Check if the user intends to write an [-yt] or [jɐn], [jyn], [yn] cluster
     {
-        int replacementIdx = out.indexOf("yut");
-
         // Initials for which <initial> + "-yu t-" exist in Jyutping
         std::unordered_set<QChar> closeFrontVowelCluster = {'z', 's', 'c', 'j'};
 
-        switch (replacementIdx) {
-        case -1: {
-            break;
-        }
-        case 0: {
-            out.replace(replacementIdx, 3, "j(a|yu)t");
-            break;
-        }
-        default: {
-            int initialIdx = replacementIdx - 1;
-            if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
-                initialIdx = replacementIdx - 2;
+        int replacementIdx = out.indexOf("yut");
+        while (replacementIdx != -1) {
+            switch (replacementIdx) {
+            case 0: {
+                out.replace(replacementIdx, 3, "j(a|yu)t");
+                break;
             }
+            default: {
+                int initialIdx = replacementIdx - 1;
+                if (replacementIdx >= 2 && out.at(initialIdx) == ")") {
+                    initialIdx = replacementIdx - 2;
+                }
 
-            if (closeFrontVowelCluster.find(out.at(initialIdx))
-                != closeFrontVowelCluster.end()) {
-                out.replace(replacementIdx, 3, "(yu)t");
-            } else {
-                out.replace(replacementIdx, 3, "(ja|jyu|yu)t");
+                if (closeFrontVowelCluster.find(out.at(initialIdx))
+                    != closeFrontVowelCluster.end()) {
+                    out.replace(replacementIdx, 3, "(yu)t");
+                } else {
+                    out.replace(replacementIdx, 3, "(ja|jyu|yu)t");
+                }
+                break;
             }
-            break;
-        }
+            }
+            replacementIdx = out.indexOf("yut", replacementIdx + 1);
         }
     }
 

--- a/src/jyut-dict/logic/utils/cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/cantoneseutils.cpp
@@ -1347,6 +1347,9 @@ bool segmentJyutping(const QString &string,
             } else {
                 // If there was no initial found, then the Jyutping isn't valid
                 valid_jyutping = false;
+                syllables.push_back(currentString.toStdString());
+                start_idx++;
+                end_idx++;
                 continue;
             }
         }

--- a/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
@@ -73,6 +73,7 @@ private slots:
     void autocorrectJyutpingEu();
     void autocorrectJyutpingErn();
     void autocorrectJyutpingOen();
+    void autocorrectJyutpingAo();
     void autocorrectJyutpingAr();
     void autocorrectJyutpingEe();
     void autocorrectJyutpingAy();
@@ -931,6 +932,39 @@ void TestCantoneseUtils::autocorrectJyutpingOen()
                                               result,
                                               /* unsafeSubstitutions */ true);
     expected = "zeon";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+}
+
+void TestCantoneseUtils::autocorrectJyutpingAo()
+{
+    QString result;
+    bool err
+        = CantoneseUtils::jyutpingAutocorrect("gao",
+                                              result,
+                                              /* unsafeSubstitutions */ false);
+    QString expected = "gau";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("gao",
+                                              result,
+                                              /* unsafeSubstitutions */ true);
+    expected = "gau";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("gaolyun",
+                                              result,
+                                              /* unsafeSubstitutions */ false);
+    expected = "gaol(ja|jyu|yu)n";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("gaolyun",
+                                              result,
+                                              /* unsafeSubstitutions */ true);
+    expected = "gaul(ja|jyu|yu)n";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 }
@@ -2372,42 +2406,42 @@ void TestCantoneseUtils::autocorrectJyutpingUt()
         = CantoneseUtils::jyutpingAutocorrect("gut",
                                               result,
                                               /* unsafeSubstitutions */ false);
-    QString expected = "g(a|u)t";
+    QString expected = "g(a|y!u)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
     err = CantoneseUtils::jyutpingAutocorrect("gut",
                                               result,
                                               /* unsafeSubstitutions */ true);
-    expected = "g(a|u)t";
+    expected = "g(a|y!u)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
     err = CantoneseUtils::jyutpingAutocorrect(" gut",
                                               result,
                                               /* unsafeSubstitutions */ false);
-    expected = " g(a|u)t";
+    expected = " g(a|y!u)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
     err = CantoneseUtils::jyutpingAutocorrect(" gut",
                                               result,
                                               /* unsafeSubstitutions */ true);
-    expected = " g(a|u)t";
+    expected = " g(a|y!u)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
     err = CantoneseUtils::jyutpingAutocorrect("gumgut",
                                               result,
                                               /* unsafeSubstitutions */ false);
-    expected = "gamg(a|u)t";
+    expected = "gamg(a|y!u)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
     err = CantoneseUtils::jyutpingAutocorrect("gumgut",
                                               result,
                                               /* unsafeSubstitutions */ true);
-    expected = "gamg(a|u)t";
+    expected = "gamg(a|y!u)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 }

--- a/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
@@ -1455,6 +1455,20 @@ void TestCantoneseUtils::autocorrectJyutpingOw()
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
+    err = CantoneseUtils::jyutpingAutocorrect("gowcat",
+                                              result,
+                                              /* unsafeSubstitutions */ false);
+    expected = "gaucat";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("gowcat",
+                                              result,
+                                              /* unsafeSubstitutions */ true);
+    expected = "gaucat";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
     // Test with ambiguous initial + non-initial after the "ow"
     err = CantoneseUtils::jyutpingAutocorrect("howu",
                                               result,

--- a/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
@@ -22,6 +22,7 @@ private slots:
     void jyutpingToYaleSpecialSyllable();
     void jyutpingToYaleTones();
     void jyutpingToYaleNoTone();
+    void jyutpingToYaleMalformedTone();
 
     void jyutpingToIPASimple();
     void jyutpingToIPARejectNoTone();
@@ -201,6 +202,12 @@ void TestCantoneseUtils::jyutpingToYaleNoTone()
     QCOMPARE(result, "mit");
 }
 
+void TestCantoneseUtils::jyutpingToYaleMalformedTone()
+{
+    std::string result = CantoneseUtils::convertJyutpingToIPA("mat 6");
+    QCOMPARE(result, "x");
+}
+
 void TestCantoneseUtils::jyutpingToIPASimple()
 {
     std::string result = CantoneseUtils::convertJyutpingToIPA("joeng4 sing4");
@@ -291,6 +298,7 @@ void TestCantoneseUtils::jyutpingToIPASpecialFinal()
     QCOMPARE(result, "ʊk̚˥  kʰei̯˧˥  jɐn˨˩");
 #endif
 }
+
 void TestCantoneseUtils::jyutpingToIPATones()
 {
     std::string result = CantoneseUtils::convertJyutpingToIPA(
@@ -304,6 +312,7 @@ void TestCantoneseUtils::jyutpingToIPATones()
              "säːm˥  kɐu̯˧˥  sei̯˧  lɪŋ˨˩  ŋ̍˩˧  jiː˨  t͡sʰɐt̚˥  päːt̚˧  lʊk̚˨");
 #endif
 }
+
 void TestCantoneseUtils::jyutpingToIPANoTone()
 {
     std::string result = CantoneseUtils::convertJyutpingToIPA("mok");

--- a/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
@@ -1277,6 +1277,22 @@ void TestCantoneseUtils::autocorrectJyutpingEy()
     expected = "ge je";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "geyegeye beycaamyeyeyeyeyeyeyepeylougeyheygeygey'gey",
+        result,
+        /* unsafeSubstitutions */ false);
+    expected = "ge jege je beicaamje je je je je je jepeilougeiheigeigei'gei";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "geyegeye beycaamyeyeyeyeyeyeyepeylougeyheygeygey'gey",
+        result,
+        /* unsafeSubstitutions */ true);
+    expected = "ge jege je beicaamje je je je je je jepeilougeiheigeigei'gei";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
 }
 
 void TestCantoneseUtils::autocorrectJyutpingOh()
@@ -1381,6 +1397,14 @@ void TestCantoneseUtils::autocorrectJyutpingOh()
                                               result,
                                               /* unsafeSubstitutions */ true);
     expected = "lo hon";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "mohmohmohlohonlohonlohjannohdoimoh moh",
+        result,
+        /* unsafeSubstitutions */ false);
+    expected = "moumoumoulo honlo honloujannoudoimou mou";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
@@ -2113,27 +2137,27 @@ void TestCantoneseUtils::autocorrectJyutpingYut()
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
-    err = CantoneseUtils::jyutpingAutocorrect("jyungin",
+    err = CantoneseUtils::jyutpingAutocorrect("zyutai",
                                               result,
                                               /* unsafeSubstitutions */ true);
-    expected = "j(yu)n gin";
+    expected = "z(yu)tai";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
     err = CantoneseUtils::jyutpingAutocorrect(
-        "jyunginjyutjyugamyut yut yutyutyut",
+        "zyutaijyutjyugamyut yut yutyutyut",
         result,
         /* unsafeSubstitutions */ false);
-    expected = "j(yu)n ginj(yu)tjyugam(ja|jyu|yu)t (ja|jyu|yu)t "
+    expected = "z(yu)taij(yu)tjyugam(ja|jyu|yu)t (ja|jyu|yu)t "
                "(ja|jyu|yu)t(ja|jyu|yu)t(ja|jyu|yu)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
     err = CantoneseUtils::jyutpingAutocorrect(
-        "jyunginjyutjyugamyut yut yutyutyut",
+        "zyutaijyutjyugamyut yut yutyutyut",
         result,
         /* unsafeSubstitutions */ true);
-    expected = "j(yu)n ginj(yu)tjyugam(ja|jyu|yu)t (ja|jyu|yu)t "
+    expected = "z(yu)taij(yu)tjyugam(ja|jyu|yu)t (ja|jyu|yu)t "
                "(ja|jyu|yu)t(ja|jyu|yu)t(ja|jyu|yu)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
@@ -2373,14 +2397,14 @@ void TestCantoneseUtils::autocorrectJyutpingUt()
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
-    err = CantoneseUtils::jyutpingAutocorrect("gamgut",
+    err = CantoneseUtils::jyutpingAutocorrect("gumgut",
                                               result,
                                               /* unsafeSubstitutions */ false);
     expected = "gamg(a|u)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
-    err = CantoneseUtils::jyutpingAutocorrect("gamgut",
+    err = CantoneseUtils::jyutpingAutocorrect("gumgut",
                                               result,
                                               /* unsafeSubstitutions */ true);
     expected = "gamg(a|u)t";

--- a/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestCantoneseUtils/tst_cantoneseutils.cpp
@@ -1383,6 +1383,14 @@ void TestCantoneseUtils::autocorrectJyutpingOh()
     expected = "lo hon";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "mohmohmohlohonlohonlohjannohdoimoh moh",
+        result,
+        /* unsafeSubstitutions */ true);
+    expected = "moumoumoulo honlo honloujannoudoimou mou";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
 }
 
 void TestCantoneseUtils::autocorrectJyutpingOw()
@@ -1461,6 +1469,20 @@ void TestCantoneseUtils::autocorrectJyutpingOw()
     expected = "ho wu";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("mowmowmowhowuho wu towgai",
+                                              result,
+                                              /* unsafeSubstitutions */ false);
+    expected = "maumaumauho wuho wu taugai";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("mowmowmowhowuho wu towgai",
+                                              result,
+                                              /* unsafeSubstitutions */ true);
+    expected = "maumaumauho wuho wu taugai";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
 }
 
 void TestCantoneseUtils::autocorrectJyutpingUm()
@@ -1510,6 +1532,13 @@ void TestCantoneseUtils::autocorrectJyutpingUm()
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 
+    err = CantoneseUtils::jyutpingAutocorrect("bumbumbumbum",
+                                              result,
+                                              /* unsafeSubstitutions */ true);
+    expected = "bambambambam";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
     // Test with an initial that is only valid for the -u m- combo
     err = CantoneseUtils::jyutpingAutocorrect("wumit",
                                               result,
@@ -1552,6 +1581,20 @@ void TestCantoneseUtils::autocorrectJyutpingUm()
                                               result,
                                               /* unsafeSubstitutions */ true);
     expected = "gu man";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("gumangumzauwumitbumbumbumbum",
+                                              result,
+                                              /* unsafeSubstitutions */ false);
+    expected = "gu mangamzauwumitbambambambam";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("gumangumzauwumitbumbumbumbum",
+                                              result,
+                                              /* unsafeSubstitutions */ true);
+    expected = "gu mangamzauwumitbambambambam";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 }
@@ -1617,6 +1660,20 @@ void TestCantoneseUtils::autocorrectJyutpingYum()
     expected = "syujam";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("cyumatcyumatcyumatsyuyumyumyum",
+                                              result,
+                                              /* unsafeSubstitutions */ false);
+    expected = "cyu matcyu matcyu matsyujamjamjam";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect("cyumatcyumatcyumatsyuyumyumyum",
+                                              result,
+                                              /* unsafeSubstitutions */ true);
+    expected = "cyu matcyu matcyu macyujamjamjam";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
 }
 
 void TestCantoneseUtils::autocorrectJyutpingYup()
@@ -1678,6 +1735,22 @@ void TestCantoneseUtils::autocorrectJyutpingYup()
                                               result,
                                               /* unsafeSubstitutions */ true);
     expected = "zeonjap";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "zeonyupzeonyupsyupeisyupeiyupyupzeonyup",
+        result,
+        /* unsafeSubstitutions */ false);
+    expected = "zeonjapzeonjapsyu peisyu peijapjapzeonjap";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "zeonyupzeonyupsyupeisyupeiyupyupzeonyup",
+        result,
+        /* unsafeSubstitutions */ true);
+    expected = "zeonjapzeonjapsyu peisyu peijapjapzeonjap";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 }
@@ -1769,6 +1842,22 @@ void TestCantoneseUtils::autocorrectJyutpingYuk()
     expected = "jyu kap";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "jyu kapgey yukgeyyukyukyukyukyuk yuk",
+        result,
+        /* unsafeSubstitutions */ false);
+    expected = "jyu kapgei jukgeijukjukjukjukjuk juk";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "jyu kapgey yukgeyyukyukyukyukyuk yuk",
+        result,
+        /* unsafeSubstitutions */ true);
+    expected = "jyu kapgei jukgeijukjukjukjukjuk juk";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
 }
 
 void TestCantoneseUtils::autocorrectJyutpingYung()
@@ -1844,6 +1933,24 @@ void TestCantoneseUtils::autocorrectJyutpingYung()
     expected = "j(yu)n gin";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "jyungingumyung yungyungyungzyungaa",
+        result,
+        /* unsafeSubstitutions */ false);
+    expected = "j(yu)n gingamj(y!u|a|eo)ng "
+               "j(y!u|a|eo)ngj(y!u|a|eo)ngj(y!u|a|eo)ngz(yu)n gaa";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "jyungingumyung yungyungyungzyungaa",
+        result,
+        /* unsafeSubstitutions */ true);
+    expected = "j(yu)n gingamj(y!u|a|eo)ng "
+               "j(y!u|a|eo)ngj(y!u|a|eo)ngj(y!u|a|eo)ngz(yu)n gaa";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
 }
 
 void TestCantoneseUtils::autocorrectJyutpingYun()
@@ -1894,7 +2001,7 @@ void TestCantoneseUtils::autocorrectJyutpingYun()
 
     err = CantoneseUtils::jyutpingAutocorrect("syuntau",
                                               result,
-                                              /* unsafeSubstitutions */ true);
+                                              /* unsafeSubstitutions */ false);
     expected = "sy(y!u|a|eo)ntau";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
@@ -1903,6 +2010,24 @@ void TestCantoneseUtils::autocorrectJyutpingYun()
                                               result,
                                               /* unsafeSubstitutions */ true);
     expected = "sy(y!u|a|eo)ntau";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "syuntausyuntaugumyunyun yunyunyun",
+        result,
+        /* unsafeSubstitutions */ false);
+    expected = "sy(y!u|a|eo)ntausy(y!u|a|eo)ntaugam(ja|jyu|yu)n("
+               "ja|jyu|yu)n (ja|jyu|yu)n(ja|jyu|yu)n(ja|jyu|yu)n";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "syuntausyuntaugumyunyun yunyunyun",
+        result,
+        /* unsafeSubstitutions */ true);
+    expected = "sy(y!u|a|eo)ntausy(y!u|a|eo)ntaugam(ja|jyu|yu)n("
+               "ja|jyu|yu)n (ja|jyu|yu)n(ja|jyu|yu)n(ja|jyu|yu)n";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 }
@@ -1978,6 +2103,24 @@ void TestCantoneseUtils::autocorrectJyutpingYut()
                                               result,
                                               /* unsafeSubstitutions */ true);
     expected = "j(yu)n gin";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "jyunginjyutjyugamyut yut yutyutyut",
+        result,
+        /* unsafeSubstitutions */ false);
+    expected = "j(yu)n ginj(yu)tjyugam(ja|jyu|yu)t (ja|jyu|yu)t "
+               "(ja|jyu|yu)t(ja|jyu|yu)t(ja|jyu|yu)t";
+    QCOMPARE(result, expected);
+    QCOMPARE(err, false);
+
+    err = CantoneseUtils::jyutpingAutocorrect(
+        "jyunginjyutjyugamyut yut yutyutyut",
+        result,
+        /* unsafeSubstitutions */ true);
+    expected = "j(yu)n ginj(yu)tjyugam(ja|jyu|yu)t (ja|jyu|yu)t "
+               "(ja|jyu|yu)t(ja|jyu|yu)t(ja|jyu|yu)t";
     QCOMPARE(result, expected);
     QCOMPARE(err, false);
 }


### PR DESCRIPTION
# Description

This commit fixes several issues in Jyutping parsing and Fuzzy Jyutping replacement:
* Repeated instances of a cluster to be replaced were replaced only once.
* Added replacement for -ao -> -au (such as "hagao" -> "haa gaau")
* Fixes infinite loop when segmenting malformed Jyutping (such as in the syllable "mat 6").

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added appropriate unit tests and ran them on macOS 15.5.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
