### PR TITLE
#161: Fix channel string for debug builds on macOS

### DIFF
--- a/src/jyut-dict/logic/update/jyutdictionaryreleasechecker.cpp
+++ b/src/jyut-dict/logic/update/jyutdictionaryreleasechecker.cpp
@@ -119,7 +119,7 @@ bool JyutDictionaryReleaseChecker::parseJSON(const std::string &data,
 
         QString applicationChannel = QLibraryInfo::isDebugBuild() ? "debug"
                                                                   : "release";
-#if defined(Q_OS_MAC) && defined(PORTABLE)
+#if defined(Q_OS_MAC) && defined(DEBUG)
         // isDebugBuild() always returns false on macOS. For more information, see
         // https://stackoverflow.com/questions/11714118/detect-if-qt-is-running-a-debug-build-at-runtime
         applicationChannel = "debug";


### PR DESCRIPTION
# Description

Accidentally committed a debugging string that prevented macOS portable versions from getting updates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS 15.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
