### PR TITLE
#161: Grab bag of small fixes for Wikipedia title parsing

### DIFF
--- a/src/dictionaries/wiki/parse.py
+++ b/src/dictionaries/wiki/parse.py
@@ -25,6 +25,7 @@ JYUTPING_REGEX = re.compile(r"(.*?)（粵拼：(.*?)[）|；|，|/]")
 LITERARY_CANTONESE_READING_REGEX_PATTERN = re.compile(r"\d\*")
 HAN_REGEX = re.compile(r"[\u4e00-\u9fff]")
 
+logging.getLogger().setLevel(logging.INFO)
 
 def insert_words(c, words):
     for key in words:
@@ -301,7 +302,7 @@ if __name__ == "__main__":
                 '"Wikipedia is a free-content online encyclopedia, written and maintained '
                 "by a community of volunteers, collectively known as Wikipedians, through open "
                 'collaboration and the use of wiki-based editing system MediaWiki." '
-                '"Text is available under the Creative Commons Attribution-ShareAlike License 4.0."'
+                '"Text is available under the Creative Commons Attribution-ShareAlike License 4.0." '
                 '"https://www.wikipedia.org/" "" "words"'
             )
         )

--- a/src/dictionaries/wiki/parse.py
+++ b/src/dictionaries/wiki/parse.py
@@ -21,7 +21,6 @@ yue_converter = opencc.OpenCC("hk2s.json")
 zh_converter = opencc.OpenCC("tw2s.json")
 
 SUPERSCRIPT_EQUIVALENT = str.maketrans("¹²³⁴⁵⁶⁷⁸⁹⁰", "1234567890", "")
-WIDE_DIGIT_EQUIVALENT = str.maketrans("1234567890", "１２３４５６７８９０", "")
 JYUTPING_REGEX = re.compile(r"(.*?)（粵拼：(.*?)[）|；|，|/]")
 LITERARY_CANTONESE_READING_REGEX_PATTERN = re.compile(r"\d\*")
 HAN_REGEX = re.compile(r"[\u4e00-\u9fff]")
@@ -238,7 +237,7 @@ def parse_file(page_filepath, langlinks_filepath, lang_src, lang_dest, words):
                     jyut = jyut.replace("ﾠ", " ")
             if not jyutping_match or not jyut:
                 jyut = pinyin_jyutping_sentence.jyutping(
-                    trad.translate(WIDE_DIGIT_EQUIVALENT),
+                    trad.replace("·", ""),
                     tone_numbers=True,
                     spaces=True,
                 )
@@ -254,7 +253,7 @@ def parse_file(page_filepath, langlinks_filepath, lang_src, lang_dest, words):
             pin = (
                 " ".join(
                     lazy_pinyin(
-                        simp,
+                        simp.replace("·", ""),
                         style=Style.TONE3,
                         neutral_tone_with_five=True,
                         v_to_u=True,

--- a/src/dictionaries/wiki/requirements.txt
+++ b/src/dictionaries/wiki/requirements.txt
@@ -1,6 +1,6 @@
 jieba==0.42.1
 msgpack==1.0.2
-opencc==1.1.7
+opencc==1.1.9
 pinyin_jyutping_sentence==1.0
 pycantonese==3.4.0
 pypinyin==0.43.0


### PR DESCRIPTION
# Description

This fixes a few issues in Wikipedia article title parsing:
* Fixes issues with numbers not getting properly Jyutping-ed
* Fixes issues with the "·" character
* Fixes issues with parentheses
* Updates some dependencies

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run on Fedora 39.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
