### PR TITLE
#161: Adopt std::span in code to clarify ownership

### DIFF
--- a/src/jyut-dict/components/definitioncard/definitioncontentwidget.cpp
+++ b/src/jyut-dict/components/definitioncard/definitioncontentwidget.cpp
@@ -44,7 +44,8 @@ void DefinitionContentWidget::changeEvent(QEvent *event)
     QWidget::changeEvent(event);
 }
 
-void DefinitionContentWidget::setEntry(const std::vector<Definition::Definition> &definitions)
+void DefinitionContentWidget::setEntry(
+    std::span<const Definition::Definition> definitions)
 {
     cleanupLabels();
 

--- a/src/jyut-dict/components/definitioncard/definitioncontentwidget.h
+++ b/src/jyut-dict/components/definitioncard/definitioncontentwidget.h
@@ -9,8 +9,7 @@
 #include <QSettings>
 #include <QWidget>
 
-#include <string>
-#include <vector>
+#include <span>
 
 // The DefinitionContentWidget shows all the definitions
 // It contains a collection of QLabels, one for each definition
@@ -25,7 +24,7 @@ public:
 
     void changeEvent(QEvent *event) override;
 
-    void setEntry(const std::vector<Definition::Definition> &definitions);
+    void setEntry(std::span<const Definition::Definition> definitions);
 
 private:
     void setStyle(bool use_dark);

--- a/src/jyut-dict/components/sentencecard/sentencecardwidget.cpp
+++ b/src/jyut-dict/components/sentencecard/sentencecardwidget.cpp
@@ -49,16 +49,17 @@ void SentenceCardWidget::changeEvent(QEvent *event)
     QWidget::changeEvent(event);
 }
 
-void SentenceCardWidget::displaySentences(const std::vector<SourceSentence> &sentences)
+void SentenceCardWidget::displaySentences(
+    std::span<const SourceSentence> sentences)
 {
     if (sentences.empty()) {
         return;
     }
 
-    _sourceSentences = sentences;
+    _sourceSentences.assign(sentences.begin(), sentences.end());
     _sourceSentencesIsValid = true;
 
-    _source = sentences.at(0).getSentenceSets().at(0).getSourceShortString();
+    _source = sentences[0].getSentenceSets()[0].getSourceShortString();
     _sentenceHeaderWidget->setCardTitle(
         QCoreApplication::translate(Strings::STRINGS_CONTEXT,
                                     Strings::SENTENCES_ALL_CAPS)

--- a/src/jyut-dict/components/sentencecard/sentencecardwidget.h
+++ b/src/jyut-dict/components/sentencecard/sentencecardwidget.h
@@ -8,7 +8,7 @@
 #include <QEvent>
 #include <QWidget>
 
-#include <vector>
+#include <span>
 
 // A SentenceCardWidget contains a header (showing that this card is used for
 // sentences), and content (showing the actual content of the sentences)
@@ -21,7 +21,7 @@ public:
 
     void changeEvent(QEvent *event) override;
 
-    void displaySentences(const std::vector<SourceSentence> &sentences);
+    void displaySentences(std::span<const SourceSentence> sentences);
     void displaySentences(const SentenceSet &set);
 
 private:

--- a/src/jyut-dict/components/sentencecard/sentencecontentwidget.cpp
+++ b/src/jyut-dict/components/sentencecard/sentencecontentwidget.cpp
@@ -53,7 +53,7 @@ void SentenceContentWidget::setSentenceSet(const SentenceSet &set)
 
     _sentenceLayout->setContentsMargins(10, 0, 10, 10);
 
-    std::vector<Sentence::TargetSentence> sentences = set.getSentences();
+    std::span<const Sentence::TargetSentence> sentences = set.getSentences();
     for (size_t i = 0; i < sentences.size(); i++) {
         std::string number = std::to_string(i + 1);
         _sentenceNumberLabels.push_back(new QLabel{number.c_str(), this});
@@ -84,7 +84,7 @@ void SentenceContentWidget::setSentenceSet(const SentenceSet &set)
 }
 
 void SentenceContentWidget::setSourceSentenceVector(
-    const std::vector<SourceSentence> &sourceSentences)
+    std::span<const SourceSentence> sourceSentences)
 {
     cleanupLabels();
 
@@ -105,7 +105,7 @@ void SentenceContentWidget::setSourceSentenceVector(
                                         .width();
         _sentenceNumberLabels.back()->setFixedWidth(definitionNumberWidth);
 
-        SourceSentence sourceSentence = sourceSentences.at(i);
+        SourceSentence sourceSentence = sourceSentences[i];
 
         QString simplified
             = QString::fromStdString(sourceSentence.getSimplified()).trimmed();

--- a/src/jyut-dict/components/sentencecard/sentencecontentwidget.h
+++ b/src/jyut-dict/components/sentencecard/sentencecontentwidget.h
@@ -13,7 +13,7 @@
 #include <QSettings>
 #include <QWidget>
 
-#include <vector>
+#include <span>
 
 // The SentenceContentWidget displays sentences.
 // When used with setSentenceSet, it will display a list of
@@ -32,8 +32,7 @@ public:
     void changeEvent(QEvent *event) override;
 
     void setSentenceSet(const SentenceSet &set);
-    void setSourceSentenceVector(
-        const std::vector<SourceSentence> &sourceSentences);
+    void setSourceSentenceVector(std::span<const SourceSentence> sourceSentences);
 
 private:
     void translateUI(void);

--- a/src/jyut-dict/components/sentencesearchresult/sentenceresultlistmodel.cpp
+++ b/src/jyut-dict/components/sentencesearchresult/sentenceresultlistmodel.cpp
@@ -22,10 +22,11 @@ void SentenceResultListModel::callback(const std::vector<SourceSentence> &senten
     setSentences(sentences);
 }
 
-void SentenceResultListModel::setSentences(const std::vector<SourceSentence> &sentences)
+void SentenceResultListModel::setSentences(
+    std::span<const SourceSentence> sentences)
 {
     beginResetModel();
-    _sentences = sentences;
+    _sentences.assign(sentences.begin(), sentences.end());
     endResetModel();
 }
 

--- a/src/jyut-dict/components/sentencesearchresult/sentenceresultlistmodel.h
+++ b/src/jyut-dict/components/sentencesearchresult/sentenceresultlistmodel.h
@@ -11,6 +11,7 @@
 #include <QObject>
 #include <QVariant>
 
+#include <span>
 #include <vector>
 
 // The SentenceResultListModel contains data (a vector of SourceSentence objects)
@@ -31,7 +32,7 @@ public:
     void callback(const std::vector<Entry> &entries, bool emptyQuery) override;
     void callback(const std::vector<SourceSentence> &sentences,
                   bool emptyQuery) override;
-    void setSentences(const std::vector<SourceSentence> &sentences);
+    void setSentences(std::span<const SourceSentence> sentences);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role) const override;

--- a/src/jyut-dict/components/sentenceview/sentenceviewsentencecardsection.cpp
+++ b/src/jyut-dict/components/sentenceview/sentenceviewsentencecardsection.cpp
@@ -10,7 +10,9 @@ void SentenceViewSentenceCardSection::setSourceSentence(const SourceSentence &se
 {
     cleanup();
 
-    std::vector<SentenceSet> sentenceSets = sentence.getSentenceSets();
+    std::vector<SentenceSet> sentenceSets;
+    sentenceSets.assign(sentence.getSentenceSets().begin(),
+                        sentence.getSentenceSets().end());
 
     // This prevents an extra space from being added at the bottom when there
     // is nothing to display in the sentence card section.

--- a/src/jyut-dict/components/sentencewindow/sentencesplitter.cpp
+++ b/src/jyut-dict/components/sentencewindow/sentencesplitter.cpp
@@ -92,7 +92,7 @@ void SentenceSplitter::setStyle(bool use_dark)
 #endif
 
 void SentenceSplitter::setSourceSentences(
-    const std::vector<SourceSentence> &sourceSentences)
+    std::span<const SourceSentence> sourceSentences)
 {
     static_cast<SentenceResultListModel *>(_model)->setSentences(sourceSentences);
     _size = static_cast<int>(sourceSentences.size());

--- a/src/jyut-dict/components/sentencewindow/sentencesplitter.h
+++ b/src/jyut-dict/components/sentencewindow/sentencesplitter.h
@@ -12,6 +12,8 @@
 #include <QSplitter>
 #include <QWidget>
 
+#include <span>
+
 // The SentenceSplitter contains a "master" listview and a "detail" scrollarea
 //
 // It handles the model changed signal that the master listview emits,
@@ -30,7 +32,7 @@ public:
     void changeEvent(QEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
 
-    void setSourceSentences(const std::vector<SourceSentence> &sourceSentences);
+    void setSourceSentences(std::span<const SourceSentence> sourceSentences);
     void setSearchTerm(const QString &searchTerm);
 
 private:

--- a/src/jyut-dict/logic/database/sqldatabaseutils.cpp
+++ b/src/jyut-dict/logic/database/sqldatabaseutils.cpp
@@ -579,11 +579,11 @@ bool SQLDatabaseUtils::removeSentencesFromDatabase(void)
 bool SQLDatabaseUtils::removeSource(const std::string &source, bool skipCleanup)
 {
     backupDatabase();
-    return removeSources({source}, skipCleanup);
+    return removeSources(std::vector<std::string>{source}, skipCleanup);
 }
 
 // Method to remove multiple sources from the database, based on the name of the sources.
-bool SQLDatabaseUtils::removeSources(const std::vector<std::string> &sources,
+bool SQLDatabaseUtils::removeSources(std::span<const std::string> sources,
                                      bool skipCleanup)
 {
     QSqlQuery query{_manager->getDatabase()};

--- a/src/jyut-dict/logic/database/sqldatabaseutils.h
+++ b/src/jyut-dict/logic/database/sqldatabaseutils.h
@@ -7,6 +7,7 @@
 #include <QObject>
 
 #include <memory>
+#include <span>
 #include <string>
 #include <unordered_map>
 
@@ -52,7 +53,7 @@ private:
     // a transaction.
     // If skipCleanup is set to true, the caller MUST call rebuildIndices()
     // after this method returns if indices are desired.
-    bool removeSources(const std::vector<std::string> &sources,
+    bool removeSources(std::span<const std::string> sources,
                        bool skipCleanup = false);
 
     std::pair<bool, std::string> insertSourcesIntoDatabase(

--- a/src/jyut-dict/logic/entry/definitionsset.cpp
+++ b/src/jyut-dict/logic/entry/definitionsset.cpp
@@ -89,7 +89,7 @@ const std::string &DefinitionsSet::getDefinitionsSnippet() const
     return _snippet;
 }
 
-const std::vector<Definition::Definition> &DefinitionsSet::getDefinitions() const
+std::span<const Definition::Definition> DefinitionsSet::getDefinitions() const
 {
     return _definitions;
 }

--- a/src/jyut-dict/logic/entry/definitionsset.h
+++ b/src/jyut-dict/logic/entry/definitionsset.h
@@ -5,6 +5,7 @@
 #include "logic/sentence/sourcesentence.h"
 
 #include <iostream>
+#include <span>
 #include <vector>
 
 namespace Definition {
@@ -58,7 +59,7 @@ public:
     const std::string &getSourceLongString() const;
     const std::string &getSourceShortString() const;
     const std::string &getDefinitionsSnippet() const;
-    const std::vector<Definition::Definition> &getDefinitions(void) const;
+    std::span<const Definition::Definition> getDefinitions(void) const;
 
 private:
     std::string _source;

--- a/src/jyut-dict/logic/entry/entry.cpp
+++ b/src/jyut-dict/logic/entry/entry.cpp
@@ -523,7 +523,7 @@ const std::vector<uint8_t> &Entry::getPinyinNumbers()
     return _pinyinNumbers;
 }
 
-const std::vector<DefinitionsSet> &Entry::getDefinitionsSets(void) const
+std::span<const DefinitionsSet> Entry::getDefinitionsSets(void) const
 {
     return _definitions;
 }

--- a/src/jyut-dict/logic/entry/entry.h
+++ b/src/jyut-dict/logic/entry/entry.h
@@ -9,6 +9,7 @@
 #include <QVariant>
 
 #include <ostream>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -74,7 +75,7 @@ public:
     void setPinyin(const std::string &pinyin);
     const std::vector<uint8_t> &getPinyinNumbers();
 
-    const std::vector<DefinitionsSet> &getDefinitionsSets(void) const;
+    std::span<const DefinitionsSet> getDefinitionsSets(void) const;
     const std::string &getDefinitionSnippet(void);
     void addDefinitions(const std::string &source,
                         const std::vector<Definition::Definition> &definitions);

--- a/src/jyut-dict/logic/entry/test/TestDefinitionsSet/tst_definitionsset.cpp
+++ b/src/jyut-dict/logic/entry/test/TestDefinitionsSet/tst_definitionsset.cpp
@@ -85,7 +85,9 @@ void TestDefinitionsSet::getDefinitions()
     };
     DefinitionsSet set{"粵典—words.hk", definitions};
     QCOMPARE(set.isEmpty(), false);
-    QCOMPARE(set.getDefinitions(), definitions);
+    QCOMPARE(std::vector<Definition::Definition>(set.getDefinitions().begin(),
+                                                 set.getDefinitions().end()),
+             definitions);
     QCOMPARE(set.getDefinitions().size(), definitions.size());
     QCOMPARE(
         set.getDefinitionsSnippet(),

--- a/src/jyut-dict/logic/entry/test/TestEntry/tst_entry.cpp
+++ b/src/jyut-dict/logic/entry/test/TestEntry/tst_entry.cpp
@@ -286,7 +286,9 @@ void TestEntry::definitions()
     std::string pinyin = "tang2 ren2 jie1";
     Entry entry{simplified, traditional, jyutping, pinyin, {definitionsSet}};
 
-    QCOMPARE(entry.getDefinitionsSets(), {definitionsSet});
+    QCOMPARE(std::vector<DefinitionsSet>(entry.getDefinitionsSets().begin(),
+                                         entry.getDefinitionsSets().end()),
+             std::vector<DefinitionsSet>{definitionsSet});
     QCOMPARE(entry.getDefinitionSnippet(),
              "Chinatown; CL:條|条[tiao2],座[zuo4]");
 
@@ -302,7 +304,9 @@ void TestEntry::definitions()
     entry.addDefinitions("粵典-words.hk", {additionalDefinition});
 
     std::vector<DefinitionsSet> sets{definitionsSet, additionalDefinitionsSet};
-    QCOMPARE(entry.getDefinitionsSets(), sets);
+    QCOMPARE(std::vector<DefinitionsSet>(entry.getDefinitionsSets().begin(),
+                                         entry.getDefinitionsSets().end()),
+             sets);
 }
 
 void TestEntry::refreshColours()

--- a/src/jyut-dict/logic/sentence/sentenceset.cpp
+++ b/src/jyut-dict/logic/sentence/sentenceset.cpp
@@ -60,7 +60,7 @@ const std::string &SentenceSet::getSourceShortString(void) const
     return _sourceShortString;
 }
 
-const std::vector<Sentence::TargetSentence> &SentenceSet::getSentenceSnippet(
+std::span<const Sentence::TargetSentence> SentenceSet::getSentenceSnippet(
     void) const
 {
     if (!_snippet.empty()) {
@@ -75,7 +75,7 @@ const std::vector<Sentence::TargetSentence> &SentenceSet::getSentenceSnippet(
     return _snippet;
 }
 
-const std::vector<Sentence::TargetSentence> &SentenceSet::getSentences() const
+std::span<const Sentence::TargetSentence> SentenceSet::getSentences() const
 {
     return _sentences;
 }

--- a/src/jyut-dict/logic/sentence/sentenceset.h
+++ b/src/jyut-dict/logic/sentence/sentenceset.h
@@ -2,6 +2,7 @@
 #define SENTENCESET_H
 
 #include <ostream>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -55,8 +56,8 @@ public:
     const std::string &getSource(void) const;
     const std::string &getSourceLongString(void) const;
     const std::string &getSourceShortString(void) const;
-    const std::vector<Sentence::TargetSentence> &getSentenceSnippet(void) const;
-    const std::vector<Sentence::TargetSentence> &getSentences(void) const;
+    std::span<const Sentence::TargetSentence> getSentenceSnippet(void) const;
+    std::span<const Sentence::TargetSentence> getSentences(void) const;
 
 private:
     std::string _source;

--- a/src/jyut-dict/logic/sentence/sourcesentence.cpp
+++ b/src/jyut-dict/logic/sentence/sourcesentence.cpp
@@ -211,7 +211,7 @@ void SourceSentence::setPinyin(const std::string &pinyin)
     _pinyin = pinyin;
 }
 
-const std::vector<SentenceSet> &SourceSentence::getSentenceSets(void) const
+std::span<const SentenceSet> SourceSentence::getSentenceSets(void) const
 {
     return _sentences;
 }
@@ -228,8 +228,9 @@ std::string SourceSentence::getSentenceSnippet(void) const
         return "";
     }
 
-    std::vector<Sentence::TargetSentence> snippets = sentenceSet
-                                                         .getSentenceSnippet();
+    std::vector<Sentence::TargetSentence>
+        snippets{sentenceSet.getSentenceSnippet().begin(),
+                 sentenceSet.getSentenceSnippet().end()};
 
     if (snippets.empty()) {
         return "";
@@ -250,8 +251,9 @@ std::string SourceSentence::getSentenceSnippetLanguage(void) const
         return "";
     }
 
-    std::vector<Sentence::TargetSentence> snippets = sentenceSet
-                                                         .getSentenceSnippet();
+    std::vector<Sentence::TargetSentence>
+        snippets{sentenceSet.getSentenceSnippet().begin(),
+                 sentenceSet.getSentenceSnippet().end()};
 
     if (snippets.empty()) {
         return "";

--- a/src/jyut-dict/logic/sentence/sourcesentence.h
+++ b/src/jyut-dict/logic/sentence/sourcesentence.h
@@ -5,6 +5,7 @@
 #include "logic/entry/entryphoneticoptions.h"
 #include "sentenceset.h"
 
+#include <span>
 #include <string>
 
 // The SourceSentence represents a Chinese sentence.
@@ -60,7 +61,7 @@ public:
     const std::string &getPrettyPinyin(void) const;
     void setPinyin(const std::string &pinyin);
 
-    const std::vector<SentenceSet> &getSentenceSets(void) const;
+    std::span<const SentenceSet> getSentenceSets(void) const;
     std::string getSentenceSnippet(void) const;
     std::string getSentenceSnippetLanguage(void) const;
 

--- a/src/jyut-dict/logic/sentence/test/TestSentenceSet/tst_sentenceset.cpp
+++ b/src/jyut-dict/logic/sentence/test/TestSentenceSet/tst_sentenceset.cpp
@@ -79,9 +79,14 @@ void TestSentenceSet::getSentences()
     };
     SentenceSet set{"粵典—words.hk", targetSentences};
     QCOMPARE(set.isEmpty(), false);
-    QCOMPARE(set.getSentences(), targetSentences);
+    QCOMPARE(std::vector<Sentence::TargetSentence>(set.getSentences().begin(),
+                                                   set.getSentences().end()),
+             targetSentences);
     QCOMPARE(set.getSentences().size(), targetSentences.size());
-    QCOMPARE(set.getSentenceSnippet(), targetSentences);
+    QCOMPARE(
+        std::vector<Sentence::TargetSentence>(set.getSentenceSnippet().begin(),
+                                              set.getSentenceSnippet().end()),
+        targetSentences);
     QCOMPARE(set.getSentenceSnippet().size(), targetSentences.size());
 
     std::vector<Sentence::TargetSentence> additionalTargetSentences = {
@@ -98,9 +103,14 @@ void TestSentenceSet::getSentences()
     allSentences.insert(allSentences.end(),
                         additionalTargetSentences.begin(),
                         additionalTargetSentences.end());
-    QCOMPARE(set.getSentences(), allSentences);
+    QCOMPARE(std::vector<Sentence::TargetSentence>(set.getSentences().begin(),
+                                                   set.getSentences().end()),
+             allSentences);
     QCOMPARE(set.getSentences().size(), allSentences.size());
-    QCOMPARE(set.getSentenceSnippet(), targetSentences);
+    QCOMPARE(
+        std::vector<Sentence::TargetSentence>(set.getSentenceSnippet().begin(),
+                                              set.getSentenceSnippet().end()),
+        targetSentences);
     QCOMPARE(set.getSentenceSnippet().size(), targetSentences.size());
 }
 

--- a/src/jyut-dict/logic/utils/chineseutils.h
+++ b/src/jyut-dict/logic/utils/chineseutils.h
@@ -5,6 +5,7 @@
 
 #include <QString>
 
+#include <span>
 #include <string>
 
 // The ChineseUtils namespace contains static functions for working with
@@ -13,9 +14,9 @@
 namespace ChineseUtils {
 
 std::string applyColours(const std::string original,
-                         const std::vector<uint8_t> &tones,
-                         const std::vector<std::string> &jyutpingToneColours,
-                         const std::vector<std::string> &pinyinToneColours,
+                         std::span<const uint8_t> tones,
+                         std::span<const std::string> jyutpingToneColours,
+                         std::span<const std::string> pinyinToneColours,
                          const EntryColourPhoneticType type
                          = EntryColourPhoneticType::CANTONESE);
 
@@ -42,7 +43,7 @@ std::string applyColours(const std::string original,
 std::string compareStrings(const std::string &original,
                            const std::string &comparison);
 
-// constructRomanisationQuery takes a vector of strings and stitches them
+// constructRomanisationQuery takes a sequence of strings and stitches them
 // together with a delimiter.
 //
 // Since this is used for searching, we check whether to add a single wildcard
@@ -85,7 +86,7 @@ std::string compareStrings(const std::string &original,
 //    wildcard, as it is terminated by a digit. The second one is not, so it
 //    is affixed with the single character wildcard. The return value is
 //    ke3 ai?.
-std::string constructRomanisationQuery(const std::vector<std::string> &words,
+std::string constructRomanisationQuery(std::span<const std::string> words,
                                        const char *delimiter);
 
 } // namespace ChineseUtils

--- a/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
+++ b/src/jyut-dict/logic/utils/test/TestChineseUtils/tst_chineseutils.cpp
@@ -103,58 +103,70 @@ void TestChineseUtils::compareStringsCompatibilityVariantNormalization()
 
 void TestChineseUtils::constructRomanisationQuerySingleSyllable()
 {
-    std::string result = ChineseUtils::constructRomanisationQuery({"se"}, "?");
+    std::string result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se"}, "?");
     QCOMPARE(result, "se?");
 
-    result = ChineseUtils::constructRomanisationQuery({"se2"}, "?");
+    result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se2"}, "?");
     QCOMPARE(result, "se2");
 
-    result = ChineseUtils::constructRomanisationQuery({"se*"}, "?");
+    result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se*"}, "?");
     QCOMPARE(result, "se*?");
 
-    result = ChineseUtils::constructRomanisationQuery({"se?"}, "?");
+    result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se?"}, "?");
     QCOMPARE(result, "se??");
 }
 
 void TestChineseUtils::constructRomanisationQueryMultiSyllable()
 {
-    std::string result = ChineseUtils::constructRomanisationQuery({"se", "dak"},
-                                                                  "?");
+    std::string result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se", "dak"}, "?");
     QCOMPARE(result, "se? dak?");
 
-    result = ChineseUtils::constructRomanisationQuery({"se2", "dak1"}, "?");
+    result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se2", "dak1"}, "?");
     QCOMPARE(result, "se2 dak1");
 
-    result = ChineseUtils::constructRomanisationQuery({"se*", "dak*"}, "?");
+    result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se*", "dak*"}, "?");
     QCOMPARE(result, "se*? dak*?");
 
-    result = ChineseUtils::constructRomanisationQuery({"se?", "dak?"}, "?");
+    result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se?", "dak?"}, "?");
     QCOMPARE(result, "se?? dak??");
 }
 
 void TestChineseUtils::constructRomanisationQueryGlobCharacters()
 {
-    std::string result = ChineseUtils::constructRomanisationQuery({"se", " *"},
-                                                                  "?");
+    std::string result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se", " *"}, "?");
     QCOMPARE(result, "se? *");
 
-    result = ChineseUtils::constructRomanisationQuery({"se", " ?", "?", "?"},
-                                                      "?");
+    result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se", " ?", "?", "?"}, "?");
     QCOMPARE(result, "se? ???");
 
-    result = ChineseUtils::constructRomanisationQuery({"se",
-                                                       " ?",
-                                                       "?",
-                                                       "? ",
-                                                       "dak"},
-                                                      "?");
+    result = ChineseUtils::constructRomanisationQuery(
+        std::vector<std::string>{"se", " ?", "?", "? ", "dak"}, "?");
     QCOMPARE(result, "se? ??? dak?");
 }
 
 void TestChineseUtils::constructRomanisationQueryOnlyGlobCharacters()
 {
     std::string result = ChineseUtils::constructRomanisationQuery(
-        {"?", "?", "?", "?", "? ", "?", "?", "?", "?"}, "?");
+        std::vector<std::string>{"?",
+                                 "?",
+                                 "?",
+                                 "?",
+                                 "? ",
+                                 "?",
+                                 "?",
+                                 "?",
+                                 "?"},
+        "?");
     QCOMPARE(QString::fromStdString(result), "????? ????");
 }
 


### PR DESCRIPTION
# Description

Using `std::span` in the code clarifies that the underlying data's ownership is not being transferred, and furthermore that `std::span<const T>` is a readonly handle to the underlying data.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS 15.7.3.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
