### PR TITLE
#161: Wait after keystroke to trigger search on Windows

### DIFF
--- a/src/jyut-dict/components/mainwindow/searchlineedit.cpp
+++ b/src/jyut-dict/components/mainwindow/searchlineedit.cpp
@@ -38,10 +38,12 @@ SearchLineEdit::SearchLineEdit(
     , _mediator{mediator}
     , _search{sqlSearch}
     , _sqlHistoryUtils{sqlHistoryUtils}
+    , _settings{Settings::getSettings(this)}
+    , _searchHistoryDelayTimer(new QTimer{this})
+#ifdef Q_OS_WIN
+    , _searchDelayTimer(new QTimer{this})
+#endif
 {
-    _settings = Settings::getSettings(this);
-    _timer = new QTimer{this};
-
     setupUI();
     translateUI();
     setStyle(Utils::isDarkMode());
@@ -113,10 +115,8 @@ void SearchLineEdit::search(std::optional<SearchParameters> paramOverride)
         _search->searchEnglish(text().trimmed());
         break;
     }
-    case SearchParameters::AUTO_DETECT: {
-        _search->searchAutoDetect(text().trimmed());
-        break;
-    }
+    case SearchParameters::AUTO_DETECT:
+        [[fallthrough]];
     default: {
         break;
     }
@@ -154,10 +154,26 @@ void SearchLineEdit::setupUI(void)
     setMinimumHeight(30);
 #endif
 
+#ifdef Q_OS_WIN
+    // Windows penalizes having multiple searches running concurrently a _lot_.
+    // As a result, setting searches on a delay helps with making the app feel
+    // much faster.
+    connect(this, &QLineEdit::textChanged, this, [this] {
+        _searchDelayTimer->stop();
+        disconnect(_searchDelayTimer, nullptr, nullptr, nullptr);
+        _searchDelayTimer->setSingleShot(true);
+        connect(_searchDelayTimer,
+                &QTimer::timeout,
+                this,
+                &SearchLineEdit::searchTriggered);
+        _searchDelayTimer->start(200);
+    });
+#else
     connect(this,
             &QLineEdit::textChanged,
             this,
             &SearchLineEdit::searchTriggered);
+#endif
 }
 
 void SearchLineEdit::translateUI(void)
@@ -277,7 +293,6 @@ void SearchLineEdit::startHandwriting(void)
     checkClearVisibility();
 
     _handwritingWindow = new HandwritingWindow{this};
-    _handwritingWindow->setAttribute(Qt::WA_DeleteOnClose);
     _handwritingWindow->setFocus();
     _handwritingWindow->show();
 
@@ -358,22 +373,25 @@ void SearchLineEdit::startTranscription(void)
 
 void SearchLineEdit::addSearchTermToHistory(SearchParameters parameters) const
 {
-    _timer->stop();
-    disconnect(_timer, nullptr, nullptr, nullptr);
-    _timer->setSingleShot(true);
-    connect(_timer, &QTimer::timeout, this, [=, this]() {
+    _searchHistoryDelayTimer->stop();
+    disconnect(_searchHistoryDelayTimer, nullptr, nullptr, nullptr);
+    _searchHistoryDelayTimer->setSingleShot(true);
+    connect(_searchHistoryDelayTimer, &QTimer::timeout, this, [=, this]() {
         if (!text().isEmpty()) {
             _sqlHistoryUtils->addSearchToHistory(text().toStdString(),
                                                  static_cast<int>(parameters));
         }
     });
-    _timer->start(500);
+    _searchHistoryDelayTimer->start(500);
 }
 
 void SearchLineEdit::searchTriggered(void)
 {
     checkClearVisibility();
     if (_settings->value("Search/autoDetectLanguage", QVariant{true}).toBool()) {
+        // Since auto-detect is a setting independent of the SearchParameter specified
+        // by the search options group box, it must be handled separately from the
+        // other options.
         _search->searchAutoDetect(text().trimmed());
         addSearchTermToHistory(SearchParameters::AUTO_DETECT);
     } else {

--- a/src/jyut-dict/components/mainwindow/searchlineedit.h
+++ b/src/jyut-dict/components/mainwindow/searchlineedit.h
@@ -67,7 +67,10 @@ private:
 #ifndef Q_OS_LINUX
     QAction *_microphone;
 #endif
-    QTimer *_timer;
+    QTimer *_searchHistoryDelayTimer;
+#ifdef Q_OS_WIN
+    QTimer *_searchDelayTimer;
+#endif
 
     HandwritingWindow *_handwritingWindow = nullptr;
 #ifndef Q_OS_LINUX

--- a/src/jyut-dict/windows/handwritingwindow.cpp
+++ b/src/jyut-dict/windows/handwritingwindow.cpp
@@ -1,5 +1,7 @@
 #include "handwritingwindow.h"
 
+#include "components/handwriting/handwritingpanel.h"
+#include "dialogs/handwritingerrordialog.h"
 #include "logic/settings/settings.h"
 #include "logic/settings/settingsutils.h"
 #include "logic/utils/utils_qt.h"
@@ -13,11 +15,17 @@
 
 #include <QCoreApplication>
 #include <QDesktopServices>
+#include <QEvent>
 #include <QFont>
+#include <QGridLayout>
+#include <QKeyEvent>
+#include <QLabel>
 #include <QPixmap>
 #include <QPropertyAnimation>
+#include <QPushButton>
 #include <QSize>
 #include <QStyle>
+#include <QTextEdit>
 #include <QTimer>
 
 namespace {
@@ -28,11 +36,11 @@ constexpr auto NUM_RESULTS_PER_COLUMN = NUM_RESULTS / NUM_COLUMNS;
 
 HandwritingWindow::HandwritingWindow(QWidget *parent)
     : QWidget{parent, Qt::Window}
+    , _settings{Settings::getSettings()}
+    , _handwritingWrapper{
+          new HandwritingWrapper(Handwriting::Script::TRADITIONAL)}
 {
     setObjectName("HandwritingWindow");
-    _settings = Settings::getSettings();
-    _handwritingWrapper = std::make_unique<HandwritingWrapper>(
-        Handwriting::Script::TRADITIONAL);
 
     connect(_handwritingWrapper.get(),
             &HandwritingWrapper::recognizedResults,
@@ -55,6 +63,7 @@ HandwritingWindow::HandwritingWindow(QWidget *parent)
     flags &= ~(Qt::WindowMinMaxButtonsHint | Qt::WindowFullscreenButtonHint);
     setWindowFlags(flags);
     setWindowModality(Qt::ApplicationModal);
+    setAttribute(Qt::WA_DeleteOnClose);
 
     setupUI();
     translateUI();

--- a/src/jyut-dict/windows/handwritingwindow.h
+++ b/src/jyut-dict/windows/handwritingwindow.h
@@ -1,18 +1,20 @@
 #ifndef HANDWRITINGWINDOW_H
 #define HANDWRITINGWINDOW_H
 
-#include "components/handwriting/handwritingpanel.h"
-#include "dialogs/handwritingerrordialog.h"
 #include "logic/handwriting/handwritingwrapper.h"
 
-#include <QEvent>
-#include <QGridLayout>
-#include <QKeyEvent>
-#include <QLabel>
-#include <QPushButton>
 #include <QSettings>
-#include <QTextEdit>
 #include <QWidget>
+
+class HandwritingPanel;
+class HandwritingErrorDialog;
+
+class QEvent;
+class QGridLayout;
+class QKeyEvent;
+class QLabel;
+class QPushButton;
+class QTextEdit;
 
 // The Handwriting Window displays a panel to write a character,
 // and a list of possible results.

--- a/src/jyut-dict/windows/transcriptionwindow.cpp
+++ b/src/jyut-dict/windows/transcriptionwindow.cpp
@@ -1,5 +1,6 @@
 #include "transcriptionwindow.h"
 
+#include "dialogs/transcriptionerrordialog.h"
 #include "logic/settings/settings.h"
 #include "logic/settings/settingsutils.h"
 #include "logic/strings/strings.h"
@@ -14,9 +15,18 @@
 
 #include <QCoreApplication>
 #include <QDesktopServices>
+#include <QEvent>
 #include <QFont>
+#include <QGraphicsPixmapItem>
+#include <QGraphicsScene>
+#include <QGraphicsView>
+#include <QGridLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
 #include <QPixmap>
 #include <QPropertyAnimation>
+#include <QPushButton>
 #include <QSize>
 #include <QStyle>
 #include <QTimer>

--- a/src/jyut-dict/windows/transcriptionwindow.h
+++ b/src/jyut-dict/windows/transcriptionwindow.h
@@ -1,25 +1,27 @@
 #ifndef TRANSCRIPTIONWINDOW_H
 #define TRANSCRIPTIONWINDOW_H
 
-#include "dialogs/transcriptionerrordialog.h"
 #include "logic/dictation/iinputvolumesubscriber.h"
 #include "logic/dictation/itranscriptionresultsubscriber.h"
 #include "logic/dictation/transcriberwrapper.h"
 
-#include <QEvent>
 #include <QGraphicsEllipseItem>
-#include <QGraphicsPixmapItem>
-#include <QGraphicsScene>
-#include <QGraphicsView>
-#include <QGridLayout>
-#include <QKeyEvent>
-#include <QLabel>
-#include <QLineEdit>
 #include <QMetaType>
-#include <QPropertyAnimation>
-#include <QPushButton>
 #include <QSettings>
 #include <QWidget>
+
+class TranscriptionErrorDialog;
+
+class QEvent;
+class QGraphicsPixmapItem;
+class QGraphicsScene;
+class QGraphicsView;
+class QGridLayout;
+class QKeyEvent;
+class QLineEdit;
+class QLabel;
+class QPropertyAnimation;
+class QPushButton;
 
 // The Transcription Window displays UI for transcription. It shows
 // a microphone with an animation to indicate that the app is listening


### PR DESCRIPTION
# Description

This commit adds a 200ms delay after the last keystroke in the search bar to start searching on Windows. The change is necessary because Windows heavily penalizes concurrent SQL queries, which is especially noticeable when fuzzy Jyutping/fuzzy Pinyin is enabled. By introducing this delay, fewer searches are initiated, and thus speeds up fetching results.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Windows 11. Also tested on Fedora and macOS to verify that no regressions are introduced.

# Checklist:

- [x] My code follows the style guidelines of this project (`black` for Python
  code, `.clang-format` in the `src/jyut-dict` directory for C++)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have translated my user-facing strings to all currently-supported languages
- [x] I have made corresponding changes to the documentation
