### PR TITLE
#161: Fix palette upon light/dark mode change on macOS

### DIFF
--- a/src/jyut-dict/components/entryview/entryscrollareawidget.cpp
+++ b/src/jyut-dict/components/entryview/entryscrollareawidget.cpp
@@ -11,6 +11,7 @@
 #include "logic/utils/utils_windows.h"
 #endif
 
+#include <QStyleHints>
 #include <QTimer>
 
 EntryScrollAreaWidget::EntryScrollAreaWidget(
@@ -110,6 +111,19 @@ EntryScrollAreaWidget::EntryScrollAreaWidget(
             &EntryContentWidget::searchQuery,
             this,
             &EntryScrollAreaWidget::searchQueryRequested);
+
+    connect(qApp->styleHints(),
+            &QStyleHints::colorSchemeChanged,
+            this,
+            [this](Qt::ColorScheme scheme) {
+                // This workaround with Qt::QueuedConnection is needed in order to
+                // get the palette _after_ the colour scheme has changed, rather
+                // than _before_.
+                QMetaObject::invokeMethod(
+                    this,
+                    [this] { setStyle(Utils::isDarkMode()); },
+                    Qt::QueuedConnection);
+            });
 }
 
 void EntryScrollAreaWidget::changeEvent(QEvent *event)

--- a/src/jyut-dict/components/mainwindow/maintoolbar.cpp
+++ b/src/jyut-dict/components/mainwindow/maintoolbar.cpp
@@ -13,6 +13,7 @@
 #include "logic/utils/utils_qt.h"
 
 #include <QGuiApplication>
+#include <QStyleHints>
 
 MainToolBar::MainToolBar(std::shared_ptr<SQLSearch> sqlSearch,
                          std::shared_ptr<SQLUserHistoryUtils> sqlHistoryUtils,
@@ -86,6 +87,13 @@ void MainToolBar::setupUI(void)
         }
     });
 
+    // On newer versions of macOS, QEvent::PaletteChange doesn't properly propagate.
+    // This is a workaround.
+    connect(qApp->styleHints(),
+            &QStyleHints::colorSchemeChanged,
+            this,
+            [this](Qt::ColorScheme scheme) { setStyle(Utils::isDarkMode()); });
+
     _searchBar->setFocus();
 }
 
@@ -95,7 +103,9 @@ void MainToolBar::changeEvent(QEvent *event)
         // QWidget emits a palette changed event when setting the stylesheet
         // So prevent it from going into an infinite loop with this timer
         _paletteRecentlyChanged = true;
-        QTimer::singleShot(10, this, [=, this]() { _paletteRecentlyChanged = false; });
+        QTimer::singleShot(10, this, [=, this]() {
+            _paletteRecentlyChanged = false;
+        });
 
         // Set the style to match whether the user started dark mode
         setStyle(Utils::isDarkMode());


### PR DESCRIPTION
# Description

This commit fixes some components of the app not properly responding to light/dark mode switches on macOS.

#161.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
